### PR TITLE
fix(lib/unpacker): Fix `indexOutOfBound`, fix parsing regex, add `autoUnpacker` & test, cleanup cloned code

### DIFF
--- a/lib/unpacker/src/aniyomi/lib/AutoUnpacker.kt
+++ b/lib/unpacker/src/aniyomi/lib/AutoUnpacker.kt
@@ -6,7 +6,12 @@ import aniyomi.lib.unpacker.Unpacker
 
 fun autoUnpacker(packedScript: String): String? = runCatching {
     try {
-        JsUnpacker.unpackAndCombine(packedScript)
+        val jsUnpacked = JsUnpacker.unpackAndCombine(packedScript)
+        if (jsUnpacked.isNullOrBlank()) {
+            Unpacker.unpack(packedScript).takeIf(String::isNotBlank)
+        } else {
+            jsUnpacked
+        }
     } catch (e: Exception) {
         Log.w("JsUnpacker", "autoUnpacker: ${e.message}", e)
         Unpacker.unpack(packedScript).takeIf(String::isNotBlank)

--- a/lib/unpacker/src/aniyomi/lib/jsunpacker/JsUnpacker.kt
+++ b/lib/unpacker/src/aniyomi/lib/jsunpacker/JsUnpacker.kt
@@ -125,10 +125,11 @@ object JsUnpacker {
             val count = result.groups[3]?.value?.toIntOrNull()
             val unbaser = Unbaser(radix)
 
-            if (symtab == null || count == null || symtab.size != count) {
-                throw Exception("Unknown p.a.c.k.e.r. encoding")
+            if (payload == null || symtab == null || count == null || symtab.size != count) {
+                // Ignore this occurrence as it cannot be unpacked correctly
+                null
             } else {
-                payload?.replace(unpackReplaceRegex) { match ->
+                payload.replace(unpackReplaceRegex) { match ->
                     val word = match.value
                     val unbased = symtab.getOrNull(unbaser.unbase(word)) ?: ""
                     unbased.ifEmpty { word }

--- a/lib/unpacker/test/kotlin/aniyomi/lib/jsunpacker/UnpackerJsUnpackerTest.kt
+++ b/lib/unpacker/test/kotlin/aniyomi/lib/jsunpacker/UnpackerJsUnpackerTest.kt
@@ -1,7 +1,9 @@
 package aniyomi.lib.jsunpacker
 
+import aniyomi.lib.autoUnpacker
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class UnpackerJsUnpackerTest {
 
@@ -9,7 +11,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackSimplePackedScript() {
         // A simple packed script example
         val packed = "}('0 1',2,2,'word0|word1'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("word0 word1", result)
     }
 
@@ -17,7 +19,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithRadix62() {
         // Test radix 62 decoding (0-9, a-z, A-Z)
         val packed = "}('0 1 a b A B',62,6,'zero|one|ten|eleven|thirtysix|thirtyseven'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("zero one a b A B", result)
     }
 
@@ -25,7 +27,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithEmptyDictionaryValues() {
         // When dictionary entry is empty, use the key itself
         val packed = "}('0 1 2',3,3,'zero||two'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("zero 1 two", result)
     }
 
@@ -33,7 +35,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithSingleQuotes() {
         // Single quotes should be replaced with double quotes
         val packed = "}('test\\'quoted',1,1,'value'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("test\"quoted", result)
     }
 
@@ -41,7 +43,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithLeftRight() {
         // Extract only data between left and right delimiters
         val packed = "}('prefix:0:suffix',1,1,'data'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("data", result)
     }
 
@@ -49,15 +51,15 @@ class UnpackerJsUnpackerTest {
     fun testUnpackEmptyData() {
         // When data is empty, return empty string
         val packed = "}('',0,0,''.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
-        assertEquals("", result)
+        val result = autoUnpacker(packed)
+        assertNull(result)
     }
 
     @Test
     fun testUnpackWithMixedRadix() {
         // Test with various radix values
         val packed = "}('a b c d e f g h i j',36,20,'val0|val1|val2|val3|val4|val5|val6|val7|val8|val9|val10|val11|val12|val13|val14|val15|val16|val17|val18|val19'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("val10 val11 val12 val13 val14 val15 val16 val17 val18 val19", result)
     }
 
@@ -65,7 +67,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithKeyOutOfBounds() {
         // When key index is >= dictionary size, use the key itself
         val packed = "}('0 99',2,2,'first|second'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("first 99", result)
     }
 
@@ -73,7 +75,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithSubstringExtractor() {
         // Test using SubstringExtractor directly
         val script = "}('prefix:0 1:suffix',2,2,'word0|word1'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
         assertEquals("word0 word1", result)
     }
 
@@ -81,7 +83,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackComplexScript() {
         // A more complex example with multiple words
         val packed = "}('0 1 2 3 0 1',10,4,'var|function|return|console'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("var function return console var function", result)
     }
 
@@ -89,7 +91,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithSpecialCharacters() {
         // Test with special characters in the data
         val packed = "}('0.1(2)',3,3,'obj|prop|func'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("obj.prop(func)", result)
     }
 
@@ -97,7 +99,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithLargeRadix() {
         // Test with radix 62 (full alphanumeric range)
         val packed = "}('z Z',62,36,'a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z|A|B|C|D|E|F|G|H|I|J'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("J Z", result) // Z in base62 = 35 + 26 = 61, but we only have 36 items (0-35), so index 61 is out of bounds
     }
 
@@ -105,7 +107,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackPreservesNonWordCharacters() {
         // Non-word characters should be preserved
         val packed = "}('0+1-2*3/4',5,5,'a|b|c|d|e'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("a+b-c*d/e", result)
     }
 
@@ -113,7 +115,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackWithLeftRightAndEmptyResult() {
         // When left/right delimiters don't match, return empty
         val packed = "}('nodelimiters',1,1,'value'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("", result)
     }
 
@@ -121,7 +123,7 @@ class UnpackerJsUnpackerTest {
     fun testUnpackRealWorldExample() {
         // A more realistic packed JavaScript example
         val packed = "}('4 0=5 1(\\'2\\');',6,6,'var|alert|Hello|World|const|message'.split('|'),0,{}))"
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
         assertEquals("const var=message alert(\"Hello\");", result)
     }
 }

--- a/lib/unpacker/test/kotlin/aniyomi/lib/jsunpacker/UnpackerJsUnpackerUnitTest.kt
+++ b/lib/unpacker/test/kotlin/aniyomi/lib/jsunpacker/UnpackerJsUnpackerUnitTest.kt
@@ -1,7 +1,9 @@
 package aniyomi.lib.jsunpacker
 
+import aniyomi.lib.autoUnpacker
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class UnpackerJsUnpackerUnitTest {
 
@@ -12,7 +14,7 @@ class UnpackerJsUnpackerUnitTest {
         val script =
             "}('0 1 9',0,0,'zero|one|two|three|four|five|six|seven|eight|nine'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
         assertEquals("zero one nine", result)
     }
@@ -22,7 +24,7 @@ class UnpackerJsUnpackerUnitTest {
         val dict62 = (0..61).joinToString("|") { "v$it" }
         val script = "}('0 a z A Z',0,0,'$dict62'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
         assertEquals("v0 v10 v35 v36 v61", result)
     }
@@ -32,7 +34,7 @@ class UnpackerJsUnpackerUnitTest {
         val dict62 = (0..61).joinToString("|") { "v$it" }
         val packed = "}('0 a z A Z',62,62,'$dict62'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(packed)
+        val result = autoUnpacker(packed)
 
         assertEquals("v0 v10 v35 v36 v61", result)
     }
@@ -42,7 +44,7 @@ class UnpackerJsUnpackerUnitTest {
         // When dictionary entry is empty, use the key itself
         val script = "}('0 1 2',0,0,'zero||two'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
         assertEquals("zero 1 two", result)
     }
@@ -53,7 +55,7 @@ class UnpackerJsUnpackerUnitTest {
         // "Z" decodes to 61 in base62; dictionary has only one entry.
         val script = "}('0 Z',0,0,'first'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
         assertEquals("first Z", result)
     }
@@ -63,7 +65,7 @@ class UnpackerJsUnpackerUnitTest {
         // Non-word characters (+-*/.) should be preserved
         val script = "}('0+1-2*3/4',0,0,'a|b|c|d|e'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
         assertEquals("a+b-c*d/e", result)
     }
@@ -72,9 +74,9 @@ class UnpackerJsUnpackerUnitTest {
     fun unpack_returnsEmptyString_whenDataSectionIsEmpty() {
         val script = "}('',0,0,''.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
-        assertEquals("", result)
+        assertNull(result)
     }
 
     @Test
@@ -82,7 +84,7 @@ class UnpackerJsUnpackerUnitTest {
         // Extract only the data between the left and right delimiters
         val script = "}('prefix:0:suffix',0,0,'value'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
         assertEquals("value", result)
     }
@@ -92,7 +94,7 @@ class UnpackerJsUnpackerUnitTest {
         // If left/right delimiters are not present in the data, unpack returns empty string
         val script = "}('nodelimiters',0,0,'value'.split('|'),0,{}))"
 
-        val result = JsUnpacker.unpackAndCombine(script)
+        val result = autoUnpacker(script)
 
         assertEquals("", result)
     }

--- a/lib/unpacker/test/kotlin/aniyomi/lib/unpacker/JsUnpackerUnpackerTest.kt
+++ b/lib/unpacker/test/kotlin/aniyomi/lib/unpacker/JsUnpackerUnpackerTest.kt
@@ -1,5 +1,6 @@
 package aniyomi.lib.unpacker
 
+import aniyomi.lib.autoUnpacker
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -13,44 +14,44 @@ class JsUnpackerUnpackerTest {
     @Test
     fun unpack_returnsEmptySequence_whenScriptIsNotPacked() {
         val unpackedScript = "var x = 5; console.log(x);"
-        val results = Unpacker.unpack(unpackedScript)
-        assertTrue(results.isEmpty())
+        val results = autoUnpacker(unpackedScript)
+        assertNull(results)
     }
 
     @Test
     fun unpack_unpacksSimplePackedScript() {
         // payload "0 1" with radix 2, symtab ["word0","word1"] -> "word0 word1"
         val packedScript = "eval(function(p,a,c,k,e,r){return p}('0 1',2,2,'word0|word1'.split('|')))"
-        val results = Unpacker.unpack(packedScript)
+        val results = autoUnpacker(packedScript)
         assertEquals("word0 word1", results)
     }
 
     @Test
     fun unpack_unpacksWithBase10() {
         val packedScript = "eval(function(p,a,c,k,e,r){return p}('0 1 2',10,3,'a|b|c'.split('|')))"
-        val results = Unpacker.unpack(packedScript)
+        val results = autoUnpacker(packedScript)
         assertEquals("a b c", results)
     }
 
     @Test
     fun unpack_unpacksWithBase62() {
         val packedScript = """eval(function(p,a,c,k,e,r){e=String;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\b'+e(c)+'\\b','g'),k[c]);return p}('0 1',2,2,'test|data'.split('|'),0,{}))"""
-        val results = Unpacker.unpack(packedScript)
+        val results = autoUnpacker(packedScript)
         assertEquals("test data", results)
     }
 
     @Test
     fun unpack_unpacksWithEmptySymtab() {
         val packedScript = "eval(function(p,a,c,k,e,r){return p}('',1,1,''.split('|')))"
-        val results = Unpacker.unpack(packedScript)
-        assertEquals("", results)
+        val results = autoUnpacker(packedScript)
+        assertNull(results)
     }
 
     @Test
     fun unpack_unpacksWithEmptySymtabWithPayload() {
         // Return unchanged payload if malformed symtab
         val packedScript = "eval(function(p,a,c,k,e,r){return p}('test data',1,1,''.split('|')))"
-        val results = Unpacker.unpack(packedScript)
+        val results = autoUnpacker(packedScript)
         assertEquals("test data", results)
     }
 
@@ -58,8 +59,8 @@ class JsUnpackerUnpackerTest {
     fun unpack_returnsEmptySequence_whenSymtabCountMismatch() {
         // symtab has 1 element, count says 2 - malformed, should be ignored
         val packedScript = "eval(function(p,a,c,k,e,r){return p}('0 1',2,2,'only'.split('|')))"
-        val results = Unpacker.unpack(packedScript)
-        assertTrue(results.isEmpty())
+        val results = autoUnpacker(packedScript)
+        assertNull(results)
     }
 
     @Test
@@ -68,7 +69,7 @@ class JsUnpackerUnpackerTest {
             eval(function(p,a,c,k,e,r){return p}('0',2,1,'first'.split('|')))
             eval(function(p,a,c,k,e,r){return p}('0',2,1,'second'.split('|')))
         """.trimIndent()
-        val results = Unpacker.unpack(packedScript)
+        val results = autoUnpacker(packedScript)
         assertEquals("first second", results)
     }
 
@@ -76,7 +77,7 @@ class JsUnpackerUnpackerTest {
     fun unpack_preservesUnknownWords() {
         // Words not in symtab (e.g. invalid index) are preserved as-is
         val packedScript = "eval(function(p,a,c,k,e,r){return p}('0 1',2,2,'a|b'.split('|')))"
-        val results = Unpacker.unpack(packedScript)
+        val results = autoUnpacker(packedScript)
         assertEquals("a b", results)
     }
 
@@ -86,14 +87,14 @@ class JsUnpackerUnpackerTest {
 
     @Test
     fun unpackAndCombine_returnsNull_whenNoPackedScript() {
-        val result = Unpacker.unpack("var x = 5;")
+        val result = autoUnpacker("var x = 5;")
         assertNull(result)
     }
 
     @Test
     fun unpackAndCombine_returnsUnpackedResult_whenSingleOccurrence() {
         val packedScript = "eval(function(p,a,c,k,e,r){return p}('0 1',2,2,'hello|world'.split('|')))"
-        val result = Unpacker.unpack(packedScript)
+        val result = autoUnpacker(packedScript)
         assertNotNull(result)
         assertEquals("hello world", result)
     }
@@ -104,7 +105,7 @@ class JsUnpackerUnpackerTest {
             eval(function(p,a,c,k,e,r){return p}('0',2,1,'first'.split('|')))
             eval(function(p,a,c,k,e,r){return p}('0',2,1,'second'.split('|')))
         """.trimIndent()
-        val result = Unpacker.unpack(packedScript)
+        val result = autoUnpacker(packedScript)
         assertNotNull(result)
         assertEquals("first second", result)
     }
@@ -113,7 +114,7 @@ class JsUnpackerUnpackerTest {
     fun testUnpackWithEmptyDictionaryValues() {
         // When dictionary entry is empty, use the key itself
         val packed = "eval(function(p,a,c,k,e,r){return p}('0 1 2',3,3,'zero||two'.split('|'),0,{}))"
-        val result = Unpacker.unpack(packed)
+        val result = autoUnpacker(packed)
         assertEquals("zero 1 two", result)
     }
 
@@ -158,8 +159,8 @@ class JsUnpackerUnpackerTest {
 
     @Test
     fun unpackCollection_returnsEmptyList_whenEmptyCollection() {
-        val results = Unpacker.unpack("")
-        assertTrue(results.isEmpty())
+        val results = autoUnpacker("")
+        assertNull(results)
     }
 
     // endregion


### PR DESCRIPTION
## Summary by Sourcery

Unify JavaScript unpacking logic across extensions with a shared auto-detecting unpacker and strengthen its test coverage.

New Features:
- Introduce a shared autoUnpacker helper that selects between different unpacking strategies for packed JavaScript.

Bug Fixes:
- Fix out-of-bounds and malformed-dictionary handling in the unpacker to avoid crashes and preserve original tokens when indices are invalid.
- Correct the packed JavaScript extraction regex to be more tolerant of whitespace and variant encodings.
- Adjust link and body parsing utilities to use centralized helpers and more robust regular expressions.

Enhancements:
- Replace duplicated, per-extension JavaScript unpacker implementations with the shared unpacker library and wire it into existing extractors.
- Simplify MundoDonghua and other extractors by switching to sequence-safe iteration and minor cleanup of unused imports and variables.
- Remove support for the deprecated Upstream hoster from the FilmPalast extension and tidy related preferences.

Build:
- Configure the unpacker module for unit testing and add Kotlin test dependencies.

Tests:
- Add extensive unit tests for JsUnpacker, Unpacker, AutoUnpacker, and related substring utilities to validate detection and decoding behavior across edge cases.