### PR TITLE
[AllAnime] Fix new playback issues and broken search

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -7,6 +7,7 @@ ext {
 apply from: "$rootDir/common.gradle"
 
 dependencies {
+    implementation(project(':lib:playlistutils'))
     implementation(project(':lib:streamlareextractor'))
     implementation(project(':lib:mp4uploadextractor'))
     implementation(project(':lib:doodextractor'))

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 49
+    extVersionCode = 50
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -430,9 +430,7 @@ class AllAnime :
         }
 
         val mask = XOR_MASKS[keyType]
-        return parsedChunks
-            .map { ((it xor mask) and 0xFF).toChar() }
-            .joinToString("")
+        return String(CharArray(parsedChunks.size) { i -> ((parsedChunks[i] xor mask) and 0xFF).toChar() })
     }
 
     private fun prioritySort(pList: List<Pair<Video, Float>>): List<Video> {

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -326,20 +326,17 @@ class AllAnime :
                 videoUrl.startsWith("/apivtwo/") && INTERAL_HOSTER_NAMES.any {
                     Regex("""\b${it.lowercase()}\b""").find(video.sourceName.lowercase()) != null &&
                         hosterSelection.contains(it.lowercase())
-                } -> {
+                } ->
                     Server(videoUrl, "internal ${video.sourceName}", video.priority)
                         .let(serverList::add)
-                }
 
-                altHosterSelection.contains("player") && video.type == "player" -> {
+                altHosterSelection.contains("player") && video.type == "player" ->
                     Server(videoUrl, "player@${video.sourceName}", video.priority)
                         .let(serverList::add)
-                }
 
-                matchingMapping != null -> {
+                matchingMapping != null ->
                     Server(videoUrl, matchingMapping.first, video.priority)
                         .let(serverList::add)
-                }
             }
         }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -351,9 +351,11 @@ class AllAnime :
                     }
 
                     sName.startsWith("player@") -> {
-                        val endPoint = client.newCall(GET("${preferences.siteUrl}/getVersion")).awaitSuccess()
-                            .parseAs<AllAnimeExtractor.VersionResponse>()
-                            .episodeIframeHead
+                        val endPoint = runCatching {
+                            client.newCall(GET("${preferences.siteUrl}/getVersion")).awaitSuccess()
+                                .parseAs<AllAnimeExtractor.VersionResponse>()
+                                .episodeIframeHead
+                        }.getOrDefault("https://blog.allanime.day")
 
                         val videoHeaders = headers.newBuilder().apply {
                             add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
@@ -414,12 +416,22 @@ class AllAnime :
             startsWith("##") -> substring(2) to 1
             startsWith("-#") -> substring(2) to 4
             startsWith("#") -> substring(1) to 0
-            else -> return this
+            else -> this to null
         }
+
+        val parsedChunks = hexPayload.chunked(2).mapNotNull { it.toIntOrNull(16) }
+
+        if (keyType == null) {
+            XOR_MASKS.forEach { mask ->
+                val decrypted = parsedChunks.map { ((it xor mask) and 0xFF).toChar() }.joinToString("")
+                if (decrypted.contains("/clock") || decrypted.contains("http")) return decrypted
+            }
+            return this
+        }
+
         val mask = XOR_MASKS[keyType]
-        return hexPayload.chunked(2)
-            .map { ((it.toInt(16)) xor mask) and 0xFF }
-            .map { it.toChar() }
+        return parsedChunks
+            .map { ((it xor mask) and 0xFF).toChar() }
             .joinToString("")
     }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -300,9 +300,6 @@ class AllAnime :
             responseBody.parseAs<EpisodeResult>().data.episode.sourceUrls
         }
 
-        val videoList = mutableListOf<Pair<Video, Float>>()
-        val serverList = mutableListOf<Server>()
-
         val hosterSelection = preferences.getHosters
         val altHosterSelection = preferences.getAltHosters
 
@@ -317,6 +314,7 @@ class AllAnime :
             "streamwish" to listOf("wish"),
         )
 
+        val serverList = mutableListOf<Server>()
         sourceUrls.forEach { video ->
             val videoUrl = video.sourceUrl.decryptSource()
 
@@ -329,15 +327,18 @@ class AllAnime :
                     Regex("""\b${it.lowercase()}\b""").find(video.sourceName.lowercase()) != null &&
                         hosterSelection.contains(it.lowercase())
                 } -> {
-                    serverList.add(Server(videoUrl, "internal ${video.sourceName}", video.priority))
+                    Server(videoUrl, "internal ${video.sourceName}", video.priority)
+                        .let(serverList::add)
                 }
 
                 altHosterSelection.contains("player") && video.type == "player" -> {
-                    serverList.add(Server(videoUrl, "player@${video.sourceName}", video.priority))
+                    Server(videoUrl, "player@${video.sourceName}", video.priority)
+                        .let(serverList::add)
                 }
 
                 matchingMapping != null -> {
-                    serverList.add(Server(videoUrl, matchingMapping.first, video.priority))
+                    Server(videoUrl, matchingMapping.first, video.priority)
+                        .let(serverList::add)
                 }
             }
         }
@@ -349,63 +350,60 @@ class AllAnime :
                 .episodeIframeHead
         }.getOrDefault(FALLBACK_PLAYER_DOMAIN)
 
-        videoList.addAll(
-            serverList.parallelCatchingFlatMap { server ->
-                val sName = server.sourceName
-                when {
-                    sName.startsWith("internal ") -> {
-                        allAnimeExtractor.videoFromUrl(server.sourceUrl, server.sourceName, iframeEndpoint)
-                    }
+        return serverList.parallelCatchingFlatMap { server ->
+            val sName = server.sourceName
+            when {
+                sName.startsWith("internal ") -> {
+                    allAnimeExtractor.videoFromUrl(server.sourceUrl, server.sourceName, iframeEndpoint)
+                }
 
-                    sName.startsWith("player@") -> {
-                        val videoHeaders = headers.newBuilder().apply {
-                            add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
-                            add("Host", server.sourceUrl.toHttpUrl().host)
-                            add("Referer", "$iframeEndpoint/")
-                        }.build()
+                sName.startsWith("player@") -> {
+                    val videoHeaders = headers.newBuilder().apply {
+                        add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
+                        add("Host", server.sourceUrl.toHttpUrl().host)
+                        add("Referer", "$iframeEndpoint/")
+                    }.build()
 
-                        Video(
-                            server.sourceUrl,
-                            "Original (player ${server.sourceName.substringAfter("player@")})",
-                            server.sourceUrl,
-                            headers = videoHeaders,
-                        ).let(::listOf)
-                    }
+                    Video(
+                        server.sourceUrl,
+                        "Original (player ${server.sourceName.substringAfter("player@")})",
+                        server.sourceUrl,
+                        headers = videoHeaders,
+                    ).let(::listOf)
+                }
 
-                    sName == "vidstreaming" -> {
-                        gogoStreamExtractor.videosFromUrl(server.sourceUrl.replace(Regex("^//"), "https://"))
-                    }
+                sName == "vidstreaming" -> {
+                    gogoStreamExtractor.videosFromUrl(server.sourceUrl.replace(Regex("^//"), "https://"))
+                }
 
-                    sName == "dood" -> {
-                        doodExtractor.videosFromUrl(server.sourceUrl)
-                    }
+                sName == "dood" -> {
+                    doodExtractor.videosFromUrl(server.sourceUrl)
+                }
 
-                    sName == "okru" -> {
-                        okruExtractor.videosFromUrl(server.sourceUrl)
-                    }
+                sName == "okru" -> {
+                    okruExtractor.videosFromUrl(server.sourceUrl)
+                }
 
-                    sName == "mp4upload" -> {
-                        mp4uploadExtractor.videosFromUrl(server.sourceUrl, headers)
-                    }
+                sName == "mp4upload" -> {
+                    mp4uploadExtractor.videosFromUrl(server.sourceUrl, headers)
+                }
 
-                    sName == "streamlare" -> {
-                        streamlareExtractor.videosFromUrl(server.sourceUrl)
-                    }
+                sName == "streamlare" -> {
+                    streamlareExtractor.videosFromUrl(server.sourceUrl)
+                }
 
-                    sName == "filemoon" -> {
-                        filemoonExtractor.videosFromUrl(server.sourceUrl, prefix = "Filemoon:")
-                    }
+                sName == "filemoon" -> {
+                    filemoonExtractor.videosFromUrl(server.sourceUrl, prefix = "Filemoon:")
+                }
 
-                    sName == "streamwish" -> {
-                        streamwishExtractor.videosFromUrl(server.sourceUrl, videoNameGen = { "StreamWish:$it" })
-                    }
+                sName == "streamwish" -> {
+                    streamwishExtractor.videosFromUrl(server.sourceUrl, videoNameGen = { "StreamWish:$it" })
+                }
 
-                    else -> emptyList()
-                }.map { v -> Pair(v, server.priority) }
-            },
-        )
-
-        return prioritySort(videoList)
+                else -> emptyList()
+            }.map { v -> Pair(v, server.priority) }
+        }
+            .let(::prioritySort)
     }
 
     // ============================= Utilities ==============================

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -423,7 +423,7 @@ class AllAnime :
 
         if (keyType == null) {
             XOR_MASKS.forEach { mask ->
-                val decrypted = parsedChunks.map { ((it xor mask) and 0xFF).toChar() }.joinToString("")
+                val decrypted = String(CharArray(parsedChunks.size) { i -> ((parsedChunks[i] xor mask) and 0xFF).toChar() })
                 if (decrypted.contains("/clock") || decrypted.contains("http")) return decrypted
             }
             return this

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -46,6 +46,8 @@ import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
+internal const val FALLBACK_PLAYER_DOMAIN = "https://blog.allanime.day"
+
 class AllAnime :
     AnimeHttpSource(),
     ConfigurableAnimeSource {
@@ -342,25 +344,26 @@ class AllAnime :
             }
         }
 
+        // Fetch and cache the endpoint BEFORE the parallel processing
+        val iframeEndpoint = runCatching {
+            client.newCall(GET("${preferences.siteUrl}/getVersion")).awaitSuccess()
+                .parseAs<AllAnimeExtractor.VersionResponse>()
+                .episodeIframeHead
+        }.getOrDefault(FALLBACK_PLAYER_DOMAIN)
+
         videoList.addAll(
             serverList.parallelCatchingFlatMap { server ->
                 val sName = server.sourceName
                 when {
                     sName.startsWith("internal ") -> {
-                        allAnimeExtractor.videoFromUrl(server.sourceUrl, server.sourceName)
+                        allAnimeExtractor.videoFromUrl(server.sourceUrl, server.sourceName, iframeEndpoint)
                     }
 
                     sName.startsWith("player@") -> {
-                        val endPoint = runCatching {
-                            client.newCall(GET("${preferences.siteUrl}/getVersion")).awaitSuccess()
-                                .parseAs<AllAnimeExtractor.VersionResponse>()
-                                .episodeIframeHead
-                        }.getOrDefault("https://blog.allanime.day")
-
                         val videoHeaders = headers.newBuilder().apply {
                             add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
                             add("Host", server.sourceUrl.toHttpUrl().host)
-                            add("Referer", "$endPoint/")
+                            add("Referer", "$iframeEndpoint/")
                         }.build()
 
                         Video(
@@ -419,7 +422,11 @@ class AllAnime :
             else -> this to null
         }
 
-        val parsedChunks = hexPayload.chunked(2).mapNotNull { it.toIntOrNull(16) }
+        val parsedChunks = try {
+            hexPayload.chunked(2).map { it.toInt(16) }
+        } catch (e: NumberFormatException) {
+            return this // Fail fast and return the original string instead of a corrupted decryption
+        }
 
         if (keyType == null) {
             XOR_MASKS.forEach { mask ->

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -46,8 +46,6 @@ import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-internal const val FALLBACK_PLAYER_DOMAIN = "https://blog.allanime.day"
-
 class AllAnime :
     AnimeHttpSource(),
     ConfigurableAnimeSource {
@@ -277,7 +275,7 @@ class AllAnime :
         return POST("$apiUrl/api", headers = postHeaders, body = payload)
     }
 
-    private val allAnimeExtractor by lazy { AllAnimeExtractor(client, headers, preferences.siteUrl) }
+    private val allAnimeExtractor by lazy { AllAnimeExtractor(client, headers) }
     private val gogoStreamExtractor by lazy { GogoStreamExtractor(client) }
     private val doodExtractor by lazy { DoodExtractor(client) }
     private val okruExtractor by lazy { OkruExtractor(client) }
@@ -424,7 +422,7 @@ class AllAnime :
 
         val parsedChunks = try {
             hexPayload.chunked(2).map { it.toInt(16) }
-        } catch (e: NumberFormatException) {
+        } catch (_: NumberFormatException) {
             return this // Fail fast and return the original string instead of a corrupted decryption
         }
 
@@ -563,6 +561,8 @@ class AllAnime :
 
         private const val PREF_DOMAIN_KEY = "preferred_domain"
         private const val PREF_DOMAIN_DEFAULT = "https://api.allanime.day"
+
+        private const val FALLBACK_PLAYER_DOMAIN = "https://blog.allanime.day"
 
         private const val PREF_SERVER_KEY = "preferred_server"
         private val PREF_SERVER_ENTRIES = arrayOf("Site Default") +

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -27,14 +27,11 @@ object AllAnimeFilters {
     private inline fun <reified R> AnimeFilterList.parseCheckbox(
         options: Array<Pair<String, String>>,
     ): String = (this.getFirst<R>() as CheckBoxFilterList).state
-        .mapNotNull { checkbox ->
-            if (checkbox.state) {
-                options.find { it.first == checkbox.name }!!.second
-            } else {
-                null
-            }
-        }.joinToString("\",\"", "[\"", "\"]")
-        .ifBlank { "all" }
+        .filter { it.state }
+        .mapNotNull { checkbox -> options.find { it.first == checkbox.name }?.second }
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString("\",\"", "[\"", "\"]")
+        ?: "all"
 
     class OriginFilter : QueryPartFilter("Origin", AllAnimeFiltersData.ORIGIN)
     class SeasonFilter : QueryPartFilter("Season", AllAnimeFiltersData.SEASONS)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.en.allanime.extractors
 
+import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
@@ -12,6 +13,8 @@ import okhttp3.OkHttpClient
 import java.util.Locale
 
 class AllAnimeExtractor(private val client: OkHttpClient, private val headers: Headers) {
+
+    private val playlistUtils by lazy { PlaylistUtils(client, headers) }
 
     private fun bytesIntoHumanReadable(bytes: Long): String {
         val kilobyte: Long = 1000
@@ -58,8 +61,6 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
                     ),
                 )
             } else if (link.hls == true) {
-                val newClient = OkHttpClient()
-
                 val masterHeaders = headers.newBuilder()
                     .add("Accept", "*/*")
                     .add("Host", link.link.toHttpUrl().host)
@@ -67,63 +68,15 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
                     .add("Referer", "$endPoint/")
                     .build()
 
-                val resp = runCatching {
-                    newClient.newCall(
-                        GET(link.link, headers = masterHeaders),
-                    ).execute()
-                }.getOrNull()
-
-                if (resp != null && resp.code == 200) {
-                    val masterPlaylist = resp.body.string()
-
-                    val audioList = mutableListOf<Track>()
-                    if (masterPlaylist.contains("#EXT-X-MEDIA:TYPE=AUDIO")) {
-                        val audioInfo = masterPlaylist.substringAfter("#EXT-X-MEDIA:TYPE=AUDIO")
-                            .substringBefore("\n")
-                        val language = audioInfo.substringAfter("NAME=\"").substringBefore("\"")
-                        val url = audioInfo.substringAfter("URI=\"").substringBefore("\"")
-                        audioList.add(
-                            Track(url, language),
-                        )
-                    }
-
-                    if (!masterPlaylist.contains("#EXT-X-STREAM-INF:")) {
-                        return if (audioList.isEmpty()) {
-                            listOf(Video(link.link, "$name - ${link.resolutionStr}", link.link, subtitleTracks = subtitles, headers = masterHeaders))
-                        } else {
-                            listOf(Video(link.link, "$name - ${link.resolutionStr}", link.link, subtitleTracks = subtitles, audioTracks = audioList, headers = masterHeaders))
-                        }
-                    }
-
-                    masterPlaylist.substringAfter("#EXT-X-STREAM-INF:").split("#EXT-X-STREAM-INF:")
-                        .forEach {
-                            val bandwidth = if (it.contains("AVERAGE-BANDWIDTH")) {
-                                " " + bytesIntoHumanReadable(it.substringAfter("AVERAGE-BANDWIDTH=").substringBefore(",").toLong())
-                            } else {
-                                ""
-                            }
-
-                            val quality = it.substringAfter("RESOLUTION=").substringAfter("x").substringBefore(",") + "p$bandwidth ($name - ${link.resolutionStr})"
-                            var videoUrl = it.substringAfter("\n").substringBefore("\n")
-
-                            if (!videoUrl.startsWith("http")) {
-                                videoUrl = resp.request.url.toString().substringBeforeLast("/") + "/$videoUrl"
-                            }
-
-                            val plHeaders = headers.newBuilder()
-                                .add("Accept", "*/*")
-                                .add("Host", videoUrl.toHttpUrl().host)
-                                .add("Origin", endPoint)
-                                .add("Referer", "$endPoint/")
-                                .build()
-
-                            if (audioList.isEmpty()) {
-                                videoList.add(Video(videoUrl, quality, videoUrl, subtitleTracks = subtitles, headers = plHeaders))
-                            } else {
-                                videoList.add(Video(videoUrl, quality, videoUrl, subtitleTracks = subtitles, audioTracks = audioList, headers = plHeaders))
-                            }
-                        }
-                }
+                videoList.addAll(
+                    playlistUtils.extractFromHls(
+                        link.link,
+                        masterHeaders = masterHeaders,
+                        videoHeaders = masterHeaders,
+                        videoNameGen = { quality -> "$quality ($name - ${link.resolutionStr})" },
+                        subtitleList = subtitles,
+                    ),
+                )
             } else if (link.crIframe == true) {
                 link.portData!!.streams.forEach {
                     if (it.format == "adaptive_dash") {

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -43,19 +43,10 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
         val linkJson = resp.parseAs<VideoLink>()
 
         for (link in linkJson.links) {
-            val subtitles = mutableListOf<Track>()
-            if (!link.subtitles.isNullOrEmpty()) {
-                subtitles.addAll(
-                    link.subtitles.map { sub ->
-                        val label = if (sub.label != null) {
-                            " - ${sub.label}"
-                        } else {
-                            ""
-                        }
-                        Track(sub.src, Locale(sub.lang).displayLanguage + label)
-                    },
-                )
-            }
+            val subtitles = link.subtitles?.map { sub ->
+                val label = sub.label?.let { " - $it" } ?: ""
+                Track(sub.src, Locale(sub.lang).displayLanguage + label)
+            } ?: emptyList()
 
             if (link.mp4 == true) {
                 videoList.add(

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -89,38 +89,24 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
                             ),
                         )
                     } else if (it.format == "adaptive_hls") {
-                        val resp = runCatching {
-                            client.newCall(
-                                GET(it.url, headers = Headers.headersOf("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:101.0) Gecko/20100101 Firefox/101.0")),
-                            ).execute()
-                        }.getOrNull()
-
-                        if (resp != null && resp.code == 200) {
-                            val masterPlaylist = resp.body.string()
-                            masterPlaylist.substringAfter("#EXT-X-STREAM-INF:").split("#EXT-X-STREAM-INF:")
-                                .forEach { t ->
-                                    val quality = t.substringAfter("RESOLUTION=").substringAfter("x").substringBefore(",") + "p (AC - HLS${if (it.hardsub_lang.isEmpty()) "" else " - Hardsub: ${it.hardsub_lang}"})"
-                                    val videoUrl = t.substringAfter("\n").substringBefore("\n")
-
-                                    videoList.add(Video(videoUrl, quality, videoUrl, subtitleTracks = subtitles))
-                                }
-                        }
+                        videoList.addAll(
+                            playlistUtils.extractFromHls(
+                                it.url,
+                                masterHeaders = headers,
+                                videoHeaders = headers,
+                                videoNameGen = { quality -> "$quality (AC - HLS${if (it.hardsub_lang.isEmpty()) "" else " - Hardsub: ${it.hardsub_lang}"})" },
+                                subtitleList = subtitles,
+                            ),
+                        )
                     }
                 }
             } else if (link.dash == true) {
                 val audioList = link.rawUrls?.audios?.map {
                     Track(it.url, bytesIntoHumanReadable(it.bandwidth))
-                }
-                val videos = link.rawUrls?.vids?.map {
-                    if (audioList == null) {
-                        Video(it.url, "$name - ${it.height} ${bytesIntoHumanReadable(it.bandwidth)}", it.url, subtitleTracks = subtitles)
-                    } else {
-                        Video(it.url, "$name - ${it.height} ${bytesIntoHumanReadable(it.bandwidth)}", it.url, audioTracks = audioList, subtitleTracks = subtitles)
-                    }
-                }
-                if (videos != null) {
-                    videoList.addAll(videos)
-                }
+                } ?: emptyList()
+                link.rawUrls?.vids?.map {
+                    Video(it.url, "$name - ${it.height} ${bytesIntoHumanReadable(it.bandwidth)}", it.url, audioTracks = audioList, subtitleTracks = subtitles)
+                }?.let(videoList::addAll)
             }
         }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -38,9 +38,11 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
     fun videoFromUrl(url: String, name: String): List<Video> {
         val videoList = mutableListOf<Video>()
 
-        val endPoint = json.decodeFromString<VersionResponse>(
-            client.newCall(GET("$siteUrl/getVersion")).execute().body.string(),
-        ).episodeIframeHead
+        val endPoint = runCatching {
+            json.decodeFromString<VersionResponse>(
+                client.newCall(GET("$siteUrl/getVersion")).execute().body.string(),
+            ).episodeIframeHead
+        }.getOrNull() ?: "https://blog.allanime.day"
 
         val resp = client.newCall(
             GET(endPoint + url.replace("/clock?", "/clock.json?")),

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -3,17 +3,15 @@ package eu.kanade.tachiyomi.animeextension.en.allanime.extractors
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import uy.kohesive.injekt.injectLazy
 import java.util.Locale
 
-class AllAnimeExtractor(private val client: OkHttpClient, private val headers: Headers, private val siteUrl: String) {
-
-    private val json: Json by injectLazy()
+class AllAnimeExtractor(private val client: OkHttpClient, private val headers: Headers) {
 
     private fun bytesIntoHumanReadable(bytes: Long): String {
         val kilobyte: Long = 1000
@@ -35,19 +33,14 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
         }
     }
 
-    fun videoFromUrl(url: String, name: String, endPoint: String): List<Video> {
+    suspend fun videoFromUrl(url: String, name: String, endPoint: String): List<Video> {
         val videoList = mutableListOf<Video>()
 
         val resp = client.newCall(
             GET(endPoint + url.replace("/clock?", "/clock.json?")),
-        ).execute()
+        ).awaitSuccess()
 
-        if (resp.code != 200) {
-            return emptyList()
-        }
-
-        val body = resp.body.string()
-        val linkJson = json.decodeFromString<VideoLink>(body)
+        val linkJson = resp.parseAs<VideoLink>()
 
         for (link in linkJson.links) {
             val subtitles = mutableListOf<Track>()
@@ -163,7 +156,7 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
                             masterPlaylist.substringAfter("#EXT-X-STREAM-INF:").split("#EXT-X-STREAM-INF:")
                                 .forEach { t ->
                                     val quality = t.substringAfter("RESOLUTION=").substringAfter("x").substringBefore(",") + "p (AC - HLS${if (it.hardsub_lang.isEmpty()) "" else " - Hardsub: ${it.hardsub_lang}"})"
-                                    var videoUrl = t.substringAfter("\n").substringBefore("\n")
+                                    val videoUrl = t.substringAfter("\n").substringBefore("\n")
 
                                     videoList.add(Video(videoUrl, quality, videoUrl, subtitleTracks = subtitles))
                                 }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
@@ -37,80 +38,88 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
     }
 
     suspend fun videoFromUrl(url: String, name: String, endPoint: String): List<Video> {
-        val videoList = mutableListOf<Video>()
-
-        val resp = client.newCall(
+        val linkJson = client.newCall(
             GET(endPoint + url.replace("/clock?", "/clock.json?")),
         ).awaitSuccess()
+            .parseAs<VideoLink>()
 
-        val linkJson = resp.parseAs<VideoLink>()
-
-        for (link in linkJson.links) {
+        return linkJson.links.parallelCatchingFlatMap { link ->
             val subtitles = link.subtitles?.map { sub ->
                 val label = sub.label?.let { " - $it" } ?: ""
                 Track(sub.src, Locale(sub.lang).displayLanguage + label)
-            } ?: emptyList()
+            }.orEmpty()
 
-            if (link.mp4 == true) {
-                videoList.add(
+            when {
+                link.mp4 == true -> {
                     Video(
                         link.link,
                         "Original ($name - ${link.resolutionStr})",
                         link.link,
                         subtitleTracks = subtitles,
-                    ),
-                )
-            } else if (link.hls == true) {
-                val masterHeaders = headers.newBuilder()
-                    .add("Accept", "*/*")
-                    .add("Host", link.link.toHttpUrl().host)
-                    .add("Origin", endPoint)
-                    .add("Referer", "$endPoint/")
-                    .build()
+                    ).let(::listOf)
+                }
 
-                videoList.addAll(
+                link.hls == true -> {
+                    val masterHeaders = headers.newBuilder()
+                        .add("Accept", "*/*")
+                        .add("Host", link.link.toHttpUrl().host)
+                        .add("Origin", endPoint)
+                        .add("Referer", "$endPoint/")
+                        .build()
+
                     playlistUtils.extractFromHls(
                         link.link,
                         masterHeaders = masterHeaders,
                         videoHeaders = masterHeaders,
                         videoNameGen = { quality -> "$quality ($name - ${link.resolutionStr})" },
                         subtitleList = subtitles,
-                    ),
-                )
-            } else if (link.crIframe == true) {
-                link.portData!!.streams.forEach {
-                    if (it.format == "adaptive_dash") {
-                        videoList.add(
-                            Video(
-                                it.url,
-                                "Original (AC - Dash${if (it.hardsub_lang.isEmpty()) "" else " - Hardsub: ${it.hardsub_lang}"})",
-                                it.url,
-                                subtitleTracks = subtitles,
-                            ),
-                        )
-                    } else if (it.format == "adaptive_hls") {
-                        videoList.addAll(
-                            playlistUtils.extractFromHls(
-                                it.url,
-                                masterHeaders = headers,
-                                videoHeaders = headers,
-                                videoNameGen = { quality -> "$quality (AC - HLS${if (it.hardsub_lang.isEmpty()) "" else " - Hardsub: ${it.hardsub_lang}"})" },
-                                subtitleList = subtitles,
-                            ),
-                        )
-                    }
+                    )
                 }
-            } else if (link.dash == true) {
-                val audioList = link.rawUrls?.audios?.map {
-                    Track(it.url, bytesIntoHumanReadable(it.bandwidth))
-                } ?: emptyList()
-                link.rawUrls?.vids?.map {
-                    Video(it.url, "$name - ${it.height} ${bytesIntoHumanReadable(it.bandwidth)}", it.url, audioTracks = audioList, subtitleTracks = subtitles)
-                }?.let(videoList::addAll)
+
+                link.crIframe == true -> {
+                    link.portData?.streams?.parallelCatchingFlatMap {
+                        when (it.format) {
+                            "adaptive_dash" ->
+                                Video(
+                                    it.url,
+                                    "Original (AC - Dash${if (it.hardsub_lang.isEmpty()) "" else " - Hardsub: ${it.hardsub_lang}"})",
+                                    it.url,
+                                    subtitleTracks = subtitles,
+                                ).let(::listOf)
+
+                            "adaptive_hls" ->
+                                playlistUtils.extractFromHls(
+                                    it.url,
+                                    masterHeaders = headers,
+                                    videoHeaders = headers,
+                                    videoNameGen = { quality -> "$quality (AC - HLS${if (it.hardsub_lang.isEmpty()) "" else " - Hardsub: ${it.hardsub_lang}"})" },
+                                    subtitleList = subtitles,
+                                )
+
+                            else -> emptyList()
+                        }
+                    }.orEmpty()
+                }
+
+                link.dash == true -> {
+                    val audioList = link.rawUrls?.audios?.map {
+                        Track(it.url, bytesIntoHumanReadable(it.bandwidth))
+                    }.orEmpty()
+
+                    link.rawUrls?.vids?.map {
+                        Video(
+                            it.url,
+                            "$name - ${it.height} ${bytesIntoHumanReadable(it.bandwidth)}",
+                            it.url,
+                            audioTracks = audioList,
+                            subtitleTracks = subtitles,
+                        )
+                    }.orEmpty()
+                }
+
+                else -> emptyList()
             }
         }
-
-        return videoList
     }
 
     @Serializable

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -35,14 +35,8 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
         }
     }
 
-    fun videoFromUrl(url: String, name: String): List<Video> {
+    fun videoFromUrl(url: String, name: String, endPoint: String): List<Video> {
         val videoList = mutableListOf<Video>()
-
-        val endPoint = runCatching {
-            json.decodeFromString<VersionResponse>(
-                client.newCall(GET("$siteUrl/getVersion")).execute().body.string(),
-            ).episodeIframeHead
-        }.getOrNull() ?: "https://blog.allanime.day"
 
         val resp = client.newCall(
             GET(endPoint + url.replace("/clock?", "/clock.json?")),


### PR DESCRIPTION
Fixed the search which last PR broke, and fixed new playback issues

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Fix AllAnime playback and search issues and harden the extension against upstream changes.

Bug Fixes:
- Resolve AllAnime playback failures by correctly resolving the episode iframe endpoint and handling unknown XOR keys safely.
- Fix AllAnime search filters returning invalid or empty parameters by ensuring unchecked filters fall back to an "all" value.

Enhancements:
- Introduce a fallback player domain and reuse a single cached iframe endpoint across video extraction to improve resilience and efficiency.
- Make decryption more robust by validating hex payloads, failing safely on malformed data, and heuristically handling responses without a known key type.

Build:
- Bump AllAnime extension version code to 50.