### PR TITLE
Update streaming sites in DopeFlix.kt

### DIFF
--- a/src/en/dopeflix/src/eu/kanade/tachiyomi/animeextension/en/dopeflix/DopeFlix.kt
+++ b/src/en/dopeflix/src/eu/kanade/tachiyomi/animeextension/en/dopeflix/DopeFlix.kt
@@ -15,7 +15,7 @@ class DopeFlix :
             "moviesdl.org",
             "movieclub-hd.com",
             // "himovies.sx", (dead)
-            // "movies4kto.lol", (site works but irrelavent)
+            // "movies4kto.lol", (site works but irrelevant)
             // "myflixtor.tv", (merged into livezy.click)
             "series2watch.net",
             "watch32.sx",

--- a/src/en/dopeflix/src/eu/kanade/tachiyomi/animeextension/en/dopeflix/DopeFlix.kt
+++ b/src/en/dopeflix/src/eu/kanade/tachiyomi/animeextension/en/dopeflix/DopeFlix.kt
@@ -9,17 +9,17 @@ class DopeFlix :
         "en",
         BuildConfig.MEGACLOUD_API,
         listOf(
-            "1flix.to",
-            "flixhq.to",
-            "fmovieszz.lol",
-            "gomovies.gg",
-            "hdtoday.cc",
-            "himovies.sx",
-            "movies4kto.lol",
-            "myflixtor.tv",
+            "1flix.stream",
+            "flixhqz.com",
+            "ww2-fmovies.com",
+            "moviesdl.org",
+            "movieclub-hd.com",
+            // "himovies.sx", (dead)
+            // "movies4kto.lol", (site works but irrelavent)
+            // "myflixtor.tv", (merged into livezy.click)
             "series2watch.net",
             "watch32.sx",
-            // "citysonic.tv",
+            "livezy.click/citysonic", // citysonic current domain
         ),
     ) {
     override val detailInfoSelector by lazy { "div.detail_page-infor, div.m_i-detail" }


### PR DESCRIPTION
Updated some sites to their latest domains

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Enhancements:
- Refresh the configured list of DopeFlix streaming domains, adding new working mirrors and dropping dead or obsolete sites.