### PR TITLE
[FR] Wiflix: Update domain

### DIFF
--- a/src/fr/wiflix/build.gradle
+++ b/src/fr/wiflix/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'Wiflix'
     extClass = '.Wiflix'
     themePkg = 'datalifeengine'
-    baseUrl = 'https://flemmix.rent'
-    overrideVersionCode = 24
+    baseUrl = 'https://flemmix.best'
+    overrideVersionCode = 25
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/fr/wiflix/src/eu/kanade/tachiyomi/animeextension/fr/wiflix/Wiflix.kt
+++ b/src/fr/wiflix/src/eu/kanade/tachiyomi/animeextension/fr/wiflix/Wiflix.kt
@@ -24,7 +24,7 @@ import org.jsoup.nodes.Element
 class Wiflix :
     DataLifeEngine(
         "Wiflix",
-        "https://flemmix.rent",
+        "https://flemmix.best",
         "fr",
     ) {
     override val categories = arrayOf(


### PR DESCRIPTION
## Summary by Sourcery

Update the Wiflix extension to use the new primary domain.

Bug Fixes:
- Fix Wiflix extension connectivity by pointing to the updated flemmix.best domain.

Enhancements:
- Bump the Wiflix extension override version code to reflect the domain change.