### PR TITLE
Add 'xprime.stream' to DOMAIN_ENTRIES

### DIFF
--- a/src/en/xprime/src/eu/kanade/tachiyomi/animeextension/en/xprime/XPrime.kt
+++ b/src/en/xprime/src/eu/kanade/tachiyomi/animeextension/en/xprime/XPrime.kt
@@ -521,7 +521,7 @@ class XPrime :
 
         private const val PREF_DOMAIN_KEY = "pref_domain"
         private const val PREF_DOMAIN_DEFAULT = "https://xprime.tv"
-        private val DOMAIN_ENTRIES = arrayOf("xprime.tv", "xprime.today")
+        private val DOMAIN_ENTRIES = arrayOf("xprime.tv", "xprime.today", "xprime.stream")
         private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }.toTypedArray()
 
         private const val PREF_LATEST_KEY = "pref_latest"


### PR DESCRIPTION
Added working domain to the list of domain entries in xprime extension

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

New Features:
- Allow the XPrime extension to use the xprime.stream domain as an additional selectable host.