### PR TITLE
AllAnime [EN]: Fix video request's referrer & support query searching with filters

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 48
+    extVersionCode = 49
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -121,7 +121,6 @@ class AllAnime :
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val filters = AllAnimeFilters.getSearchParameters(filters)
-        val translationType = if (filters.tracks == "") preferences.subPref else filters.tracks
 
         val data = buildJsonObject {
             putJsonObject("variables") {

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -279,14 +279,13 @@ class AllAnime :
         val payload = episode.url
             .toRequestBody("application/json; charset=utf-8".toMediaType())
 
-        val siteUrl = preferences.siteUrl
         val postHeaders = headers.newBuilder().apply {
             add("Accept", "*/*")
             add("Content-Length", payload.contentLength().toString())
             add("Content-Type", payload.contentType().toString())
             add("Host", apiUrl.toHttpUrl().host)
-            add("Origin", siteUrl)
-            add("Referer", "$apiUrl/")
+            add("Origin", GRAPHQL_ORIGIN)
+            add("Referer", "$GRAPHQL_ORIGIN/")
         }.build()
 
         return POST("$apiUrl/api", headers = postHeaders, body = payload)
@@ -459,14 +458,13 @@ class AllAnime :
     private fun buildPost(dataObject: JsonObject): Request {
         val payload = dataObject.toJsonString().toJsonBody()
 
-        val siteUrl = preferences.siteUrl
         val postHeaders = headers.newBuilder().apply {
             add("Accept", "*/*")
             add("Content-Length", payload.contentLength().toString())
             add("Content-Type", payload.contentType().toString())
             add("Host", apiUrl.toHttpUrl().host)
-            add("Origin", siteUrl)
-            add("Referer", "$apiUrl/")
+            add("Origin", GRAPHQL_ORIGIN)
+            add("Referer", "$GRAPHQL_ORIGIN/")
         }.build()
 
         return POST("$apiUrl/api", headers = postHeaders, body = payload)
@@ -540,6 +538,7 @@ class AllAnime :
 
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API
+        private const val GRAPHQL_ORIGIN = "https://youtu-chan.com"
         private val INTERAL_HOSTER_NAMES = arrayOf(
             "Default", "Ac", "Ak", "Kir", "Rab", "Luf-mp4",
             "Si-Hls", "S-mp4", "Ac-Hls", "Uv-mp4", "Pn-Hls",

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -22,7 +22,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.bodyString
 import keiyoushi.utils.getPreferencesLazy
@@ -350,7 +349,7 @@ class AllAnime :
                     }
 
                     sName.startsWith("player@") -> {
-                        val endPoint = client.newCall(GET("${preferences.siteUrl}/getVersion")).await()
+                        val endPoint = client.newCall(GET("${preferences.siteUrl}/getVersion")).awaitSuccess()
                             .parseAs<AllAnimeExtractor.VersionResponse>()
                             .episodeIframeHead
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -128,14 +128,14 @@ class AllAnime :
                     if (query.isNotBlank()) put("query", query)
                     put("allowAdult", true)
                     put("allowUnknown", true)
-                    if (filters.sortBy != "Recent") put("sortBy", filters.sortBy)
-                    if (filters.season != "all") put("season", filters.season)
-                    if (filters.releaseYear != "all") put("year", filters.releaseYear.toInt())
-                    if (filters.genres != "all") {
+                    filters.sortBy.takeIf { it != "Recent" && it.isNotBlank() }?.let { put("sortBy", it) }
+                    filters.season.takeIf { it != "all" && it.isNotBlank() }?.let { put("season", it) }
+                    filters.releaseYear.toIntOrNull()?.let { put("year", it) }
+                    if (filters.genres != "all" && filters.genres.isNotBlank()) {
                         put("genres", filters.genres.parseAs<JsonElement>())
                         put("excludeGenres", buildJsonArray { })
                     }
-                    if (filters.types != "all") put("types", filters.types.parseAs<JsonElement>())
+                    if (filters.types != "all" && filters.types.isNotBlank()) put("types", filters.types.parseAs<JsonElement>())
                 }
                 put("limit", PAGE_SIZE)
                 put("page", page)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -121,47 +121,31 @@ class AllAnime :
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val filters = AllAnimeFilters.getSearchParameters(filters)
+        val translationType = if (filters.tracks == "") preferences.subPref else filters.tracks
 
-        return if (query.isNotEmpty()) {
-            val data = buildJsonObject {
-                putJsonObject("variables") {
-                    putJsonObject("search") {
-                        put("query", query)
-                        put("allowAdult", true)
-                        put("allowUnknown", true)
+        val data = buildJsonObject {
+            putJsonObject("variables") {
+                putJsonObject("search") {
+                    if (query.isNotEmpty()) put("query", query)
+                    put("allowAdult", true)
+                    put("allowUnknown", true)
+                    if (filters.sortBy != "Recent") put("sortBy", filters.sortBy)
+                    if (filters.season != "all") put("season", filters.season)
+                    if (filters.releaseYear != "all") put("year", filters.releaseYear.toInt())
+                    if (filters.genres != "all") {
+                        put("genres", filters.genres.parseAs<JsonElement>())
+                        put("excludeGenres", buildJsonArray { })
                     }
-                    put("limit", PAGE_SIZE)
-                    put("page", page)
-                    put("translationType", preferences.subPref)
-                    put("countryOrigin", "ALL")
+                    if (filters.types != "all") put("types", filters.types.parseAs<JsonElement>())
                 }
-                put("query", SEARCH_QUERY)
+                put("limit", PAGE_SIZE)
+                put("page", page)
+                put("translationType", translationType)
+                put("countryOrigin", filters.origin)
             }
-            buildPost(data)
-        } else {
-            val data = buildJsonObject {
-                putJsonObject("variables") {
-                    putJsonObject("search") {
-                        put("allowAdult", true)
-                        put("allowUnknown", true)
-                        if (filters.season != "all") put("season", filters.season)
-                        if (filters.releaseYear != "all") put("year", filters.releaseYear.toInt())
-                        if (filters.genres != "all") {
-                            put("genres", filters.genres.parseAs<JsonElement>())
-                            put("excludeGenres", buildJsonArray { })
-                        }
-                        if (filters.types != "all") put("types", filters.types.parseAs<JsonElement>())
-                        if (filters.sortBy != "update") put("sortBy", filters.sortBy)
-                    }
-                    put("limit", PAGE_SIZE)
-                    put("page", page)
-                    put("translationType", preferences.subPref)
-                    put("countryOrigin", filters.origin)
-                }
-                put("query", SEARCH_QUERY)
-            }
-            buildPost(data)
+            put("query", SEARCH_QUERY)
         }
+        return buildPost(data)
     }
 
     override fun searchAnimeParse(response: Response): AnimesPage = parseAnime(response)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -125,7 +125,7 @@ class AllAnime :
         val data = buildJsonObject {
             putJsonObject("variables") {
                 putJsonObject("search") {
-                    if (query.isNotEmpty()) put("query", query)
+                    if (query.isNotBlank()) put("query", query)
                     put("allowAdult", true)
                     put("allowUnknown", true)
                     if (filters.sortBy != "Recent") put("sortBy", filters.sortBy)
@@ -139,6 +139,7 @@ class AllAnime :
                 }
                 put("limit", PAGE_SIZE)
                 put("page", page)
+                put("translationType", preferences.subPref)
                 put("countryOrigin", filters.origin)
             }
             put("query", SEARCH_QUERY)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -139,7 +139,6 @@ class AllAnime :
                 }
                 put("limit", PAGE_SIZE)
                 put("page", page)
-                put("translationType", translationType)
                 put("countryOrigin", filters.origin)
             }
             put("query", SEARCH_QUERY)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -80,13 +80,14 @@ class AllAnime :
     override fun popularAnimeParse(response: Response): AnimesPage {
         val parsed = response.parseAs<PopularResult>()
 
-        val animeList = parsed.data.queryPopular.recommendations.filter { it.anyCard != null }.map {
+        val animeList = parsed.data.queryPopular.recommendations.mapNotNull {
+            if (it.anyCard == null) return@mapNotNull null
             SAnime.create().apply {
                 title = when (preferences.titleStyle) {
-                    "romaji" -> it.anyCard!!.name
-                    "eng" -> it.anyCard!!.englishName ?: it.anyCard.name
-                    else -> it.anyCard!!.nativeName ?: it.anyCard.name
-                }
+                    "romaji" -> it.anyCard.name
+                    "eng" -> it.anyCard.englishName
+                    else -> it.anyCard.nativeName
+                } ?: it.anyCard.name
                 thumbnail_url = it.anyCard.thumbnail?.let(::thumbnailUrl)
                 url = "${it.anyCard.id}<&sep>${it.anyCard.slugTime ?: ""}<&sep>${it.anyCard.name.slugify()}"
             }
@@ -149,7 +150,8 @@ class AllAnime :
     override fun searchAnimeParse(response: Response): AnimesPage = parseAnime(response)
 
     override fun relatedAnimeListRequest(anime: SAnime): Request {
-        val genres = anime.genre?.split(",").orEmpty()
+        val genres = anime.genre!!
+            .split(",")
             .map { it.trim() }
             .toJsonString()
         val data = buildJsonObject {
@@ -198,7 +200,7 @@ class AllAnime :
         val show = response.parseAs<DetailsResult>().data.show
 
         return SAnime.create().apply {
-            genre = show.genres?.joinToString(separator = ", ") ?: ""
+            genre = show.genres?.joinToString()
             status = parseStatus(show.status)
             author = show.studios?.firstOrNull()
             description = buildString {
@@ -359,14 +361,12 @@ class AllAnime :
                             add("Referer", "$endPoint/")
                         }.build()
 
-                        listOf(
-                            Video(
-                                server.sourceUrl,
-                                "Original (player ${server.sourceName.substringAfter("player@")})",
-                                server.sourceUrl,
-                                headers = videoHeaders,
-                            ),
-                        )
+                        Video(
+                            server.sourceUrl,
+                            "Original (player ${server.sourceName.substringAfter("player@")})",
+                            server.sourceUrl,
+                            headers = videoHeaders,
+                        ).let(::listOf)
                     }
 
                     sName == "vidstreaming" -> {
@@ -398,7 +398,7 @@ class AllAnime :
                     }
 
                     else -> emptyList()
-                }.let { it.map { v -> Pair(v, server.priority) } }
+                }.map { v -> Pair(v, server.priority) }
             },
         )
 
@@ -434,7 +434,8 @@ class AllAnime :
                 { it.first.quality.contains(quality, true) },
                 { it.first.quality.contains(subPref, true) },
             ),
-        ).reversed().map { t -> t.first }
+        ).reversed()
+            .map { t -> t.first }
     }
 
     private fun buildPost(dataObject: JsonObject): Request {
@@ -476,9 +477,9 @@ class AllAnime :
             SAnime.create().apply {
                 title = when (preferences.titleStyle) {
                     "romaji" -> ani.name
-                    "eng" -> ani.englishName ?: ani.name
-                    else -> ani.nativeName ?: ani.name
-                }
+                    "eng" -> ani.englishName
+                    else -> ani.nativeName
+                } ?: ani.name
                 thumbnail_url = ani.thumbnail?.let(::thumbnailUrl)
                 url = "${ani.id}<&sep>${ani.slugTime ?: ""}<&sep>${ani.name.slugify()}"
             }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -108,8 +108,9 @@ object AllAnimeFilters {
             Pair("Fall", "Fall"),
         )
 
-        // dynamic from 1975 till now
-        val YEARS = arrayOf(ALL) + (Calendar.getInstance().get(Calendar.YEAR) downTo 1975)
+        // current year, but not less than 2026
+        private val currentYear = Calendar.getInstance().get(Calendar.YEAR).coerceAtLeast(2026)
+        val YEARS = arrayOf(ALL) + (currentYear downTo 1975)
             .map { Pair(it.toString(), it.toString()) }
             .toTypedArray()
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.animeextension.en.allanime
 
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import java.util.Calendar
 
 object AllAnimeFilters {
 
@@ -107,59 +108,10 @@ object AllAnimeFilters {
             Pair("Fall", "Fall"),
         )
 
-        val YEARS = arrayOf(
-            ALL,
-            Pair("2024", "2024"),
-            Pair("2023", "2023"),
-            Pair("2022", "2022"),
-            Pair("2021", "2021"),
-            Pair("2020", "2020"),
-            Pair("2019", "2019"),
-            Pair("2018", "2018"),
-            Pair("2017", "2017"),
-            Pair("2016", "2016"),
-            Pair("2015", "2015"),
-            Pair("2014", "2014"),
-            Pair("2013", "2013"),
-            Pair("2012", "2012"),
-            Pair("2011", "2011"),
-            Pair("2010", "2010"),
-            Pair("2009", "2009"),
-            Pair("2008", "2008"),
-            Pair("2007", "2007"),
-            Pair("2006", "2006"),
-            Pair("2005", "2005"),
-            Pair("2004", "2004"),
-            Pair("2003", "2003"),
-            Pair("2002", "2002"),
-            Pair("2001", "2001"),
-            Pair("2000", "2000"),
-            Pair("1999", "1999"),
-            Pair("1998", "1998"),
-            Pair("1997", "1997"),
-            Pair("1996", "1996"),
-            Pair("1995", "1995"),
-            Pair("1994", "1994"),
-            Pair("1993", "1993"),
-            Pair("1992", "1992"),
-            Pair("1991", "1991"),
-            Pair("1990", "1990"),
-            Pair("1989", "1989"),
-            Pair("1988", "1988"),
-            Pair("1987", "1987"),
-            Pair("1986", "1986"),
-            Pair("1985", "1985"),
-            Pair("1984", "1984"),
-            Pair("1983", "1983"),
-            Pair("1982", "1982"),
-            Pair("1981", "1981"),
-            Pair("1980", "1980"),
-            Pair("1979", "1979"),
-            Pair("1978", "1978"),
-            Pair("1977", "1977"),
-            Pair("1976", "1976"),
-            Pair("1975", "1975"),
-        )
+        // dynamic from 1975 till now
+        val YEARS = arrayOf(ALL) + (Calendar.getInstance().get(Calendar.YEAR) downTo 1975)
+            .map { Pair(it.toString(), it.toString()) }
+            .toTypedArray()
 
         val SORT_BY = arrayOf(
             Pair("Update", "update"),

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -41,6 +41,7 @@ object AllAnimeFilters {
             }
         }
 
+    class TrackFilter : QueryPartFilter("Tracks", AllAnimeFiltersData.TRACKS)
     class OriginFilter : QueryPartFilter("Origin", AllAnimeFiltersData.ORIGIN)
     class SeasonFilter : QueryPartFilter("Season", AllAnimeFiltersData.SEASONS)
     class ReleaseYearFilter : QueryPartFilter("Released at", AllAnimeFiltersData.YEARS)
@@ -59,6 +60,7 @@ object AllAnimeFilters {
         )
 
     val FILTER_LIST get() = AnimeFilterList(
+        TrackFilter(),
         OriginFilter(),
         SeasonFilter(),
         ReleaseYearFilter(),
@@ -69,6 +71,7 @@ object AllAnimeFilters {
     )
 
     data class FilterSearchParams(
+        val tracks: String = "",
         val origin: String = "",
         val season: String = "",
         val releaseYear: String = "",
@@ -81,6 +84,7 @@ object AllAnimeFilters {
         if (filters.isEmpty()) return FilterSearchParams()
 
         return FilterSearchParams(
+            filters.asQueryPart<TrackFilter>(),
             filters.asQueryPart<OriginFilter>(),
             filters.asQueryPart<SeasonFilter>(),
             filters.asQueryPart<ReleaseYearFilter>(),
@@ -92,6 +96,11 @@ object AllAnimeFilters {
 
     private object AllAnimeFiltersData {
         val ALL = Pair("All", "all")
+
+        val TRACKS = arrayOf(
+            Pair("Sub", "sub"),
+            Pair("Dub", "dub"),
+        )
 
         val ORIGIN = arrayOf(
             Pair("All", "ALL"),
@@ -115,7 +124,7 @@ object AllAnimeFilters {
             .toTypedArray()
 
         val SORT_BY = arrayOf(
-            Pair("Update", "update"),
+            Pair("Update", "Recent"),
             Pair("Name Asc", "Name_ASC"),
             Pair("Name Desc", "Name_DESC"),
             Pair("Ratings", "Top"),

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -110,7 +110,7 @@ object AllAnimeFilters {
 
         // current year, but not less than 2026
         private val currentYear = Calendar.getInstance().get(Calendar.YEAR).coerceAtLeast(2026)
-        val YEARS = arrayOf(ALL) + (currentYear downTo 1975)
+        val YEARS = arrayOf(ALL) + (currentYear + 1 downTo 1975)
             .map { Pair(it.toString(), it.toString()) }
             .toTypedArray()
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -33,13 +33,8 @@ object AllAnimeFilters {
             } else {
                 null
             }
-        }.joinToString("\",\"").let {
-            if (it.isBlank()) {
-                "all"
-            } else {
-                "[\"$it\"]"
-            }
-        }
+        }.joinToString("\",\"", "[\'", "\']")
+        .ifBlank { "all" }
 
     class OriginFilter : QueryPartFilter("Origin", AllAnimeFiltersData.ORIGIN)
     class SeasonFilter : QueryPartFilter("Season", AllAnimeFiltersData.SEASONS)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -33,7 +33,7 @@ object AllAnimeFilters {
             } else {
                 null
             }
-        }.joinToString("\",\"", "[\'", "\']")
+        }.joinToString("\",\"", "[\"", "\"]")
         .ifBlank { "all" }
 
     class OriginFilter : QueryPartFilter("Origin", AllAnimeFiltersData.ORIGIN)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -41,7 +41,6 @@ object AllAnimeFilters {
             }
         }
 
-    class TrackFilter : QueryPartFilter("Tracks", AllAnimeFiltersData.TRACKS)
     class OriginFilter : QueryPartFilter("Origin", AllAnimeFiltersData.ORIGIN)
     class SeasonFilter : QueryPartFilter("Season", AllAnimeFiltersData.SEASONS)
     class ReleaseYearFilter : QueryPartFilter("Released at", AllAnimeFiltersData.YEARS)
@@ -71,7 +70,6 @@ object AllAnimeFilters {
     )
 
     data class FilterSearchParams(
-        val tracks: String = "",
         val origin: String = "",
         val season: String = "",
         val releaseYear: String = "",
@@ -96,11 +94,6 @@ object AllAnimeFilters {
 
     private object AllAnimeFiltersData {
         val ALL = Pair("All", "all")
-
-        val TRACKS = arrayOf(
-            Pair("Sub", "sub"),
-            Pair("Dub", "dub"),
-        )
 
         val ORIGIN = arrayOf(
             Pair("All", "ALL"),

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -59,7 +59,6 @@ object AllAnimeFilters {
         )
 
     val FILTER_LIST get() = AnimeFilterList(
-        TrackFilter(),
         OriginFilter(),
         SeasonFilter(),
         ReleaseYearFilter(),
@@ -82,7 +81,6 @@ object AllAnimeFilters {
         if (filters.isEmpty()) return FilterSearchParams()
 
         return FilterSearchParams(
-            filters.asQueryPart<TrackFilter>(),
             filters.asQueryPart<OriginFilter>(),
             filters.asQueryPart<SeasonFilter>(),
             filters.asQueryPart<ReleaseYearFilter>(),


### PR DESCRIPTION
Resolves #205 

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the AllAnime extension to fix video request headers and unify search so queries can be combined with filters while keeping metadata and filter options in sync with the upstream API.

Bug Fixes:
- Correct GraphQL and player video request Origin/Referer headers to use the dedicated AllAnime origin domain, improving compatibility with the site.
- Avoid null-related issues when building titles, genres, and related-anime genres by tightening null handling and defaults.

Enhancements:
- Allow text queries to be used together with season, year, genre, type, and sort filters in search requests.
- Align search sort keys and year options with the upstream API, including dynamic generation of year filter values based on the current year.
- Simplify genre list formatting and video list mapping to reduce redundant logic.

Build:
- Bump the AllAnime extension version code to 49.