### PR TITLE
AllAnime [EN]: Update videoListRequest method  to use GET persisted query instead of POST payload

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 50
+    extVersionCode = 51
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 51
+    extVersionCode = 50
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -29,16 +29,17 @@ import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.toJsonString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
 import java.security.MessageDigest
@@ -260,19 +261,47 @@ class AllAnime :
     // ============================ Video Links =============================
 
     override fun videoListRequest(episode: SEpisode): Request {
-        val payload = episode.url
-            .toRequestBody("application/json; charset=utf-8".toMediaType())
+        val episodeData = Json.parseToJsonElement(episode.url).jsonObject
+        val variablesObj = episodeData["variables"]!!.jsonObject
 
-        val postHeaders = headers.newBuilder().apply {
+        val showId = variablesObj["showId"]?.jsonPrimitive?.content ?: ""
+        val episodeString = variablesObj["episodeString"]?.jsonPrimitive?.content ?: ""
+        val translationType = variablesObj["translationType"]?.jsonPrimitive?.content ?: "sub"
+
+        val variables = buildJsonObject {
+            put("showId", showId)
+            put("translationType", translationType)
+            put("episodeString", episodeString)
+        }.toString()
+
+        val extensions = buildJsonObject {
+            putJsonObject("persistedQuery") {
+                put("version", 1)
+                put(
+                    "sha256Hash",
+                    "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec",
+                )
+            }
+        }.toString()
+
+        val url = apiUrl.toHttpUrl()
+            .newBuilder()
+            .addPathSegment("api")
+            .addQueryParameter("variables", variables)
+            .addQueryParameter("extensions", extensions)
+            .build()
+
+        val getHeaders = headers.newBuilder().apply {
             add("Accept", "*/*")
-            add("Content-Length", payload.contentLength().toString())
-            add("Content-Type", payload.contentType().toString())
-            add("Host", apiUrl.toHttpUrl().host)
-            add("Origin", GRAPHQL_ORIGIN)
-            add("Referer", "$GRAPHQL_ORIGIN/")
+            add("Origin", PREF_SITE_DOMAIN_DEFAULT)
+            add("Referer", "${PREF_SITE_DOMAIN_DEFAULT}/")
+            set(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
+            )
         }.build()
 
-        return POST("$apiUrl/api", headers = postHeaders, body = payload)
+        return GET(url.toString(), headers = getHeaders)
     }
 
     private val allAnimeExtractor by lazy { AllAnimeExtractor(client, headers) }
@@ -358,7 +387,16 @@ class AllAnime :
                     val videoHeaders = headers.newBuilder().apply {
                         add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
                         add("Host", server.sourceUrl.toHttpUrl().host)
-                        add("Referer", "$iframeEndpoint/")
+
+                        val playerName = server.sourceName.substringAfter("player@")
+                        add(
+                            "Referer",
+                            if (playerName.contains("yt-mp4", ignoreCase = true)) {
+                                "https://allanime.day/"   /// only for yt-mp4 source
+                            } else {
+                                "$iframeEndpoint/"
+                            }
+                        )
                     }.build()
 
                     Video(

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -252,7 +252,6 @@ class AllAnime :
                         put("translationType", subPref)
                         put("episodeString", ep)
                     }
-                    put("query", STREAMS_QUERY)
                 }.toJsonString()
             }
         }
@@ -279,7 +278,7 @@ class AllAnime :
                 put("version", 1)
                 put(
                     "sha256Hash",
-                    "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec",
+                    STREAMS_QUERY,
                 )
             }
         }.toString()
@@ -295,10 +294,6 @@ class AllAnime :
             add("Accept", "*/*")
             add("Origin", PREF_SITE_DOMAIN_DEFAULT)
             add("Referer", "${PREF_SITE_DOMAIN_DEFAULT}/")
-            set(
-                "User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
-            )
         }.build()
 
         return GET(url.toString(), headers = getHeaders)
@@ -392,10 +387,10 @@ class AllAnime :
                         add(
                             "Referer",
                             if (playerName.contains("yt-mp4", ignoreCase = true)) {
-                                "https://allanime.day/"   /// only for yt-mp4 source
+                                "https://allanime.day/" // only for yt-mp4 playback
                             } else {
                                 "$iframeEndpoint/"
-                            }
+                            },
                         )
                     }.build()
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -63,6 +63,11 @@ class AllAnime :
 
     private val preferences by getPreferencesLazy()
 
+    // ============================== Headers ===============================
+    override fun headersBuilder() = super.headersBuilder()
+        .add("Origin", GRAPHQL_ORIGIN)
+        .add("Referer", "$GRAPHQL_ORIGIN/")
+
     // ============================== Popular ===============================
 
     override fun popularAnimeRequest(page: Int): Request {
@@ -292,8 +297,6 @@ class AllAnime :
 
         val getHeaders = headers.newBuilder().apply {
             add("Accept", "*/*")
-            add("Origin", PREF_SITE_DOMAIN_DEFAULT)
-            add("Referer", "${PREF_SITE_DOMAIN_DEFAULT}/")
         }.build()
 
         return GET(url.toString(), headers = getHeaders)
@@ -564,7 +567,7 @@ class AllAnime :
 
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API
-        private const val GRAPHQL_ORIGIN = "https://youtu-chan.com"
+        private const val GRAPHQL_ORIGIN = "https://allmanga.to"
         private val INTERAL_HOSTER_NAMES = arrayOf(
             "Default", "Ac", "Ak", "Kir", "Rab", "Luf-mp4",
             "Si-Hls", "S-mp4", "Ac-Hls", "Uv-mp4", "Pn-Hls",

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
@@ -98,20 +98,5 @@ val EPISODES_QUERY = buildQuery {
     """
 }
 
-val STREAMS_QUERY = buildQuery {
-    """
-        query(
-            %showId: String!,
-            %translationType: VaildTranslationTypeEnumType!,
-            %episodeString: String!
-        ) {
-            episode(
-                showId: %showId
-                translationType: %translationType
-                episodeString: %episodeString
-            ) {
-                sourceUrls
-            }
-        }
-    """
-}
+// Persisted Query ID other one returns 403
+const val STREAMS_QUERY = "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---
Closes #253 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Switch AllAnime video fetching to use a GET GraphQL persisted query and adjust playback headers for compatibility with yt-mp4 sources.

Bug Fixes:
- Fix AllAnime video list retrieval by migrating from POST payloads to GET-based persisted GraphQL queries.
- Correct Referer handling for yt-mp4 video sources to restore playback.
- Update AllAnime extension version code to trigger client updates.