### PR TITLE
Revert to Older Rate Limit Method (Support Outdated Applications)

### DIFF
--- a/lib-multisrc/animekaitheme/build.gradle.kts
+++ b/lib-multisrc/animekaitheme/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 2
+baseVersionCode = 3
 
 dependencies {
     implementation(project(":lib:megaupextractor"))

--- a/lib-multisrc/animekaitheme/src/eu/kanade/tachiyomi/multisrc/animekaitheme/AnimeKaiTheme.kt
+++ b/lib-multisrc/animekaitheme/src/eu/kanade/tachiyomi/multisrc/animekaitheme/AnimeKaiTheme.kt
@@ -45,8 +45,8 @@ import org.jsoup.nodes.Element
 import uy.kohesive.injekt.injectLazy
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.seconds
 
 abstract class AnimeKaiTheme(
     override val lang: String,
@@ -72,11 +72,13 @@ abstract class AnimeKaiTheme(
 
     protected var docHeaders by LazyMutable { headersBuilder().build() }
 
+    // Go back to depreciated rate limit method, as apps e.g. Dantotsu do not support kotlin.time yet
     override var client: OkHttpClient by LazyMutable {
         network.client.newBuilder()
-            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1.seconds)
+            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1, unit = TimeUnit.SECONDS)
             .build()
     }
+
     private val cacheControl by lazy { CacheControl.Builder().maxAge(1.hours).build() }
 
     // ============================ Headers & Client =========================
@@ -360,7 +362,7 @@ abstract class AnimeKaiTheme(
 
     protected open fun updateDomainConfig() {
         client = network.client.newBuilder()
-            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1.seconds)
+            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1, unit = TimeUnit.SECONDS)
             .build()
         docHeaders = headersBuilder().build()
         megaUpExtractor = MegaUpExtractor(client, docHeaders, context)

--- a/lib-multisrc/animekaitheme/src/eu/kanade/tachiyomi/multisrc/animekaitheme/AnimeKaiTheme.kt
+++ b/lib-multisrc/animekaitheme/src/eu/kanade/tachiyomi/multisrc/animekaitheme/AnimeKaiTheme.kt
@@ -72,7 +72,7 @@ abstract class AnimeKaiTheme(
 
     protected var docHeaders by LazyMutable { headersBuilder().build() }
 
-    // Go back to depreciated rate limit method, as apps e.g. Dantotsu do not support kotlin.time yet
+    // Go back to deprecated rate limit method, as apps e.g. Dantotsu do not support kotlin.time yet
     override var client: OkHttpClient by LazyMutable {
         network.client.newBuilder()
             .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1, unit = TimeUnit.SECONDS)

--- a/lib-multisrc/animekaitheme/src/eu/kanade/tachiyomi/multisrc/animekaitheme/AnimeKaiTheme.kt
+++ b/lib-multisrc/animekaitheme/src/eu/kanade/tachiyomi/multisrc/animekaitheme/AnimeKaiTheme.kt
@@ -75,7 +75,7 @@ abstract class AnimeKaiTheme(
     // Go back to depreciated rate limit method, as apps e.g. Dantotsu do not support kotlin.time yet
     override var client: OkHttpClient by LazyMutable {
         network.client.newBuilder()
-            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1, unit = TimeUnit.SECONDS)
+            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1L, unit = TimeUnit.SECONDS)
             .build()
     }
 
@@ -362,7 +362,7 @@ abstract class AnimeKaiTheme(
 
     protected open fun updateDomainConfig() {
         client = network.client.newBuilder()
-            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1, unit = TimeUnit.SECONDS)
+            .rateLimitHost(baseUrl.toHttpUrl(), permits = rateLimit, period = 1L, unit = TimeUnit.SECONDS)
             .build()
         docHeaders = headersBuilder().build()
         megaUpExtractor = MegaUpExtractor(client, docHeaders, context)

--- a/lib-multisrc/sudatchi/src/eu/kanade/tachiyomi/multisrc/sudatchi/Sudatchi.kt
+++ b/lib-multisrc/sudatchi/src/eu/kanade/tachiyomi/multisrc/sudatchi/Sudatchi.kt
@@ -23,6 +23,7 @@ import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import java.util.concurrent.TimeUnit
 
 open class Sudatchi(
     override val name: String = "Sudatchi",
@@ -32,7 +33,7 @@ open class Sudatchi(
     override val baseUrl = "https://sudatchi.com"
 
     override val client = network.client.newBuilder()
-        .rateLimitHost("$baseUrl/api/".toHttpUrl(), 5)
+        .rateLimitHost("$baseUrl/api/".toHttpUrl(), 5, 1L, TimeUnit.SECONDS)
         .build()
 
     override val lang = "all"

--- a/lib-multisrc/sudatchi/src/eu/kanade/tachiyomi/multisrc/sudatchi/Sudatchi.kt
+++ b/lib-multisrc/sudatchi/src/eu/kanade/tachiyomi/multisrc/sudatchi/Sudatchi.kt
@@ -23,7 +23,6 @@ import keiyoushi.utils.parseAs
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import java.util.concurrent.TimeUnit
 
 open class Sudatchi(
     override val name: String = "Sudatchi",
@@ -33,7 +32,7 @@ open class Sudatchi(
     override val baseUrl = "https://sudatchi.com"
 
     override val client = network.client.newBuilder()
-        .rateLimitHost("$baseUrl/api/".toHttpUrl(), 5, 1L, TimeUnit.SECONDS)
+        .rateLimitHost("$baseUrl/api/".toHttpUrl(), 5)
         .build()
 
     override val lang = "all"

--- a/src/en/anilist/build.gradle
+++ b/src/en/anilist/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniList'
     extClass = '.AniList'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/AniList.kt
+++ b/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/AniList.kt
@@ -28,6 +28,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
+import java.util.concurrent.TimeUnit
 
 class AniList :
     AnimeHttpSource(),
@@ -44,7 +45,7 @@ class AniList :
     override val supportsLatest = true
 
     override val client = network.client.newBuilder()
-        .rateLimitHost("https://api.jikan.moe".toHttpUrl(), 1)
+        .rateLimitHost("https://api.jikan.moe".toHttpUrl(), 1, 1L, TimeUnit.SECONDS)
         .build()
 
     private val json: Json by injectLazy()


### PR DESCRIPTION
Reverts to TimeUnit.SECONDS instead of .seconds as applications, like Dantotsu, don't support it yet.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Enhancements:
- Restore TimeUnit-based rate limit configuration on AnimeKaiTheme HTTP client to support apps that do not yet handle kotlin.time Duration.