### PR TITLE
Animetsu [Multi]: Add Dio Server & Update Popular

### DIFF
--- a/src/all/animetsu/build.gradle
+++ b/src/all/animetsu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animetsu'
     extClass = '.Animetsu'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -35,7 +35,7 @@ class Animetsu :
 
     override val name = "Animetsu"
 
-    private val preferences: SharedPreferences by getPreferencesLazy()
+    private val preferences: SharedPreferences by getPreferencesLazy { clearOldPrefs() }
 
     override val baseUrl: String
         get() = preferences.getString(PREF_DOMAIN_KEY, DOMAIN_VALUES.first()) ?: DOMAIN_VALUES.first()
@@ -390,6 +390,19 @@ class Animetsu :
     }
 
     // ============================= Utilities ==============================
+
+    private fun SharedPreferences.clearOldPrefs() {
+        val hostExclusion = getStringSet(PREF_HOSTER_EXCLUDE_KEY, PREF_HOSTER_EXCLUDE_DEFAULT)!!
+        val invalidHosters = hostExclusion.any { it !in SERVER_VALUES }
+        val invalidServer = getString(PREF_PREFERRED_SERVER_KEY, PREF_PREFERRED_SERVER_DEFAULT) !in PREF_PREFERRED_SERVER_VALUES
+
+        if (invalidHosters || invalidServer) {
+            edit().also { editor ->
+                if (invalidHosters) editor.putStringSet(PREF_HOSTER_EXCLUDE_KEY, hostExclusion.filter { it in SERVER_VALUES }.toSet())
+                if (invalidServer) editor.putString(PREF_PREFERRED_SERVER_KEY, PREF_PREFERRED_SERVER_DEFAULT)
+            }.apply()
+        }
+    }
 
     companion object {
         private const val PREF_DOMAIN_KEY = "preferred_domain"

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -55,8 +55,8 @@ class Animetsu :
     private val hideAdult: Boolean
         get() = preferences.getBoolean(PREF_HIDE_ADULT_KEY, PREF_HIDE_ADULT_DEFAULT)
 
-    private val enabledServers: Set<String>
-        get() = preferences.getStringSet(PREF_SERVER_KEY, PREF_SERVER_DEFAULT) ?: PREF_SERVER_DEFAULT
+    private val excludedHosts: Set<String>
+        get() = preferences.getStringSet(PREF_HOSTER_EXCLUDE_KEY, PREF_HOSTER_EXCLUDE_DEFAULT) ?: PREF_HOSTER_EXCLUDE_DEFAULT
 
     private val preferredServer: String
         get() = preferences.getString(PREF_PREFERRED_SERVER_KEY, PREF_PREFERRED_SERVER_DEFAULT) ?: PREF_PREFERRED_SERVER_DEFAULT
@@ -226,7 +226,7 @@ class Animetsu :
         val allServers = serverResponse.parseAs<List<AnimetsuServerDto>>()
 
         val servers = allServers
-            .filter { server -> server.id in enabledServers }
+            .filter { server -> server.id !in excludedHosts }
             .sortedByDescending { server -> server.id == preferredServer }
 
         val sortedAudioTypes = enabledAudioTypes
@@ -367,12 +367,12 @@ class Animetsu :
         )
 
         screen.addSetPreference(
-            key = PREF_SERVER_KEY,
+            key = PREF_HOSTER_EXCLUDE_KEY,
             title = "Enable/Disable Hosts",
-            summary = "Select which video hosts to show in the episode list",
+            summary = "Choose which hosts you want to exclude",
             entries = SERVER_ENTRIES,
             entryValues = SERVER_VALUES,
-            default = PREF_SERVER_DEFAULT,
+            default = PREF_HOSTER_EXCLUDE_DEFAULT,
         )
 
         screen.addSetPreference(
@@ -409,10 +409,11 @@ class Animetsu :
         private val PREF_PREFERRED_SERVER_ENTRIES = listOf("None", "Pahe - Fast, Multi Quality", "Kite - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kiss - Multi Language")
         private val PREF_PREFERRED_SERVER_VALUES = listOf("none", "pahe", "kite", "dio", "meg", "kiss")
 
-        private const val PREF_SERVER_KEY = "enabled_servers"
-        private val PREF_SERVER_DEFAULT = setOf("pahe", "kite", "dio", "meg", "kiss")
+        private const val PREF_HOSTER_EXCLUDE_KEY = "hoster_exclusion"
+        private val PREF_HOSTER_EXCLUDE_DEFAULT = emptySet<String>()
         private val SERVER_ENTRIES = listOf("Pahe - Fast, Multi Quality", "Kite - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kiss - Multi Language")
         private val SERVER_VALUES = listOf("pahe", "kite", "dio", "meg", "kiss")
+
         private const val PREF_PREFERRED_AUDIO_TYPE_KEY = "preferred_audio_type"
         private const val PREF_PREFERRED_AUDIO_TYPE_DEFAULT = "none"
         private val PREF_PREFERRED_AUDIO_TYPE_ENTRIES = listOf("None", "Sub", "Dub")

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -247,12 +247,9 @@ class Animetsu :
                 }.orEmpty()
 
                 // Following order: AnimePahe proxy server, Anikoto proxy server, Unknown proxy server, AnimeGG proxy server and KickAssAnime proxy server
-                val subLabel = when {
-                    server.id.equals("pahe", ignoreCase = true) -> " [Hard Subs]"
-                    server.id.equals("kite", ignoreCase = true) -> " [Soft Subs]"
-                    server.id.equals("dio", ignoreCase = true) -> " [Hard Subs]"
-                    server.id.equals("meg", ignoreCase = true) -> " [Hard Subs]"
-                    server.id.equals("kiss", ignoreCase = true) -> " [Soft Subs]"
+                val subLabel = when (server.id.lowercase()) {
+                    "pahe", "dio", "meg" -> " [Hard Subs]"
+                    "kite", "kiss" -> " [Soft Subs]"
                     else -> ""
                 }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -250,6 +250,7 @@ class Animetsu :
                 val subLabel = when {
                     server.id.equals("pahe", ignoreCase = true) -> " [Hard Subs]"
                     server.id.equals("kite", ignoreCase = true) -> " [Soft Subs]"
+                    server.id.equals("dio", ignoreCase = true) -> " [Hard Subs]"
                     server.id.equals("meg", ignoreCase = true) -> " [Hard Subs]"
                     server.id.equals("kiss", ignoreCase = true) -> " [Soft Subs]"
                     else -> ""
@@ -405,13 +406,13 @@ class Animetsu :
 
         private const val PREF_PREFERRED_SERVER_KEY = "preferred_server"
         private const val PREF_PREFERRED_SERVER_DEFAULT = "none"
-        private val PREF_PREFERRED_SERVER_ENTRIES = listOf("None", "Pahe - Fast, Multi Quality", "Kite - Multi Quality", "Meg - Multi Quality", "Kiss - Multi Language")
-        private val PREF_PREFERRED_SERVER_VALUES = listOf("none", "pahe", "kite", "meg", "kiss")
+        private val PREF_PREFERRED_SERVER_ENTRIES = listOf("None", "Pahe - Fast, Multi Quality", "Kite - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kiss - Multi Language")
+        private val PREF_PREFERRED_SERVER_VALUES = listOf("none", "pahe", "kite", "dio", "meg", "kiss")
 
         private const val PREF_SERVER_KEY = "enabled_servers"
-        private val PREF_SERVER_DEFAULT = setOf("pahe", "kite", "meg", "kiss")
-        private val SERVER_ENTRIES = listOf("Pahe - Fast, Multi Quality", "Kite - Multi Quality", "Meg - Multi Quality", "Kiss - Multi Language")
-        private val SERVER_VALUES = listOf("pahe", "kite", "meg", "kiss")
+        private val PREF_SERVER_DEFAULT = setOf("pahe", "kite", "dio", "meg", "kiss")
+        private val SERVER_ENTRIES = listOf("Pahe - Fast, Multi Quality", "Kite - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kiss - Multi Language")
+        private val SERVER_VALUES = listOf("pahe", "kite", "dio", "meg", "kiss")
         private const val PREF_PREFERRED_AUDIO_TYPE_KEY = "preferred_audio_type"
         private const val PREF_PREFERRED_AUDIO_TYPE_DEFAULT = "none"
         private val PREF_PREFERRED_AUDIO_TYPE_ENTRIES = listOf("None", "Sub", "Dub")

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -88,7 +88,7 @@ class Animetsu :
     }
 
     // ============================== Popular ===============================
-    override fun popularAnimeRequest(page: Int): Request = GET("$apiUrl/anime/search/?sort=popularity&page=$page&per_page=35", apiHeaders())
+    override fun popularAnimeRequest(page: Int): Request = GET("$apiUrl/anime/search/?sort=trending&page=$page&per_page=35", apiHeaders())
 
     override fun popularAnimeParse(response: Response) = searchAnimeParse(response)
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -246,7 +246,7 @@ class Animetsu :
                     Track(sub.url, sub.lang ?: "Unknown")
                 }.orEmpty()
 
-                // Following order: AnimePahe proxy server, Anikoto proxy server, AnimeGG proxy server and KickAssAnime proxy server
+                // Following order: AnimePahe proxy server, Anikoto proxy server, Unknown proxy server, AnimeGG proxy server and KickAssAnime proxy server
                 val subLabel = when {
                     server.id.equals("pahe", ignoreCase = true) -> " [Hard Subs]"
                     server.id.equals("kite", ignoreCase = true) -> " [Soft Subs]"


### PR DESCRIPTION
Adds Dio as new Hard Sub server.
Bump to version 3.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add support for the Dio streaming server as a hard sub option in Animetsu and update related server preference settings.

New Features:
- Introduce Dio as a new hard sub streaming server option in Animetsu.

Enhancements:
- Include Dio in preferred and enabled server preference lists with appropriate labels.