### PR TITLE
Animenosub: Fix Vtube & Wolfstream extractors

### DIFF
--- a/src/en/animenosub/build.gradle
+++ b/src/en/animenosub/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Animenosub'
     themePkg = 'animestream'
     baseUrl = 'https://animenosub.to'
-    overrideVersionCode = 18
+    overrideVersionCode = 19
     isNsfw = true
 }
 

--- a/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
+++ b/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
@@ -1,49 +1,49 @@
 package eu.kanade.tachiyomi.animeextension.en.animenosub.extractors
 
-import aniyomi.lib.jsunpacker.JsUnpacker
+import aniyomi.lib.autoUnpacker
+import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.asJsoup
+import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.parallelCatchingFlatMap
+import keiyoushi.utils.useAsJsoup
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 
 class VtubeExtractor(private val client: OkHttpClient, private val headers: Headers) {
-    fun videosFromUrl(url: String, baseUrl: String, prefix: String): List<Video> {
-        val videoList = mutableListOf<Video>()
 
+    private val playlistUtils by lazy { PlaylistUtils(client) }
+    private val sourcesRegex by lazy { Regex("""sources\s*:\s*(.+?]),""") }
+    private val urlsRegex by lazy { Regex("""file\s*:\s*["'](.+?)["']""") }
+
+    suspend fun videosFromUrl(url: String, baseUrl: String, prefix: String): List<Video> {
         val docHeaders = headers.newBuilder()
             .add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
             .add("Host", url.toHttpUrl().host)
             .add("Referer", "$baseUrl/")
             .build()
-        val doc = client.newCall(GET(url, headers = docHeaders)).execute().asJsoup()
+        val doc = client.newCall(GET(url, headers = docHeaders)).awaitSuccess().useAsJsoup()
 
-        val jsEval = doc.selectFirst("script:containsData(m3u8)")!!.data()
+        val jsEval = doc.selectFirst("script:containsData(function(p,a,c,k,e,d))")?.data()
+        val unpacked = jsEval?.let(::autoUnpacker) ?: doc.toString()
 
-        val masterUrl = JsUnpacker.unpackAndCombine(jsEval)
-            ?.substringAfter("source")
-            ?.substringAfter("file:\"")
-            ?.substringBefore("\"")
-            ?: return emptyList()
+        val sources = sourcesRegex.find(unpacked)?.groupValues[1] ?: return emptyList()
+        val urls = urlsRegex.findAll(sources)
+            .mapNotNull { match -> match.groupValues[1].takeIf { it.isNotBlank() } }.toList()
 
-        val playlistHeaders = headers.newBuilder()
-            .add("Accept", "*/*")
-            .add("Host", masterUrl.toHttpUrl().host)
-            .add("Origin", "https://${url.toHttpUrl().host}")
-            .add("Referer", "https://${url.toHttpUrl().host}/")
-            .build()
-
-        val masterPlaylist = client.newCall(
-            GET(masterUrl, headers = playlistHeaders),
-        ).execute().body.string()
-        val separator = "#EXT-X-STREAM-INF:"
-        masterPlaylist.substringAfter(separator).split(separator).forEach {
-            val quality = prefix + it.substringAfter("RESOLUTION=").substringAfter("x").substringBefore(",") + "p "
-            val videoUrl = it.substringAfter("\n").substringBefore("\n")
-            videoList.add(Video(videoUrl, quality, videoUrl, headers = playlistHeaders))
+        return urls.parallelCatchingFlatMap { videoUrl ->
+            playlistUtils.extractFromHls(
+                videoUrl,
+                videoNameGen = { quality ->
+                    listOfNotNull(
+                        prefix.takeIf { it.isNotBlank() },
+                        quality,
+                    ).joinToString(" ")
+                },
+                masterHeaders = headers,
+                videoHeaders = headers,
+            )
         }
-
-        return videoList
     }
 }

--- a/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
+++ b/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
@@ -26,7 +26,9 @@ class VtubeExtractor(private val client: OkHttpClient, private val headers: Head
         val doc = client.newCall(GET(url, headers = docHeaders)).awaitSuccess().useAsJsoup()
 
         val jsEval = doc.selectFirst("script:containsData(function(p,a,c,k,e,d))")?.data()
-        val unpacked = jsEval?.let(::autoUnpacker) ?: doc.toString()
+        val unpacked = jsEval?.let(::autoUnpacker)
+            ?: doc.selectFirst("script:containsData(sources)")?.data()
+            ?: return emptyList()
 
         val sources = sourcesRegex.find(unpacked)?.groupValues[1] ?: return emptyList()
         val urls = urlsRegex.findAll(sources)

--- a/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
+++ b/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
@@ -37,14 +37,13 @@ class VtubeExtractor(private val client: OkHttpClient, private val headers: Head
         return urls.parallelCatchingFlatMap { videoUrl ->
             playlistUtils.extractFromHls(
                 videoUrl,
+                referer = url,
                 videoNameGen = { quality ->
                     listOfNotNull(
                         prefix.takeIf { it.isNotBlank() },
                         quality,
                     ).joinToString(" ")
                 },
-                masterHeaders = headers,
-                videoHeaders = headers,
             )
         }
     }

--- a/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
+++ b/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/VtubeExtractor.kt
@@ -14,8 +14,8 @@ import okhttp3.OkHttpClient
 class VtubeExtractor(private val client: OkHttpClient, private val headers: Headers) {
 
     private val playlistUtils by lazy { PlaylistUtils(client) }
-    private val sourcesRegex by lazy { Regex("""sources\s*:\s*(.+?]),""") }
-    private val urlsRegex by lazy { Regex("""file\s*:\s*["'](.+?)["']""") }
+    private val sourcesRegex by lazy { Regex("""sources\s*:\s*(.+?]),""", RegexOption.DOT_MATCHES_ALL) }
+    private val urlsRegex by lazy { Regex("""file\s*:\s*["']([^"']+)["']""") }
 
     suspend fun videosFromUrl(url: String, baseUrl: String, prefix: String): List<Video> {
         val docHeaders = headers.newBuilder()

--- a/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/WolfstreamExtractor.kt
+++ b/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/WolfstreamExtractor.kt
@@ -8,8 +8,8 @@ import okhttp3.OkHttpClient
 
 class WolfstreamExtractor(private val client: OkHttpClient) {
 
-    private val sourcesRegex by lazy { Regex("""sources\s*:\s*(.+?]),""") }
-    private val urlsRegex by lazy { Regex("""file\s*:\s*["'](.+?)["']""") }
+    private val sourcesRegex by lazy { Regex("""sources\s*:\s*(.+?]),""", RegexOption.DOT_MATCHES_ALL) }
+    private val urlsRegex by lazy { Regex("""file\s*:\s*["']([^"']+)["']""") }
 
     suspend fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
         val urls = client.newCall(

--- a/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/WolfstreamExtractor.kt
+++ b/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/WolfstreamExtractor.kt
@@ -5,19 +5,24 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.useAsJsoup
 import okhttp3.OkHttpClient
-import org.jsoup.nodes.Element
 
 class WolfstreamExtractor(private val client: OkHttpClient) {
+
+    private val sourcesRegex by lazy { Regex("""sources\s*:\s*(.+?]),""") }
+    private val urlsRegex by lazy { Regex("""file\s*:\s*["'](.+?)["']""") }
+
     suspend fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
-        val url = client.newCall(
+        val urls = client.newCall(
             GET(url),
         ).awaitSuccess().useAsJsoup()
-            .selectFirst("script:containsData(sources)")
-            ?.let { it: Element ->
-                it.data().substringAfter("{file:\"").substringBefore("\"")
+            .selectFirst("script:containsData(sources)")?.data()
+            ?.let { unpacked ->
+                val sources = sourcesRegex.find(unpacked)?.groupValues[1] ?: return emptyList()
+                urlsRegex.findAll(sources)
+                    .mapNotNull { match -> match.groupValues[1].takeIf { it.isNotBlank() } }.toList()
             } ?: return emptyList()
-        return listOf(
-            Video(url, "${prefix}WolfStream", url),
-        )
+        return urls.map { videoUl ->
+            Video(videoUl, "${prefix}WolfStream", videoUl)
+        }
     }
 }

--- a/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/WolfstreamExtractor.kt
+++ b/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/WolfstreamExtractor.kt
@@ -2,16 +2,20 @@ package eu.kanade.tachiyomi.animeextension.en.animenosub.extractors
 
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.asJsoup
+import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.useAsJsoup
 import okhttp3.OkHttpClient
+import org.jsoup.nodes.Element
 
 class WolfstreamExtractor(private val client: OkHttpClient) {
-    fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
+    suspend fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
         val url = client.newCall(
             GET(url),
-        ).execute().asJsoup().selectFirst("script:containsData(sources)")?.let {
-            it.data().substringAfter("{file:\"").substringBefore("\"")
-        } ?: return emptyList()
+        ).awaitSuccess().useAsJsoup()
+            .selectFirst("script:containsData(sources)")
+            ?.let { it: Element ->
+                it.data().substringAfter("{file:\"").substringBefore("\"")
+            } ?: return emptyList()
         return listOf(
             Video(url, "${prefix}WolfStream", url),
         )


### PR DESCRIPTION
## Summary by Sourcery

Fix and modernize the Animenosub Vtube and Wolfstream video extractors for compatibility with current hosts.

Bug Fixes:
- Restore Vtube extractor functionality by correctly unpacking scripts and resolving all available HLS source URLs.
- Restore Wolfstream extractor functionality by correctly parsing the embedded source URL from the host page.

Enhancements:
- Refactor Vtube extractor to use shared playlist utilities, asynchronous requests, and parallel extraction for multiple HLS streams.
- Update Wolfstream extractor to use the newer awaitSuccess/useAsJsoup helpers for more reliable HTML fetching and parsing.

Build:
- Bump the Animenosub extension overrideVersionCode to 19 for release of the extractor fixes.