### PR TITLE
Fix FPS and lag issues by disabling HTTP/2 for video clients

### DIFF
--- a/src/en/animekai/build.gradle
+++ b/src/en/animekai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeKai'
     extClass = '.AnimeKai'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
+++ b/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
@@ -75,6 +75,7 @@ class AnimeKai :
     override var client by LazyMutable {
         network.client.newBuilder()
             .rateLimitHost(baseUrl.toHttpUrl(), permits = RATE_LIMIT, period = 1, unit = TimeUnit.SECONDS)
+            .protocols(listOf(Protocol.HTTP_1_1))
             .build()
     }
 

--- a/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
+++ b/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKai.kt
@@ -565,6 +565,7 @@ class AnimeKai :
             docHeaders = headersBuilder().build()
             client = network.client.newBuilder()
                 .rateLimitHost(baseUrl.toHttpUrl(), permits = RATE_LIMIT, period = 1, unit = TimeUnit.SECONDS)
+                .protocols(listOf(Protocol.HTTP_1_1))
                 .build()
             megaUpExtractor = MegaUpExtractor(client, docHeaders)
         }

--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 37
+    extVersionCode = 38
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -42,6 +42,7 @@ class AnimePahe :
 
     override val client = network.client.newBuilder()
         .addInterceptor(interceptor)
+        .protocols(listOf(Protocol.HTTP_1_1))
         .build()
 
     override val name = "AnimePahe"


### PR DESCRIPTION
This pull request addresses the reported FPS drops, lag, and initial playback buffering issues on **AnimePahe** and **AnimeKai**. 

The root cause of the stuttering and frame pacing issues during the first load of video streams is that ExoPlayer/MPV often struggles with chunk retrieval when the `OkHttpClient` defaults to `HTTP/2` for video playback (especially with specific CDNs like Kwik and MegaUp). 

By explicitly forcing `.protocols(listOf(Protocol.HTTP_1_1))` on the OkHttp client builder, we ensure stable and consistent connections during playback, which resolves the lag without requiring users to "refresh" the page.

**Changes:**
- **AnimePahe:** Added `Protocol.HTTP_1_1` to the video client builder. Bumped version code to 38.
- **AnimeKai:** Added `Protocol.HTTP_1_1` to the video client builder. Bumped version code to 14.

## Summary by Sourcery

Force HTTP/1.1 for AnimePahe and AnimeKai video clients to address playback stability issues and update their extension versions accordingly.

Bug Fixes:
- Resolve FPS drops, lag, and initial buffering issues on AnimePahe and AnimeKai by disabling HTTP/2 on their video HTTP clients.

Chores:
- Bump AnimePahe extension version code to 38 and AnimeKai extension version code to 14.