### PR TITLE
AnimeOnsen: Fix user agent that prevented videos from loading

### DIFF
--- a/src/all/animeonsen/build.gradle
+++ b/src/all/animeonsen/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeOnsen'
     extClass = '.AnimeOnsen'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
+++ b/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
@@ -170,7 +170,7 @@ class AnimeOnsen :
     }
 }
 
-const val AO_USER_AGENT = "Aniyomi/App (mobile)"
+const val AO_USER_AGENT = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36"
 private const val PREF_SUB_KEY = "preferred_subLang"
 private const val PREF_SUB_TITLE = "Preferred sub language"
 const val PREF_SUB_DEFAULT = "en-US"

--- a/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
+++ b/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
@@ -32,7 +32,7 @@ class AnimeOnsen :
 
     override val name = "AnimeOnsen"
 
-    override val baseUrl = "https://animeonsen.xyz"
+    override val baseUrl = "https://www.animeonsen.xyz"
 
     private val apiUrl = "https://api.animeonsen.xyz/v4"
 
@@ -170,7 +170,7 @@ class AnimeOnsen :
     }
 }
 
-const val AO_USER_AGENT = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36"
+const val AO_USER_AGENT = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.3"
 private const val PREF_SUB_KEY = "preferred_subLang"
 private const val PREF_SUB_TITLE = "Preferred sub language"
 const val PREF_SUB_DEFAULT = "en-US"


### PR DESCRIPTION
Updated AnimeOnsen to fix error 429 - Too many requests.
Bumped to version 8.
Closes #67.
Doesn't load initially (buffering), but it seems that re-selecting quality makes it load. Hope someone can adjust this little quirk. 

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the AnimeOnsen extension to resolve video loading issues by adjusting its user agent and bumping the extension version.

Bug Fixes:
- Fix AnimeOnsen video requests failing by replacing the custom user agent with a standard Android Chrome user agent string.

Build:
- Bump AnimeOnsen extension version code from 7 to 8.