### PR TITLE
Update domain of witanime [ar]

### DIFF
--- a/src/ar/witanime/build.gradle
+++ b/src/ar/witanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'WIT ANIME'
     extClass = '.WitAnime'
-    extVersionCode = 59
+    extVersionCode = 60
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/witanime/src/eu/kanade/tachiyomi/animeextension/ar/witanime/WitAnime.kt
+++ b/src/ar/witanime/src/eu/kanade/tachiyomi/animeextension/ar/witanime/WitAnime.kt
@@ -30,7 +30,7 @@ class WitAnime :
 
     override val name = "WIT ANIME"
 
-    override val baseUrl = "https://witanime.cyou"
+    override val baseUrl = "https://witanime.life"
 
     override val lang = "ar"
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the Arabic WIT ANIME extension to point to the new domain and bump its extension version code.

Bug Fixes:
- Fix WIT ANIME Arabic source by updating its base URL to the current domain.

Build:
- Increment the WIT ANIME Arabic extension version code to reflect the domain change.