### PR TITLE
Animelib [ru]: Update domain and API url

### DIFF
--- a/src/ru/animelib/build.gradle
+++ b/src/ru/animelib/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animelib'
     extClass = '.Animelib'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -45,9 +45,9 @@ class Animelib :
 
     override val supportsLatest = true
 
-    private val domain = "v3.animelib.org"
+    private val domain = "animelib.org"
     override val baseUrl = "https://$domain/ru"
-    private val apiSite = "https://api.cdnlibs.org"
+    private val apiSite = "https://hapi.hentaicdn.org"
     private val apiUrl = "$apiSite/api"
     private val coverDomain = "cover.imglib.info"
 


### PR DESCRIPTION
Updated domain from v3.animelib.org to animelib.org (site suggests that v3 is depreciated)
Updated api from api.cdnlibs.org to hapi.hentaicdn.org.
Bump version from 11 to 12.
Closes #110. Updated URL was not v5 but was simply animelib.org. V3 depreciated. 

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the Animelib (ru) extension to use the new main site and API endpoints and bump its extension version.

Bug Fixes:
- Point the Animelib (ru) extension to the current animelib.org domain instead of the deprecated v3 subdomain.
- Update the Animelib (ru) extension API base URL to the new hapi.hentaicdn.org endpoint.

Enhancements:
- Increment the Animelib (ru) extension version code to reflect the endpoint changes.