### PR TITLE
Update AnimeKai domains

### DIFF
--- a/src/en/animekai/build.gradle
+++ b/src/en/animekai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeKai'
     extClass = '.AnimeKai'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
+++ b/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
@@ -457,13 +457,13 @@ class AnimeKai :
     companion object {
         private const val PREF_DOMAIN_KEY = "preferred_domain"
 
-        // Domain list: https://animekai.ws
+        // Domain list: https://animekai.pw
         private val DOMAIN_ENTRIES = listOf(
             "animekai.to",
-            "animekai.im",
+            "animekai.fi",
+            "animekai.fo",
+            "animekai.gs",
             "animekai.la",
-            "animekai.nl",
-            "animekai.vc",
             "anikai.to",
         )
         private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }


### PR DESCRIPTION
Updated AnimeKai new domains.
Updated AnimeKai  mirror list in AnimeKai.kt.
Bumped version code from 12 to 13.
Closes issue #58.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the AnimeKai extension to use the latest mirror domains and bump its extension version code.

Bug Fixes:
- Refresh the AnimeKai mirror domain list to point to currently active domains.

Build:
- Increment the AnimeKai extension extVersionCode from 12 to 13.