### PR TITLE
AnimeKai: Update filters

### DIFF
--- a/src/en/animekai/build.gradle
+++ b/src/en/animekai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeKai'
     extClass = '.AnimeKai'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKaiFilters.kt
+++ b/src/en/animekai/src/eu/kanade/tachiyomi/animeextension/en/animekai/AnimeKaiFilters.kt
@@ -110,6 +110,8 @@ object AnimeKaiFilters {
         )
 
         val YEARS = listOf(
+            Pair("2027", "2027"),
+            Pair("2026", "2026"),
             Pair("2025", "2025"),
             Pair("2024", "2024"),
             Pair("2023", "2023"),
@@ -158,12 +160,13 @@ object AnimeKaiFilters {
             Pair("Name A-Z", "title_az"),
             Pair("Average score", "avg_score"),
             Pair("MAL score", "mal_score"),
-            Pair("Total views", "total_views"),
-            Pair("Total bookmarks", "total_bookmarks"),
-            Pair("Total episodes", "total_episodes"),
+            Pair("Most viewed", "most_viewed"),
+            Pair("Most followed", "most_followed"),
+            Pair("Episode count", "episode_count"),
         )
 
         val STATUS = listOf(
+            Pair("Not Yet Aired", "info"),
             Pair("Releasing", "releasing"),
             Pair("Completed", "completed"),
         )


### PR DESCRIPTION
Update AnimeKai to include newer filters.
Bump version to 14.

Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [X] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update AnimeKai extension filters to support new year, sorting, and status options and bump the extension version.

New Features:
- Add 2026 and 2027 to the available year filter options for AnimeKai.
- Add new sorting options for most viewed, most followed, and episode count in AnimeKai.
- Add a "Not Yet Aired" status filter option in AnimeKai.

Build:
- Bump AnimeKai extension version code from 13 to 14.