### PR TITLE
Animetsu [Multi]: Update Proxy URL

### DIFF
--- a/src/all/animetsu/build.gradle
+++ b/src/all/animetsu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animetsu'
     extClass = '.Animetsu'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -43,7 +43,7 @@ class Animetsu :
     private val apiUrl: String
         get() = "$baseUrl/v2/api"
 
-    private val proxyUrl = "https://mega-cloud.top/proxy"
+    private val proxyUrl = "https://swiftstream.top/proxy"
 
     override val lang = "all"
 


### PR DESCRIPTION
Changed to use new video proxy URL.
Bump to version 2.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the Animetsu extension to use a new proxy endpoint and bump its extension version code.

Bug Fixes:
- Switch Animetsu video proxy requests to the new proxy URL to restore proper playback.

Build:
- Increment Animetsu extension extVersionCode from 1 to 2.