### PR TITLE
[skip ci] refactor: migrate `parseAs` import to `keiyoushi.utils`

### DIFF
--- a/lib-multisrc/anilist/src/eu/kanade/tachiyomi/multisrc/anilist/AniListAnimeHttpSource.kt
+++ b/lib-multisrc/anilist/src/eu/kanade/tachiyomi/multisrc/anilist/AniListAnimeHttpSource.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.animesource.model.AnimesPage
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.add

--- a/lib-multisrc/dopeflix/src/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlix.kt
+++ b/lib-multisrc/dopeflix/src/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlix.kt
@@ -21,11 +21,11 @@ import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMap
 import eu.kanade.tachiyomi.util.parallelFlatMap
 import eu.kanade.tachiyomi.util.parallelMapNotNull
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.CacheControl
 import okhttp3.Headers
 import okhttp3.HttpUrl

--- a/lib-multisrc/sudatchi/src/eu/kanade/tachiyomi/multisrc/sudatchi/Sudatchi.kt
+++ b/lib-multisrc/sudatchi/src/eu/kanade/tachiyomi/multisrc/sudatchi/Sudatchi.kt
@@ -18,8 +18,8 @@ import eu.kanade.tachiyomi.multisrc.sudatchi.dto.SeriesDto
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response

--- a/lib-multisrc/wcotheme/src/eu/kanade/tachiyomi/multisrc/wcotheme/WcoTheme.kt
+++ b/lib-multisrc/wcotheme/src/eu/kanade/tachiyomi/multisrc/wcotheme/WcoTheme.kt
@@ -13,9 +13,9 @@ import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
+++ b/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
@@ -15,12 +15,12 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMap
 import eu.kanade.tachiyomi.util.parallelMapNotNull
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.addSwitchPreference
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/lib/bangumiscraper/src/aniyomi/lib/bangumiscraper/BangumiScraper.kt
+++ b/lib/bangumiscraper/src/aniyomi/lib/bangumiscraper/BangumiScraper.kt
@@ -3,7 +3,7 @@ package aniyomi.lib.bangumiscraper
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject

--- a/lib/buzzheavierextractor/src/aniyomi/lib/buzzheavierextractor/BuzzheavierExtractor.kt
+++ b/lib/buzzheavierextractor/src/aniyomi/lib/buzzheavierextractor/BuzzheavierExtractor.kt
@@ -3,7 +3,7 @@ package aniyomi.lib.buzzheavierextractor
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import okhttp3.Headers

--- a/lib/dailymotionextractor/src/aniyomi/lib/dailymotionextractor/DailymotionExtractor.kt
+++ b/lib/dailymotionextractor/src/aniyomi/lib/dailymotionextractor/DailymotionExtractor.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody
 import okhttp3.Headers

--- a/lib/googledriveepisodes/src/aniyomi/lib/googledriveepisodes/GoogleDriveEpisodes.kt
+++ b/lib/googledriveepisodes/src/aniyomi/lib/googledriveepisodes/GoogleDriveEpisodes.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/lib/lycorisextractor/src/aniyomi/lib/lycorisextractor/LycorisExtractor.kt
+++ b/lib/lycorisextractor/src/aniyomi/lib/lycorisextractor/LycorisExtractor.kt
@@ -4,7 +4,7 @@ import android.util.Base64
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
 import okhttp3.HttpUrl

--- a/lib/megamaxmultiserver/src/aniyomi/lib/megamaxmultiserver/MegaMaxMultiServer.kt
+++ b/lib/megamaxmultiserver/src/aniyomi/lib/megamaxmultiserver/MegaMaxMultiServer.kt
@@ -4,8 +4,8 @@ import android.util.Log
 import aniyomi.lib.megamaxmultiserver.dto.IframeResponse
 import aniyomi.lib.megamaxmultiserver.dto.LeechResponse
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.UrlUtils
+import keiyoushi.utils.parseAs
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import kotlin.math.abs

--- a/lib/vidsrcextractor/src/aniyomi/lib/vidsrcextractor/VidSrcExtractor.kt
+++ b/lib/vidsrcextractor/src/aniyomi/lib/vidsrcextractor/VidSrcExtractor.kt
@@ -6,7 +6,7 @@ import aniyomi.lib.vidsrcextractor.MediaResponseBody.Result
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
+++ b/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
@@ -17,8 +17,8 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonPrimitive

--- a/src/all/anizone/src/eu/kanade/tachiyomi/animeextension/all/anizone/AniZone.kt
+++ b/src/all/anizone/src/eu/kanade/tachiyomi/animeextension/all/anizone/AniZone.kt
@@ -17,8 +17,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray

--- a/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
+++ b/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
@@ -21,9 +21,9 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.commonEmptyRequestBody
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/all/googledriveindex/src/eu/kanade/tachiyomi/animeextension/all/googledriveindex/GoogleDriveIndex.kt
+++ b/src/all/googledriveindex/src/eu/kanade/tachiyomi/animeextension/all/googledriveindex/GoogleDriveIndex.kt
@@ -22,8 +22,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.Credentials

--- a/src/all/shabakatycinemana/src/eu/kanade/tachiyomi/animeextension/all/shabakatycinemana/ShabakatyCinemana.kt
+++ b/src/all/shabakatycinemana/src/eu/kanade/tachiyomi/animeextension/all/shabakatycinemana/ShabakatyCinemana.kt
@@ -12,8 +12,8 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -17,7 +17,6 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMap
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.Source
 import keiyoushi.utils.addEditTextPreference
@@ -26,6 +25,7 @@ import keiyoushi.utils.delegate
 import keiyoushi.utils.firstInstance
 import keiyoushi.utils.get
 import keiyoushi.utils.getSwitchPreference
+import keiyoushi.utils.parseAs
 import keiyoushi.utils.post
 import keiyoushi.utils.toRequestBody
 import kotlinx.coroutines.CancellationException

--- a/src/de/moflixstream/src/eu/kanade/tachiyomi/animeextension/de/moflixstream/MoflixStream.kt
+++ b/src/de/moflixstream/src/eu/kanade/tachiyomi/animeextension/de/moflixstream/MoflixStream.kt
@@ -24,8 +24,8 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.Response

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -23,8 +23,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMap
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/src/en/allanimechi/src/eu/kanade/tachiyomi/animeextension/en/allanimechi/AllAnimeChi.kt
+++ b/src/en/allanimechi/src/eu/kanade/tachiyomi/animeextension/en/allanimechi/AllAnimeChi.kt
@@ -23,8 +23,8 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject

--- a/src/en/allanimechi/src/eu/kanade/tachiyomi/animeextension/en/allanimechi/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanimechi/src/eu/kanade/tachiyomi/animeextension/en/allanimechi/extractors/AllAnimeExtractor.kt
@@ -4,7 +4,7 @@ import android.util.Base64
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Headers

--- a/src/en/allanimechi/src/eu/kanade/tachiyomi/animeextension/en/allanimechi/extractors/InternalExtractor.kt
+++ b/src/en/allanimechi/src/eu/kanade/tachiyomi/animeextension/en/allanimechi/extractors/InternalExtractor.kt
@@ -5,7 +5,7 @@ import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animeextension.en.allanimechi.AllAnimeChi
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Headers

--- a/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/AniList.kt
+++ b/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/AniList.kt
@@ -15,8 +15,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.add

--- a/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/CoverProviders.kt
+++ b/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/CoverProviders.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.animeextension.en.anilist
 
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 

--- a/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
+++ b/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
@@ -26,12 +26,12 @@ import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelFlatMap
 import eu.kanade.tachiyomi.util.parallelMapNotNull
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.delegate
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import keiyoushi.utils.toRequestBody
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put

--- a/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/MegaUpExtractor.kt
+++ b/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/MegaUpExtractor.kt
@@ -7,7 +7,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import keiyoushi.utils.toRequestBody
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -17,8 +17,8 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request

--- a/src/en/animeparadise/src/eu/kanade/tachiyomi/animeextension/en/animeparadise/AnimeParadise.kt
+++ b/src/en/animeparadise/src/eu/kanade/tachiyomi/animeextension/en/animeparadise/AnimeParadise.kt
@@ -13,8 +13,8 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request

--- a/src/en/aniplay/src/eu/kanade/tachiyomi/animeextension/en/aniplay/AniPlay.kt
+++ b/src/en/aniplay/src/eu/kanade/tachiyomi/animeextension/en/aniplay/AniPlay.kt
@@ -16,8 +16,8 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.multisrc.anilist.AniListAnimeHttpSource
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.parallelFlatMap
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import okhttp3.Headers

--- a/src/en/aniwavese/src/eu/kanade/tachiyomi/animeextension/en/aniwavese/AniwaveSe.kt
+++ b/src/en/aniwavese/src/eu/kanade/tachiyomi/animeextension/en/aniwavese/AniwaveSe.kt
@@ -19,8 +19,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelFlatMapBlocking
 import eu.kanade.tachiyomi.util.parallelMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response

--- a/src/en/asiaflix/src/eu/kanade/tachiyomi/animeextension/en/asiaflix/AsiaFlix.kt
+++ b/src/en/asiaflix/src/eu/kanade/tachiyomi/animeextension/en/asiaflix/AsiaFlix.kt
@@ -25,8 +25,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement

--- a/src/en/donghuastream/src/eu/kanade/tachiyomi/animeextension/en/donghuastream/extractors/StreamPlayExtractor.kt
+++ b/src/en/donghuastream/src/eu/kanade/tachiyomi/animeextension/en/donghuastream/extractors/StreamPlayExtractor.kt
@@ -5,7 +5,7 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Headers

--- a/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
+++ b/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
@@ -13,8 +13,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/en/hstream/src/eu/kanade/tachiyomi/animeextension/en/hstream/Hstream.kt
+++ b/src/en/hstream/src/eu/kanade/tachiyomi/animeextension/en/hstream/Hstream.kt
@@ -14,8 +14,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/en/kayoanime/src/eu/kanade/tachiyomi/animeextension/en/kayoanime/Kayoanime.kt
+++ b/src/en/kayoanime/src/eu/kanade/tachiyomi/animeextension/en/kayoanime/Kayoanime.kt
@@ -15,8 +15,8 @@ import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -25,8 +25,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll

--- a/src/en/kisskh/src/eu/kanade/tachiyomi/animeextension/en/kisskh/KissKH.kt
+++ b/src/en/kisskh/src/eu/kanade/tachiyomi/animeextension/en/kisskh/KissKH.kt
@@ -12,12 +12,12 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.delegate
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope

--- a/src/en/movhub/src/eu/kanade/tachiyomi/animeextension/en/movhub/RapidShareExtractor.kt
+++ b/src/en/movhub/src/eu/kanade/tachiyomi/animeextension/en/movhub/RapidShareExtractor.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import okhttp3.Headers

--- a/src/en/myrunningman/src/eu/kanade/tachiyomi/animeextension/en/myrunningman/MyRunningMan.kt
+++ b/src/en/myrunningman/src/eu/kanade/tachiyomi/animeextension/en/myrunningman/MyRunningMan.kt
@@ -13,7 +13,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Response

--- a/src/en/oppaistream/src/eu/kanade/tachiyomi/animeextension/en/oppaistream/OppaiStream.kt
+++ b/src/en/oppaistream/src/eu/kanade/tachiyomi/animeextension/en/oppaistream/OppaiStream.kt
@@ -17,8 +17,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request

--- a/src/en/putlocker/src/eu/kanade/tachiyomi/animeextension/en/putlocker/extractors/PutServerExtractor.kt
+++ b/src/en/putlocker/src/eu/kanade/tachiyomi/animeextension/en/putlocker/extractors/PutServerExtractor.kt
@@ -10,7 +10,7 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/en/yflix/src/eu/kanade/tachiyomi/animeextension/en/yflix/RapidShareExtractor.kt
+++ b/src/en/yflix/src/eu/kanade/tachiyomi/animeextension/en/yflix/RapidShareExtractor.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import okhttp3.Headers

--- a/src/es/beatzanime/src/eu/kanade/tachiyomi/animeextension/es/beatzanime/BeatZAnime.kt
+++ b/src/es/beatzanime/src/eu/kanade/tachiyomi/animeextension/es/beatzanime/BeatZAnime.kt
@@ -8,7 +8,7 @@ import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import okhttp3.FormBody

--- a/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/Doramasyt.kt
+++ b/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/Doramasyt.kt
@@ -22,8 +22,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response

--- a/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/Hentaila.kt
+++ b/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/Hentaila.kt
@@ -26,8 +26,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.int

--- a/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/Jkanime.kt
+++ b/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/Jkanime.kt
@@ -25,10 +25,10 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.delegate
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody
 import okhttp3.Headers

--- a/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/extractors/JkanimeExtractor.kt
+++ b/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/extractors/JkanimeExtractor.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
 import okhttp3.MediaType.Companion.toMediaTypeOrNull

--- a/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/Pelisplushd.kt
+++ b/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/Pelisplushd.kt
@@ -10,7 +10,7 @@ import eu.kanade.tachiyomi.multisrc.pelisplus.PelisPlus
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import keiyoushi.utils.toRequestBody
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/src/es/veranimes/src/eu/kanade/tachiyomi/animeextension/es/veranimes/VerAnimes.kt
+++ b/src/es/veranimes/src/eu/kanade/tachiyomi/animeextension/es/veranimes/VerAnimes.kt
@@ -19,8 +19,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody

--- a/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
+++ b/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
@@ -23,8 +23,8 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
 import eu.kanade.tachiyomi.util.parallelMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request

--- a/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/extractors/VidCdnExtractor.kt
+++ b/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/extractors/VidCdnExtractor.kt
@@ -2,8 +2,8 @@ package eu.kanade.tachiyomi.animeextension.fr.anisama.extractors
 
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.commonEmptyHeaders
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
+++ b/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnity.kt
@@ -14,8 +14,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl

--- a/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
+++ b/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
@@ -19,8 +19,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request

--- a/src/pl/desuonline/src/eu/kanade/tachiyomi/animeextension/pl/desuonline/extractors/CDAExtractor.kt
+++ b/src/pl/desuonline/src/eu/kanade/tachiyomi/animeextension/pl/desuonline/extractors/CDAExtractor.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/src/pt/animesbr/src/eu/kanade/tachiyomi/animeextension/pt/animesbr/extractors/FourNimesExtractor.kt
+++ b/src/pt/animesbr/src/eu/kanade/tachiyomi/animeextension/pt/animesbr/extractors/FourNimesExtractor.kt
@@ -4,7 +4,7 @@ import dev.datlag.jsunpacker.JsUnpacker
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient

--- a/src/pt/animescx/src/eu/kanade/tachiyomi/animeextension/pt/animescx/AnimesCX.kt
+++ b/src/pt/animescx/src/eu/kanade/tachiyomi/animeextension/pt/animescx/AnimesCX.kt
@@ -15,8 +15,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigital.kt
+++ b/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigital.kt
@@ -15,8 +15,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/pt/animesgames/src/eu/kanade/tachiyomi/animeextension/pt/animesgames/AnimesGames.kt
+++ b/src/pt/animesgames/src/eu/kanade/tachiyomi/animeextension/pt/animesgames/AnimesGames.kt
@@ -11,7 +11,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody

--- a/src/pt/animesotaku/src/eu/kanade/tachiyomi/animeextension/pt/animesotaku/AnimeCore.kt
+++ b/src/pt/animesotaku/src/eu/kanade/tachiyomi/animeextension/pt/animesotaku/AnimeCore.kt
@@ -15,7 +15,7 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response

--- a/src/pt/animesroll/src/eu/kanade/tachiyomi/animeextension/pt/animesroll/AnimesROLL.kt
+++ b/src/pt/animesroll/src/eu/kanade/tachiyomi/animeextension/pt/animesroll/AnimesROLL.kt
@@ -16,7 +16,7 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import okhttp3.Request
 import okhttp3.Response

--- a/src/pt/donghuanosekai/src/eu/kanade/tachiyomi/animeextension/pt/donghuanosekai/DonghuaNoSekai.kt
+++ b/src/pt/donghuanosekai/src/eu/kanade/tachiyomi/animeextension/pt/donghuanosekai/DonghuaNoSekai.kt
@@ -16,8 +16,8 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody

--- a/src/pt/hentaistube/src/eu/kanade/tachiyomi/animeextension/pt/hentaistube/HentaisTube.kt
+++ b/src/pt/hentaistube/src/eu/kanade/tachiyomi/animeextension/pt/hentaistube/HentaisTube.kt
@@ -17,8 +17,8 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document

--- a/src/pt/pifansubs/src/eu/kanade/tachiyomi/animeextension/pt/pifansubs/extractors/BlembedExtractor.kt
+++ b/src/pt/pifansubs/src/eu/kanade/tachiyomi/animeextension/pt/pifansubs/extractors/BlembedExtractor.kt
@@ -3,7 +3,7 @@ package eu.kanade.tachiyomi.animeextension.pt.pifansubs.extractors
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Headers

--- a/src/pt/tomato/src/eu/kanade/tachiyomi/animeextension/pt/tomato/Tomato.kt
+++ b/src/pt/tomato/src/eu/kanade/tachiyomi/animeextension/pt/tomato/Tomato.kt
@@ -19,8 +19,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.util.parallelMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -22,9 +22,9 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelFlatMap
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
+++ b/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
@@ -33,8 +33,8 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody

--- a/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/Anizm.kt
+++ b/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/Anizm.kt
@@ -29,8 +29,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Request

--- a/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/HDFilmCehennemi.kt
+++ b/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/HDFilmCehennemi.kt
@@ -19,8 +19,8 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMapBlocking
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.FormBody
 import okhttp3.MultipartBody

--- a/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/extractors/RapidrameExtractor.kt
+++ b/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/extractors/RapidrameExtractor.kt
@@ -8,7 +8,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/extractors/XBetExtractor.kt
+++ b/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/extractors/XBetExtractor.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/zh/anime1/src/eu/kanade/tachiyomi/animeextension/zh/anime1/Anime1.kt
+++ b/src/zh/anime1/src/eu/kanade/tachiyomi/animeextension/zh/anime1/Anime1.kt
@@ -18,8 +18,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.contentOrNull

--- a/src/zh/cycity/src/eu/kanade/tachiyomi/animeextension/zh/cycity/Cycity.kt
+++ b/src/zh/cycity/src/eu/kanade/tachiyomi/animeextension/zh/cycity/Cycity.kt
@@ -15,8 +15,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response

--- a/src/zh/iyf/src/eu/kanade/tachiyomi/animeextension/zh/iyf/Iyf.kt
+++ b/src/zh/iyf/src/eu/kanade/tachiyomi/animeextension/zh/iyf/Iyf.kt
@@ -9,7 +9,7 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonArray

--- a/src/zh/nivod/src/eu/kanade/tachiyomi/animeextension/zh/nivod/Nivod.kt
+++ b/src/zh/nivod/src/eu/kanade/tachiyomi/animeextension/zh/nivod/Nivod.kt
@@ -9,8 +9,8 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
-import eu.kanade.tachiyomi.util.parseAs
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl


### PR DESCRIPTION
Update the import of `parseAs` from `eu.kanade.tachiyomi.util` to `keiyoushi.utils` across multiple extensions and libraries to ensure consistency and maintainability.

## Summary by Sourcery

Chores:
- Standardize parseAs import source to keiyoushi.utils throughout multisrc modules, shared libraries, and anime extensions for consistency.