### PR TITLE
Animelib [RU]: Update extension to include the various available domains to Animelib

### DIFF
--- a/src/ru/animelib/build.gradle
+++ b/src/ru/animelib/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animelib'
     extClass = '.Animelib'
-    extVersionCode = 11
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/ru/animelib/build.gradle
+++ b/src/ru/animelib/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animelib'
     extClass = '.Animelib'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = true
 }
 

--- a/src/ru/animelib/build.gradle
+++ b/src/ru/animelib/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animelib'
     extClass = '.Animelib'
-    extVersionCode = 13
+    extVersionCode = 12
     isNsfw = true
 }
 

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -45,9 +45,9 @@ class Animelib :
 
     override val supportsLatest = true
 
-    private val domain = "v3.animelib.org"
+    private val domain = "animelib.org"
     override val baseUrl = "https://$domain/ru"
-    private val apiSite = "https://api.cdnlibs.org"
+    private val apiSite = "https://hapi.hentaicdn.org"
     private val apiUrl = "$apiSite/api"
     private val coverDomain = "cover.imglib.info"
 

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -45,12 +45,8 @@ class Animelib :
 
     override val supportsLatest = true
 
-    private val domain: String
-        get() = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
-
-    override val baseUrl: String
-        get() = "https://$domain/ru"
-
+    private val domain = "animelib.org"
+    override val baseUrl = "https://$domain/ru"
     private val apiSite = "https://hapi.hentaicdn.org"
     private val apiUrl = "$apiSite/api"
     private val coverDomain = "cover.imglib.info"
@@ -59,10 +55,6 @@ class Animelib :
     private val dateFormatter by lazy { SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH) }
 
     companion object {
-        private const val PREF_DOMAIN_KEY = "pref_domain"
-        private val PREF_DOMAIN_ENTRIES = arrayOf("animelib.org", "v3.animelib.org", "v4.animelib.org", "v5.animelib.org")
-        private const val PREF_DOMAIN_DEFAULT = "v5.animelib.org"
-
         private const val PREF_QUALITY_KEY = "pref_quality"
         private val PREF_QUALITY_ENTRIES = arrayOf("360", "720", "1080", "2160")
 
@@ -101,19 +93,6 @@ class Animelib :
     private val preferences by getPreferencesLazy()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        ListPreference(screen.context).apply {
-            key = PREF_DOMAIN_KEY
-            title = "Домен"
-            entries = PREF_DOMAIN_ENTRIES
-            entryValues = PREF_DOMAIN_ENTRIES
-            summary = "Текущий домен: %s"
-            setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putString(key, newValue as String).commit()
-            }
-        }.also(screen::addPreference)
-
         ListPreference(screen.context).apply {
             key = PREF_SERVER_KEY
             title = "Предпочитаемый сервер плеера Animelib"
@@ -397,7 +376,7 @@ class Animelib :
 
         val kodikPage = UrlUtils.fixUrl(playerUrl) ?: return emptyList()
         val headers = Headers.Builder()
-        headers.add("Referer", "https://$domain/")
+        headers.add("Referer", baseUrl)
 
         // Parse form parameters for video link request
         val page = client.newCall(GET(kodikPage, headers.build())).awaitSuccess().useAsJsoup()

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -45,8 +45,12 @@ class Animelib :
 
     override val supportsLatest = true
 
-    private val domain = "animelib.org"
-    override val baseUrl = "https://$domain/ru"
+    private val domain: String
+        get() = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
+
+    override val baseUrl: String
+        get() = "https://$domain/ru"
+
     private val apiSite = "https://hapi.hentaicdn.org"
     private val apiUrl = "$apiSite/api"
     private val coverDomain = "cover.imglib.info"
@@ -55,6 +59,10 @@ class Animelib :
     private val dateFormatter by lazy { SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH) }
 
     companion object {
+        private const val PREF_DOMAIN_KEY = "pref_domain"
+        private val PREF_DOMAIN_ENTRIES = arrayOf("animelib.org", "v3.animelib.org", "v4.animelib.org", "v5.animelib.org")
+        private const val PREF_DOMAIN_DEFAULT = "v5.animelib.org"
+
         private const val PREF_QUALITY_KEY = "pref_quality"
         private val PREF_QUALITY_ENTRIES = arrayOf("360", "720", "1080", "2160")
 
@@ -93,6 +101,19 @@ class Animelib :
     private val preferences by getPreferencesLazy()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        ListPreference(screen.context).apply {
+            key = PREF_DOMAIN_KEY
+            title = "Домен"
+            entries = PREF_DOMAIN_ENTRIES
+            entryValues = PREF_DOMAIN_ENTRIES
+            summary = "Текущий домен: %s"
+            setDefaultValue(PREF_DOMAIN_DEFAULT)
+
+            setOnPreferenceChangeListener { _, newValue ->
+                preferences.edit().putString(key, newValue as String).commit()
+            }
+        }.also(screen::addPreference)
+
         ListPreference(screen.context).apply {
             key = PREF_SERVER_KEY
             title = "Предпочитаемый сервер плеера Animelib"
@@ -376,7 +397,7 @@ class Animelib :
 
         val kodikPage = UrlUtils.fixUrl(playerUrl) ?: return emptyList()
         val headers = Headers.Builder()
-        headers.add("Referer", baseUrl)
+        headers.add("Referer", "https://$domain/")
 
         // Parse form parameters for video link request
         val page = client.newCall(GET(kodikPage, headers.build())).awaitSuccess().useAsJsoup()

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -373,7 +373,7 @@ class Animelib :
 
         val kodikPage = UrlUtils.fixUrl(playerUrl) ?: return emptyList()
         val headers = Headers.Builder()
-        headers.add("Referer", "https://$domain/")
+        headers.add("Referer", "$baseUrl/")
 
         // Parse form parameters for video link request
         val page = client.newCall(GET(kodikPage, headers.build())).awaitSuccess().useAsJsoup()

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -61,7 +61,7 @@ class Animelib :
     companion object {
         private const val PREF_DOMAIN_KEY = "pref_domain"
         private val PREF_DOMAIN_ENTRIES = arrayOf("animelib.org", "v3.animelib.org", "v4.animelib.org", "v5.animelib.org")
-        private const val PREF_DOMAIN_DEFAULT = "v5.animelib.org"
+        private const val PREF_DOMAIN_DEFAULT = "animelib.org"
 
         private const val PREF_QUALITY_KEY = "pref_quality"
         private val PREF_QUALITY_ENTRIES = arrayOf("360", "720", "1080", "2160")
@@ -108,10 +108,6 @@ class Animelib :
             entryValues = PREF_DOMAIN_ENTRIES
             summary = "Текущий домен: %s"
             setDefaultValue(PREF_DOMAIN_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putString(key, newValue as String).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -25,6 +25,7 @@ import keiyoushi.utils.bodyString
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.tryParse
 import keiyoushi.utils.useAsJsoup
 import okhttp3.FormBody
 import okhttp3.Headers
@@ -117,10 +118,6 @@ class Animelib :
             entryValues = PREF_SERVER_ENTRIES
             summary = "%s"
             setDefaultValue(PREF_SERVER_ENTRIES[0])
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putString(key, newValue as String).commit()
-            }
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
@@ -151,11 +148,6 @@ class Animelib :
                 entryValues = PREF_QUALITY_ENTRIES
                 summary = "При отсутствии нужного качества могут возникать ошибки!"
                 setDefaultValue(PREF_QUALITY_ENTRIES.toSet())
-
-                setOnPreferenceChangeListener { _, newValue ->
-                    @Suppress("UNCHECKED_CAST")
-                    preferences.edit().putStringSet(key, newValue as Set<String>).commit()
-                }
             }.also(screen::addPreference)
         }
 
@@ -164,10 +156,6 @@ class Animelib :
             title = "Включить парсинг видео из плеера Kodik"
             summary = "Некоторые видео доступны только в нем, но он может работать нестабильно"
             setDefaultValue(PREF_USE_KODIK_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putBoolean(key, newValue as Boolean).commit()
-            }
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
@@ -175,10 +163,6 @@ class Animelib :
             title = "Игнорировать субтитры"
             summary = "Исключает видео с субтитрами"
             setDefaultValue(PREF_IGNORE_SUBS_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putBoolean(key, newValue as Boolean).commit()
-            }
         }.also(screen::addPreference)
 
         EditTextPreference(screen.context).apply {
@@ -186,10 +170,6 @@ class Animelib :
             title = "Предпочитаемые студии озвучки"
             summary = "Список студий или ключевых слов через запятую (экспериментальная функция)"
             setDefaultValue("")
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putString(key, newValue as String).commit()
-            }
         }.also(screen::addPreference)
     }
 
@@ -368,8 +348,8 @@ class Animelib :
         url.addPathSegment("constants")
         url.addQueryParameter("fields[]", "videoServers")
 
-        val videoServerResponse = client.newCall(GET(url.build())).awaitSuccess()
-        val videoServers = videoServerResponse.parseAs<VideoServerData>()
+        val videoServers = client.newCall(GET(url.build())).awaitSuccess()
+            .parseAs<VideoServerData>()
 
         val serverPreference = preferences.getString(PREF_SERVER_KEY, PREF_SERVER_ENTRIES[0])
         if (serverPreference.isNullOrEmpty()) {
@@ -558,6 +538,6 @@ class Animelib :
         url = "api/episodes/$id"
         name = "Сезон $season Серия $number $episodeName"
         episode_number = number.toFloat()
-        date_upload = dateFormatter.parse(date)?.time ?: 0L
+        date_upload = dateFormatter.tryParse(date)
     }
 }


### PR DESCRIPTION
Add various domains to extension.
Add support to select domain.
Bump version to 13.
Closes #130. Maybe...

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add configurable domain support for the Animelib (RU) extension and bump its version.

New Features:
- Allow users to select among multiple Animelib domains via an in-extension preference.

Enhancements:
- Use the selected domain dynamically for the extension base URL and related requests.

Build:
- Increase Animelib extension version code to 13.