### PR TITLE
AllAnime [EN]: Fix video extraction with AES-256 decryption

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 46
+    extVersionCode = 47
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -314,14 +314,17 @@ class AllAnime :
         }.getOrNull()
 
         // 2. Determine the source URLs list by decrypting if necessary
-        val sourceUrls = if (encryptedJson?.data?.tobeparsed != null) {
-            val decryptedString = decryptTobeparsed(encryptedJson.data.tobeparsed)
-            val decryptedJson = json.decodeFromString<DecryptedEpisodeResult>(decryptedString)
-            decryptedJson.episode.sourceUrls
+        val sourceUrls = if (!encryptedJson?.data?.tobeparsed.isNullOrBlank()) {
+            runCatching {
+                val decryptedString = decryptTobeparsed(encryptedJson!!.data.tobeparsed!!)
+                json.decodeFromString<DecryptedEpisodeResult>(decryptedString).episode.sourceUrls
+            }.getOrElse {
+                // Malformed encrypted payload — fall back to plain-text parsing
+                json.decodeFromString<EpisodeResult>(responseBody).data.episode.sourceUrls
+            }
         } else {
             // Fallback to old plain-text parsing
-            val videoJson = json.decodeFromString<EpisodeResult>(responseBody)
-            videoJson.data.episode.sourceUrls
+            json.decodeFromString<EpisodeResult>(responseBody).data.episode.sourceUrls
         }
 
         val videoList = mutableListOf<Pair<Video, Float>>()
@@ -519,26 +522,25 @@ class AllAnime :
 
     private fun decryptTobeparsed(base64Payload: String): String {
         // 1. Generate the SHA-256 key from the reversed secret string
-        val secret = "P7K2RGbFgauVtmiS".reversed()
-        val keyBytes = MessageDigest.getInstance("SHA-256").digest(secret.toByteArray())
+        val keyBytes = MessageDigest.getInstance(DECRYPT_KEY_ALGO)
+            .digest(DECRYPT_SECRET.reversed().toByteArray(Charsets.UTF_8))
 
         // 2. Decode the Base64 payload
         val decodedBytes = Base64.decode(base64Payload, Base64.DEFAULT)
 
-        // 3. Separate the IV (first 12 bytes) and the encrypted data
-        val iv = decodedBytes.sliceArray(0 until 12)
-        val encryptedData = decodedBytes.sliceArray(12 until decodedBytes.size)
+        // 3. Separate the IV and the encrypted data
+        val iv = decodedBytes.sliceArray(0 until DECRYPT_IV_LENGTH)
+        val encryptedData = decodedBytes.sliceArray(DECRYPT_IV_LENGTH until decodedBytes.size)
 
         // 4. Initialize the AES-GCM Cipher
-        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        val keySpec = SecretKeySpec(keyBytes, "AES")
-        val gcmSpec = GCMParameterSpec(128, iv)
+        val cipher = Cipher.getInstance(DECRYPT_CIPHER_ALGO)
+        val keySpec = SecretKeySpec(keyBytes, DECRYPT_KEY_TYPE)
+        val gcmSpec = GCMParameterSpec(DECRYPT_TAG_LENGTH, iv)
 
         cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmSpec)
 
         // 5. Decrypt and convert back to a JSON String
-        val decryptedBytes = cipher.doFinal(encryptedData)
-        return String(decryptedBytes)
+        return String(cipher.doFinal(encryptedData), Charsets.UTF_8)
     }
 
     companion object {
@@ -608,6 +610,13 @@ class AllAnime :
 
         private const val PREF_SUB_KEY = "preferred_sub"
         private const val PREF_SUB_DEFAULT = "sub"
+
+        private const val DECRYPT_SECRET = "P7K2RGbFgauVtmiS"
+        private const val DECRYPT_IV_LENGTH = 12
+        private const val DECRYPT_TAG_LENGTH = 128
+        private const val DECRYPT_KEY_ALGO = "SHA-256"
+        private const val DECRYPT_KEY_TYPE = "AES"
+        private const val DECRYPT_CIPHER_ALGO = "AES/GCM/NoPadding"
     }
 
     // ============================== Settings ==============================

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -1,9 +1,14 @@
 package eu.kanade.tachiyomi.animeextension.en.allanime
 
 import android.content.SharedPreferences
+import android.util.Base64
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 import aniyomi.lib.doodextractor.DoodExtractor
 import aniyomi.lib.filemoonextractor.FilemoonExtractor
 import aniyomi.lib.gogostreamextractor.GogoStreamExtractor
@@ -301,8 +306,24 @@ class AllAnime :
 
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
         val response = client.newCall(videoListRequest(episode)).await()
+        val responseBody = response.body.string()
 
-        val videoJson = response.parseAs<EpisodeResult>()
+        // 1. Try parsing the encrypted wrapper
+        val encryptedJson = runCatching {
+            json.decodeFromString<EncryptedEpisodeResult>(responseBody)
+        }.getOrNull()
+
+        // 2. Determine the source URLs list by decrypting if necessary
+        val sourceUrls = if (encryptedJson?.data?.tobeparsed != null) {
+            val decryptedString = decryptTobeparsed(encryptedJson.data.tobeparsed)
+            val decryptedJson = json.decodeFromString<DecryptedEpisodeResult>(decryptedString)
+            decryptedJson.episode.sourceUrls
+        } else {
+            // Fallback to old plain-text parsing
+            val videoJson = json.decodeFromString<EpisodeResult>(responseBody)
+            videoJson.data.episode.sourceUrls
+        }
+
         val videoList = mutableListOf<Pair<Video, Float>>()
         val serverList = mutableListOf<Server>()
 
@@ -320,7 +341,7 @@ class AllAnime :
             "streamwish" to listOf("wish"),
         )
 
-        videoJson.data.episode.sourceUrls.forEach { video ->
+        sourceUrls.forEach { video ->
             val videoUrl = video.sourceUrl.decryptSource()
 
             val matchingMapping = mappings.firstOrNull { (altHoster, urlMatches) ->
@@ -495,6 +516,30 @@ class AllAnime :
     }
 
     private fun String.containsAny(keywords: List<String>): Boolean = keywords.any { this.contains(it) }
+
+    private fun decryptTobeparsed(base64Payload: String): String {
+        // 1. Generate the SHA-256 key from the reversed secret string
+        val secret = "P7K2RGbFgauVtmiS".reversed()
+        val keyBytes = MessageDigest.getInstance("SHA-256").digest(secret.toByteArray())
+
+        // 2. Decode the Base64 payload
+        val decodedBytes = Base64.decode(base64Payload, Base64.DEFAULT)
+
+        // 3. Separate the IV (first 12 bytes) and the encrypted data
+        val iv = decodedBytes.sliceArray(0 until 12)
+        val encryptedData = decodedBytes.sliceArray(12 until decodedBytes.size)
+
+        // 4. Initialize the AES-GCM Cipher
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val keySpec = SecretKeySpec(keyBytes, "AES")
+        val gcmSpec = GCMParameterSpec(128, iv)
+
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmSpec)
+
+        // 5. Decrypt and convert back to a JSON String
+        val decryptedBytes = cipher.doFinal(encryptedData)
+        return String(decryptedBytes)
+    }
 
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -23,6 +23,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
+import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.bodyString
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
@@ -301,8 +303,8 @@ class AllAnime :
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
 
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
-        val response = client.newCall(videoListRequest(episode)).await()
-        val responseBody = response.body.string()
+        val responseBody = client.newCall(videoListRequest(episode))
+            .awaitSuccess().bodyString()
 
         // 1. Try parsing the encrypted wrapper
         val encryptedJson = runCatching {

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -313,7 +313,7 @@ class AllAnime :
         // 2. Determine the source URLs list by decrypting if necessary
         val sourceUrls = encryptedJson?.data?.tobeparsed?.takeIf(String::isNotBlank)
             ?.runCatching {
-                val decryptedString = decryptTobeparsed(encryptedJson.data.tobeparsed)
+                val decryptedString = decryptTobeparsed(this)
                 decryptedString.parseAs<DecryptedEpisodeResult>().episode.sourceUrls
             }?.getOrNull()
             // Malformed encrypted payload — fall back to old plain-text parsing

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -28,9 +28,9 @@ import keiyoushi.utils.bodyString
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.toJsonString
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -42,7 +42,10 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
-import uy.kohesive.injekt.injectLazy
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 class AllAnime :
     AnimeHttpSource(),
@@ -57,8 +60,6 @@ class AllAnime :
     override val lang = "en"
 
     override val supportsLatest = true
-
-    private val json: Json by injectLazy()
 
     private val preferences by getPreferencesLazy()
 
@@ -146,10 +147,10 @@ class AllAnime :
                         if (filters.season != "all") put("season", filters.season)
                         if (filters.releaseYear != "all") put("year", filters.releaseYear.toInt())
                         if (filters.genres != "all") {
-                            put("genres", json.decodeFromString(filters.genres))
+                            put("genres", filters.genres.parseAs<JsonElement>())
                             put("excludeGenres", buildJsonArray { })
                         }
-                        if (filters.types != "all") put("types", json.decodeFromString(filters.types))
+                        if (filters.types != "all") put("types", filters.types.parseAs<JsonElement>())
                         if (filters.sortBy != "update") put("sortBy", filters.sortBy)
                     }
                     put("limit", PAGE_SIZE)
@@ -174,7 +175,7 @@ class AllAnime :
                 putJsonObject("search") {
                     put("allowAdult", true)
                     put("allowUnknown", true)
-                    put("genres", json.decodeFromString(genres))
+                    put("genres", genres.parseAs<JsonElement>())
                 }
                 put("limit", PAGE_SIZE)
                 put("page", 1)
@@ -260,16 +261,14 @@ class AllAnime :
             SEpisode.create().apply {
                 episode_number = ep.toFloatOrNull() ?: 0F
                 name = "Episode $numName ($subPref)"
-                url = json.encodeToString(
-                    buildJsonObject {
-                        putJsonObject("variables") {
-                            put("showId", medias.data.show.id)
-                            put("translationType", subPref)
-                            put("episodeString", ep)
-                        }
-                        put("query", STREAMS_QUERY)
-                    },
-                )
+                url = buildJsonObject {
+                    putJsonObject("variables") {
+                        put("showId", medias.data.show.id)
+                        put("translationType", subPref)
+                        put("episodeString", ep)
+                    }
+                    put("query", STREAMS_QUERY)
+                }.toJsonString()
             }
         }
     }
@@ -308,22 +307,17 @@ class AllAnime :
 
         // 1. Try parsing the encrypted wrapper
         val encryptedJson = runCatching {
-            json.decodeFromString<EncryptedEpisodeResult>(responseBody)
+            responseBody.parseAs<EncryptedEpisodeResult>()
         }.getOrNull()
 
         // 2. Determine the source URLs list by decrypting if necessary
-        val sourceUrls = if (!encryptedJson?.data?.tobeparsed.isNullOrBlank()) {
-            runCatching {
-                val decryptedString = decryptTobeparsed(encryptedJson!!.data.tobeparsed!!)
-                json.decodeFromString<DecryptedEpisodeResult>(decryptedString).episode.sourceUrls
-            }.getOrElse {
-                // Malformed encrypted payload — fall back to plain-text parsing
-                json.decodeFromString<EpisodeResult>(responseBody).data.episode.sourceUrls
-            }
-        } else {
-            // Fallback to old plain-text parsing
-            json.decodeFromString<EpisodeResult>(responseBody).data.episode.sourceUrls
-        }
+        val sourceUrls = encryptedJson?.data?.tobeparsed?.takeIf(String::isNotBlank)
+            ?.runCatching {
+                val decryptedString = decryptTobeparsed(encryptedJson.data.tobeparsed)
+                decryptedString.parseAs<DecryptedEpisodeResult>().episode.sourceUrls
+            }?.getOrNull()
+            // Malformed encrypted payload — fall back to old plain-text parsing
+            ?: responseBody.parseAs<EpisodeResult>().data.episode.sourceUrls
 
         val videoList = mutableListOf<Pair<Video, Float>>()
         val serverList = mutableListOf<Server>()
@@ -459,8 +453,7 @@ class AllAnime :
     }
 
     private fun buildPost(dataObject: JsonObject): Request {
-        val payload = json.encodeToString(dataObject)
-            .toRequestBody("application/json; charset=utf-8".toMediaType())
+        val payload = dataObject.toJsonString().toJsonBody()
 
         val siteUrl = preferences.siteUrl
         val postHeaders = headers.newBuilder().apply {

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -5,10 +5,6 @@ import android.util.Base64
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
-import java.security.MessageDigest
-import javax.crypto.Cipher
-import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.SecretKeySpec
 import aniyomi.lib.doodextractor.DoodExtractor
 import aniyomi.lib.filemoonextractor.FilemoonExtractor
 import aniyomi.lib.gogostreamextractor.GogoStreamExtractor

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -621,13 +621,6 @@ class AllAnime :
             entryValues = arrayOf("https://allmanga.to")
             setDefaultValue(PREF_SITE_DOMAIN_DEFAULT)
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -637,13 +630,6 @@ class AllAnime :
             entryValues = arrayOf("https://api.allanime.day")
             setDefaultValue(PREF_DOMAIN_DEFAULT)
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -653,13 +639,6 @@ class AllAnime :
             entryValues = PREF_SERVER_ENTRY_VALUES
             setDefaultValue(PREF_SERVER_DEFAULT)
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         MultiSelectListPreference(screen.context).apply {
@@ -668,10 +647,6 @@ class AllAnime :
             entries = INTERAL_HOSTER_NAMES
             entryValues = PREF_HOSTER_ENTRY_VALUES
             setDefaultValue(PREF_HOSTER_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putStringSet(key, newValue as Set<String>).commit()
-            }
         }.also(screen::addPreference)
 
         MultiSelectListPreference(screen.context).apply {
@@ -680,10 +655,6 @@ class AllAnime :
             entries = ALT_HOSTER_NAMES
             entryValues = ALT_HOSTER_NAMES
             setDefaultValue(ALT_HOSTER_NAMES.toSet())
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putStringSet(key, newValue as Set<String>).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -693,13 +664,6 @@ class AllAnime :
             entryValues = PREF_QUALITY_ENTRY_VALUES
             setDefaultValue(PREF_QUALITY_DEFAULT)
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -709,13 +673,6 @@ class AllAnime :
             entryValues = arrayOf("romaji", "eng", "native")
             setDefaultValue(PREF_TITLE_STYLE_DEFAULT)
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -725,13 +682,6 @@ class AllAnime :
             entryValues = arrayOf("sub", "dub")
             setDefaultValue(PREF_SUB_DEFAULT)
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
     }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
@@ -133,3 +133,18 @@ data class EpisodeResult(
         }
     }
 }
+
+@Serializable
+data class EncryptedEpisodeResult(
+    val data: EncryptedData
+) {
+    @Serializable
+    data class EncryptedData(
+        val tobeparsed: String? = null
+    )
+}
+
+@Serializable
+data class DecryptedEpisodeResult(
+    val episode: EpisodeResult.DataEpisode.Episode
+)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
@@ -136,15 +136,15 @@ data class EpisodeResult(
 
 @Serializable
 data class EncryptedEpisodeResult(
-    val data: EncryptedData
+    val data: EncryptedData,
 ) {
     @Serializable
     data class EncryptedData(
-        val tobeparsed: String? = null
+        val tobeparsed: String? = null,
     )
 }
 
 @Serializable
 data class DecryptedEpisodeResult(
-    val episode: EpisodeResult.DataEpisode.Episode
+    val episode: EpisodeResult.DataEpisode.Episode,
 )


### PR DESCRIPTION
Closes #157 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Handle AllAnime episode stream responses that may be AES-encrypted and ensure video extraction continues to work.

Bug Fixes:
- Restore video list extraction when the AllAnime API returns AES-256-GCM–encrypted episode data by decrypting the payload before processing.
- Gracefully fall back to legacy plain JSON parsing when the encrypted episode payload is missing or malformed.

Enhancements:
- Introduce DTOs for encrypted and decrypted episode responses and reuse shared JSON helper utilities instead of a lazily injected Json instance.
- Simplify preference handling by relying on default ListPreference and MultiSelectListPreference persistence behavior.
- Use shared helpers for JSON body construction and response reading in network requests.

Build:
- Bump the AllAnime extension version code to 47.