### PR TITLE
Update base URL in build.gradle

### DIFF
--- a/src/en/dopeflix/build.gradle
+++ b/src/en/dopeflix/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'DopeFlix'
     extClass = '.DopeFlix'
     themePkg = 'dopeflix'
-    baseUrl = 'https://citysonic.tv'
+    baseUrl = 'https://1flix.stream'
     overrideVersionCode = 2
 }
 


### PR DESCRIPTION
Update the base URL to the working 1flix domain

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
