### PR TITLE
AllAnime [EN]: Add AES-256 decryption

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 46
+    extVersionCode = 47
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.animeextension.en.allanime
 
 import android.content.SharedPreferences
+import android.util.Base64
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
@@ -24,7 +25,6 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
-import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -40,6 +40,10 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
 import uy.kohesive.injekt.injectLazy
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 class AllAnime :
     AnimeHttpSource(),
@@ -75,7 +79,7 @@ class AllAnime :
     }
 
     override fun popularAnimeParse(response: Response): AnimesPage {
-        val parsed = response.parseAs<PopularResult>()
+        val parsed = parseResponse<PopularResult>(response)
 
         val animeList = parsed.data.queryPopular.recommendations.filter { it.anyCard != null }.map {
             SAnime.create().apply {
@@ -209,7 +213,7 @@ class AllAnime :
     }
 
     override fun animeDetailsParse(response: Response): SAnime {
-        val show = response.parseAs<DetailsResult>().data.show
+        val show = parseResponse<DetailsResult>(response).data.show
 
         return SAnime.create().apply {
             genre = show.genres?.joinToString(separator = ", ") ?: ""
@@ -243,7 +247,7 @@ class AllAnime :
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val subPref = preferences.subPref
-        val medias = response.parseAs<SeriesResult>()
+        val medias = parseResponse<SeriesResult>(response)
 
         val episodesDetail = if (subPref == "sub") {
             medias.data.show.availableEpisodesDetail.sub!!
@@ -302,7 +306,7 @@ class AllAnime :
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
         val response = client.newCall(videoListRequest(episode)).await()
 
-        val videoJson = response.parseAs<EpisodeResult>()
+        val videoJson = parseResponse<EpisodeResult>(response)
         val videoList = mutableListOf<Pair<Video, Float>>()
         val serverList = mutableListOf<Server>()
 
@@ -354,8 +358,8 @@ class AllAnime :
                     }
 
                     sName.startsWith("player@") -> {
-                        val endPoint = client.newCall(GET("${preferences.siteUrl}/getVersion")).await()
-                            .parseAs<AllAnimeExtractor.VersionResponse>()
+                        val versionResponse = client.newCall(GET("${preferences.siteUrl}/getVersion")).await()
+                        val endPoint = parseResponse<AllAnimeExtractor.VersionResponse>(versionResponse)
                             .episodeIframeHead
 
                         val videoHeaders = headers.newBuilder().apply {
@@ -411,6 +415,46 @@ class AllAnime :
     }
 
     // ============================= Utilities ==============================
+
+    /**
+     * Parses an API response, handling potential AES-GCM encryption.
+     * If the response contains a `data.tobeparsed` field, it decrypts it
+     * and re-wraps the result for normal parsing.
+     */
+    private inline fun <reified T> parseResponse(response: Response): T {
+        val rawBody = response.body.string()
+
+        val wrapper = json.decodeFromString<EncryptedWrapper>(rawBody)
+        val encrypted = wrapper.data?.tobeparsed
+
+        val bodyToParse = if (encrypted != null) {
+            val decrypted = decryptAesGcm(encrypted)
+            "{\"data\":$decrypted}"
+        } else {
+            rawBody
+        }
+
+        return json.decodeFromString<T>(bodyToParse)
+    }
+
+    private fun decryptAesGcm(encoded: String): String {
+        val keyBytes = MessageDigest.getInstance("SHA-256")
+            .digest(AES_KEY.toByteArray(Charsets.UTF_8))
+
+        val data = Base64.decode(encoded, Base64.DEFAULT)
+        val iv = data.copyOfRange(0, 12)
+        val ciphertext = data.copyOfRange(12, data.size)
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+            init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(keyBytes, "AES"),
+                GCMParameterSpec(128, iv),
+            )
+        }
+
+        return cipher.doFinal(ciphertext).toString(Charsets.UTF_8)
+    }
 
     private fun String.decryptSource(): String {
         if (!this.startsWith("-")) return this
@@ -471,7 +515,7 @@ class AllAnime :
         .lowercase()
 
     private fun parseAnime(response: Response): AnimesPage {
-        val parsed = response.parseAs<SearchResult>()
+        val parsed = parseResponse<SearchResult>(response)
 
         val animeList = parsed.data.shows.edges.map { ani ->
             SAnime.create().apply {
@@ -498,6 +542,8 @@ class AllAnime :
 
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API
+        private const val AES_KEY = "SimtVuagFbGR2K7P"
+
         private val INTERAL_HOSTER_NAMES = arrayOf(
             "Default", "Ac", "Ak", "Kir", "Rab", "Luf-mp4",
             "Si-Hls", "S-mp4", "Ac-Hls", "Uv-mp4", "Pn-Hls",

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
@@ -133,3 +133,11 @@ data class EpisodeResult(
         }
     }
 }
+
+// Wrapper for detecting encrypted API responses.
+// The API now returns `{"data":{"tobeparsed":"<encrypted>"}}`
+@Serializable
+data class EncryptedWrapper(val data: EncryptedInner? = null)
+
+@Serializable
+data class EncryptedInner(val tobeparsed: String? = null)


### PR DESCRIPTION
Fix AllAnime videos not loading, caused by new AES 256 encryption.
Used same logic as AllManga.
Bump to version 47.
Closes #157.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
