### PR TITLE
AnimePahe: Fix video loading

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 37
+    extVersionCode = 38
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 36
+    extVersionCode = 37
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -450,6 +450,7 @@ class AnimePahe :
         private const val PREF_DOMAIN_KEY = "preferred_domain"
         private const val PREF_DOMAIN_TITLE = "Preferred domain (requires app restart)"
         private val PREF_DOMAIN_ENTRIES = listOf(
+            "animepahe.pw",
             "animepahe.com",
             "animepahe.org",
         )

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -21,7 +21,6 @@ import keiyoushi.utils.parallelCatchingMapNotNull
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.useAsJsoup
 import kotlinx.coroutines.runBlocking
-import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -317,45 +316,30 @@ class AnimePahe :
         val downloadLinks = document.select("div#pickDownload > a")
         return runBlocking {
             document.select("div#resolutionMenu > button").withIndex().parallelCatchingMapNotNull { (index, btn) ->
-                val kwikLink = btn.attr("data-src")
                 val quality = btn.text()
                 val paheWinLink = downloadLinks.getOrNull(index)?.attr("href")
                     ?: return@parallelCatchingMapNotNull null
-                getVideo(paheWinLink, kwikLink, quality)
+
+                // Fixed: Removed kwikLink from the call to match the new signature
+                getVideo(paheWinLink, quality)
             }
         }
     }
 
-    private suspend fun getVideo(paheUrl: String, kwikUrl: String, quality: String): Video {
-        val normalizedKwikUrl = when {
-            kwikUrl.startsWith("//") -> "https:$kwikUrl"
-            kwikUrl.startsWith("http") -> kwikUrl
-            else -> "https://$kwikUrl"
-        }
-
-        val videoUrl = if (preferences.getBoolean(PREF_LINK_TYPE_KEY, PREF_LINK_TYPE_DEFAULT)) {
-            KwikExtractor(client).getHlsStreamUrl(normalizedKwikUrl, referer = baseUrl)
-        } else {
-            KwikExtractor(client).getStreamUrlFromKwik(paheUrl)
-        }
+    private suspend fun getVideo(paheUrl: String, quality: String): Video {
+        // Temporarily forcing the MP4 extraction as HLS is currently broken.
+        // Also bypasses the PREF_LINK_TYPE_KEY preference check.
+        val videoUrl = KwikExtractor(client).getStreamUrlFromKwik(paheUrl)
 
         return Video(
             videoUrl,
             quality,
             videoUrl,
-            headers = Headers.headersOf(
-                "referer",
-                normalizedKwikUrl,
-                "origin",
-                "https://kwik.cx",
-                "user-agent",
-                "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-                "accept",
-                "*/*",
-            ),
+            headers = headers.newBuilder()
+                .set("referer", "https://kwik.cx/")
+                .build(),
         )
     }
-
     override fun List<Video>.sort(): List<Video> {
         val subPreference = preferences.getString(PREF_SUB_KEY, PREF_SUB_DEFAULT)!!
         val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -327,14 +327,8 @@ class AnimePahe :
     }
 
     private suspend fun getVideo(paheUrl: String, kwikUrl: String, quality: String): Video {
-        val normalizedKwikUrl = when {
-            kwikUrl.startsWith("//") -> "https:$kwikUrl"
-            kwikUrl.startsWith("http") -> kwikUrl
-            else -> "https://$kwikUrl"
-        }
-
         val videoUrl = if (preferences.getBoolean(PREF_LINK_TYPE_KEY, PREF_LINK_TYPE_DEFAULT)) {
-            KwikExtractor(client).getHlsStreamUrl(normalizedKwikUrl, referer = baseUrl)
+            KwikExtractor(client).getHlsStreamUrl(kwikUrl, referer = "$baseUrl/")
         } else {
             KwikExtractor(client).getStreamUrlFromKwik(paheUrl)
         }
@@ -343,16 +337,7 @@ class AnimePahe :
             videoUrl,
             quality,
             videoUrl,
-            headers = Headers.headersOf(
-                "referer",
-                normalizedKwikUrl,
-                "origin",
-                "https://kwik.cx",
-                "user-agent",
-                "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-                "accept",
-                "*/*",
-            ),
+            headers = Headers.headersOf("referer", "https://kwik.cx/"),
         )
     }
 
@@ -479,13 +464,11 @@ class AnimePahe :
         private val PREF_SUB_ENTRIES = listOf("sub", "dub")
         private val PREF_SUB_VALUES = listOf("jpn", "eng")
 
-        private const val PREF_LINK_TYPE_KEY = "preferred_link_type"
+        private const val PREF_LINK_TYPE_KEY = "preferred_link_type_" // Temporary renamed to use HLS
         private const val PREF_LINK_TYPE_TITLE = "Use HLS links"
-        private const val PREF_LINK_TYPE_DEFAULT = false
+        private const val PREF_LINK_TYPE_DEFAULT = true // Temporary set to `true` to use HLS
         private val PREF_LINK_TYPE_SUMMARY by lazy {
-            """Enable this if you are having Cloudflare issues.
-            |Note that this will break the ability to seek inside of the video unless the episode is downloaded in advance.
-            """.trimMargin()
+            """Enable this if you are having Cloudflare issues.""".trimMargin()
         }
 
         // Big slap to whoever misspelled `preferred`

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -327,16 +327,32 @@ class AnimePahe :
     }
 
     private suspend fun getVideo(paheUrl: String, kwikUrl: String, quality: String): Video {
+        val normalizedKwikUrl = when {
+            kwikUrl.startsWith("//") -> "https:$kwikUrl"
+            kwikUrl.startsWith("http") -> kwikUrl
+            else -> "https://$kwikUrl"
+        }
+
         val videoUrl = if (preferences.getBoolean(PREF_LINK_TYPE_KEY, PREF_LINK_TYPE_DEFAULT)) {
-            KwikExtractor(client).getHlsStreamUrl(kwikUrl, referer = baseUrl)
+            KwikExtractor(client).getHlsStreamUrl(normalizedKwikUrl, referer = baseUrl)
         } else {
             KwikExtractor(client).getStreamUrlFromKwik(paheUrl)
         }
+
         return Video(
             videoUrl,
             quality,
             videoUrl,
-            headers = Headers.headersOf("referer", "https://kwik.cx"),
+            headers = Headers.headersOf(
+                "referer",
+                normalizedKwikUrl,
+                "origin",
+                "https://kwik.cx",
+                "user-agent",
+                "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+                "accept",
+                "*/*",
+            ),
         )
     }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -21,6 +21,7 @@ import keiyoushi.utils.parallelCatchingMapNotNull
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.useAsJsoup
 import kotlinx.coroutines.runBlocking
+import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -316,30 +317,45 @@ class AnimePahe :
         val downloadLinks = document.select("div#pickDownload > a")
         return runBlocking {
             document.select("div#resolutionMenu > button").withIndex().parallelCatchingMapNotNull { (index, btn) ->
+                val kwikLink = btn.attr("data-src")
                 val quality = btn.text()
                 val paheWinLink = downloadLinks.getOrNull(index)?.attr("href")
                     ?: return@parallelCatchingMapNotNull null
-
-                // Fixed: Removed kwikLink from the call to match the new signature
-                getVideo(paheWinLink, quality)
+                getVideo(paheWinLink, kwikLink, quality)
             }
         }
     }
 
-    private suspend fun getVideo(paheUrl: String, quality: String): Video {
-        // Temporarily forcing the MP4 extraction as HLS is currently broken.
-        // Also bypasses the PREF_LINK_TYPE_KEY preference check.
-        val videoUrl = KwikExtractor(client).getStreamUrlFromKwik(paheUrl)
+    private suspend fun getVideo(paheUrl: String, kwikUrl: String, quality: String): Video {
+        val normalizedKwikUrl = when {
+            kwikUrl.startsWith("//") -> "https:$kwikUrl"
+            kwikUrl.startsWith("http") -> kwikUrl
+            else -> "https://$kwikUrl"
+        }
+
+        val videoUrl = if (preferences.getBoolean(PREF_LINK_TYPE_KEY, PREF_LINK_TYPE_DEFAULT)) {
+            KwikExtractor(client).getHlsStreamUrl(normalizedKwikUrl, referer = baseUrl)
+        } else {
+            KwikExtractor(client).getStreamUrlFromKwik(paheUrl)
+        }
 
         return Video(
             videoUrl,
             quality,
             videoUrl,
-            headers = headers.newBuilder()
-                .set("referer", "https://kwik.cx/")
-                .build(),
+            headers = Headers.headersOf(
+                "referer",
+                normalizedKwikUrl,
+                "origin",
+                "https://kwik.cx",
+                "user-agent",
+                "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+                "accept",
+                "*/*",
+            ),
         )
     }
+
     override fun List<Video>.sort(): List<Video> {
         val subPreference = preferences.getString(PREF_SUB_KEY, PREF_SUB_DEFAULT)!!
         val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!


### PR DESCRIPTION
Fixed how extension grabs video links.  Addresses error 403: Forbidden error.
Added specific changes, notably user agent to fix loading issues.
Bumped to version 38.
Closes #134.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
