### PR TITLE
[PT] AnimesBr: Remove libs dependency since site appear to be dead

### DIFF
--- a/src/pt/animesbr/build.gradle
+++ b/src/pt/animesbr/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    extName = 'AnimesBr'
+    extName = 'AnimesBr (Dead)'
     extClass = '.AnimesBr'
     themePkg = 'dooplay'
     baseUrl = 'https://animesbr.tv'
@@ -8,8 +8,3 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
-
-dependencies {
-    implementation(project(":lib:unpacker"))
-    implementation(project(":lib:vidmolyextractor"))
-}

--- a/src/pt/animesbr/src/eu/kanade/tachiyomi/animeextension/pt/animesbr/AnimesBr.kt
+++ b/src/pt/animesbr/src/eu/kanade/tachiyomi/animeextension/pt/animesbr/AnimesBr.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.animeextension.pt.animesbr
 
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import aniyomi.lib.vidmolyextractor.VidMolyExtractor
 import eu.kanade.tachiyomi.animeextension.pt.animesbr.extractors.FourNimesExtractor
 import eu.kanade.tachiyomi.animeextension.pt.animesbr.extractors.RuplayExtractor
 import eu.kanade.tachiyomi.animesource.model.SAnime
@@ -83,7 +82,6 @@ class AnimesBr :
 
     private val fourNimesExtractor by lazy { FourNimesExtractor(client) }
     private val ruplayExtractor by lazy { RuplayExtractor(client) }
-    private val vidMolyExtractor by lazy { VidMolyExtractor(client) }
 
     private fun getPlayerVideos(player: Element): List<Video> {
         val name = player.selectFirst("span.title")!!.text()
@@ -100,7 +98,6 @@ class AnimesBr :
         return when {
             "4nimes.com" in url -> fourNimesExtractor.videosFromUrl(url, "$name - ")
             "4youmovies" in url -> fourNimesExtractor.videosFromUrl(url, "$name - ")
-            "vidmoly" in url -> vidMolyExtractor.videosFromUrl(url, "$name - ")
             "/embed/" in url -> ruplayExtractor.videosFromUrl(url, "$name - ")
             else -> emptyList()
         }

--- a/src/pt/animesbr/src/eu/kanade/tachiyomi/animeextension/pt/animesbr/extractors/FourNimesExtractor.kt
+++ b/src/pt/animesbr/src/eu/kanade/tachiyomi/animeextension/pt/animesbr/extractors/FourNimesExtractor.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.pt.animesbr.extractors
 
-import aniyomi.lib.jsunpacker.JsUnpacker
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
@@ -14,7 +13,7 @@ class FourNimesExtractor(private val client: OkHttpClient) {
         val doc = client.newCall(GET(url)).execute().asJsoup()
 
         val script = doc.selectFirst("script:containsData(eval):containsData(p,a,c,k,e,d)")?.data()
-            ?.let(JsUnpacker::unpackAndCombine)
+            // ?.let(JsUnpacker::unpackAndCombine)
             ?: return emptyList()
 
         val kaken = script.substringAfter("kaken", "")


### PR DESCRIPTION
## Summary by Sourcery

Mark the AnimesBr PT extension as dead and remove its unused unpacker and VidMoly extractor dependencies and logic.

Enhancements:
- Update the AnimesBr extension name to indicate the source is dead.
- Remove the VidMoly extractor usage and associated player handling from the AnimesBr extension.
- Comment out JS unpacking in the FourNimes extractor to drop the jsunpacker library dependency.