### PR TITLE
AllAnime [EN]: Fix video request

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 50
+    extVersionCode = 51
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 50
+    extVersionCode = 52
 }
 
 apply from: "$rootDir/common.gradle"
@@ -15,4 +15,5 @@ dependencies {
     implementation(project(':lib:gogostreamextractor'))
     implementation(project(':lib:filemoonextractor'))
     implementation(project(':lib:streamwishextractor'))
+    implementation(project(':lib:cloudflareinterceptor'))
 }

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -15,5 +15,4 @@ dependencies {
     implementation(project(':lib:gogostreamextractor'))
     implementation(project(':lib:filemoonextractor'))
     implementation(project(':lib:streamwishextractor'))
-    implementation(project(':lib:cloudflareinterceptor'))
 }

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 52
+    extVersionCode = 51
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -39,7 +39,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
-import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -75,9 +74,9 @@ class AllAnime :
         .addInterceptor(CloudflareInterceptor(network.cloudflareClient))
         .build()
 
-    override fun headersBuilder() = Headers.Builder()
-        .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0")
-        .add("Referer", "$baseUrl/")
+    override fun headersBuilder() = super.headersBuilder()
+        .set("User-Agent", USER_AGENT)
+        .set("Referer", "$baseUrl/")
 
     // ============================== Popular ===============================
 
@@ -647,6 +646,8 @@ class AllAnime :
         private val XOR_MASKS = XOR_KEYS.map { key ->
             key.fold(0) { mask, ch -> mask xor ch.code }
         }.toIntArray()
+
+        private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
     }
 
     // ============================== Settings ==============================

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -29,16 +29,17 @@ import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.toJsonString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
 import java.security.MessageDigest
@@ -260,19 +261,47 @@ class AllAnime :
     // ============================ Video Links =============================
 
     override fun videoListRequest(episode: SEpisode): Request {
-        val payload = episode.url
-            .toRequestBody("application/json; charset=utf-8".toMediaType())
+        val episodeData = Json.parseToJsonElement(episode.url).jsonObject
+        val variablesObj = episodeData["variables"]!!.jsonObject
 
-        val postHeaders = headers.newBuilder().apply {
+        val showId = variablesObj["showId"]?.jsonPrimitive?.content ?: ""
+        val episodeString = variablesObj["episodeString"]?.jsonPrimitive?.content ?: ""
+        val translationType = variablesObj["translationType"]?.jsonPrimitive?.content ?: "sub"
+
+        val variables = buildJsonObject {
+            put("showId", showId)
+            put("translationType", translationType)
+            put("episodeString", episodeString)
+        }.toString()
+
+        val extensions = buildJsonObject {
+            putJsonObject("persistedQuery") {
+                put("version", 1)
+                put(
+                    "sha256Hash",
+                    "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec",
+                )
+            }
+        }.toString()
+
+        val url = apiUrl.toHttpUrl()
+            .newBuilder()
+            .addPathSegment("api")
+            .addQueryParameter("variables", variables)
+            .addQueryParameter("extensions", extensions)
+            .build()
+
+        val getHeaders = headers.newBuilder().apply {
             add("Accept", "*/*")
-            add("Content-Length", payload.contentLength().toString())
-            add("Content-Type", payload.contentType().toString())
-            add("Host", apiUrl.toHttpUrl().host)
-            add("Origin", GRAPHQL_ORIGIN)
-            add("Referer", "$GRAPHQL_ORIGIN/")
+            add("Origin", PREF_SITE_DOMAIN_DEFAULT)
+            add("Referer", "${PREF_SITE_DOMAIN_DEFAULT}/")
+            set(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
+            )
         }.build()
 
-        return POST("$apiUrl/api", headers = postHeaders, body = payload)
+        return GET(url.toString(), headers = getHeaders)
     }
 
     private val allAnimeExtractor by lazy { AllAnimeExtractor(client, headers) }
@@ -358,7 +387,16 @@ class AllAnime :
                     val videoHeaders = headers.newBuilder().apply {
                         add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
                         add("Host", server.sourceUrl.toHttpUrl().host)
-                        add("Referer", "$iframeEndpoint/")
+
+                        val playerName = server.sourceName.substringAfter("player@")
+                        add(
+                            "Referer",
+                            if (playerName.contains("yt-mp4", ignoreCase = true)) {
+                                "https://allanime.day/"   /// only for yt-mp4 source
+                            } else {
+                                "$iframeEndpoint/"
+                            }
+                        )
                     }.build()
 
                     Video(

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -252,7 +252,6 @@ class AllAnime :
                         put("translationType", subPref)
                         put("episodeString", ep)
                     }
-                    put("query", STREAMS_QUERY)
                 }.toJsonString()
             }
         }
@@ -279,7 +278,7 @@ class AllAnime :
                 put("version", 1)
                 put(
                     "sha256Hash",
-                    "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec",
+                    STREAMS_QUERY,
                 )
             }
         }.toString()
@@ -295,10 +294,6 @@ class AllAnime :
             add("Accept", "*/*")
             add("Origin", PREF_SITE_DOMAIN_DEFAULT)
             add("Referer", "${PREF_SITE_DOMAIN_DEFAULT}/")
-            set(
-                "User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0",
-            )
         }.build()
 
         return GET(url.toString(), headers = getHeaders)
@@ -392,10 +387,10 @@ class AllAnime :
                         add(
                             "Referer",
                             if (playerName.contains("yt-mp4", ignoreCase = true)) {
-                                "https://allanime.day/"   /// only for yt-mp4 source
+                                "https://allanime.day/" // only for yt-mp4 playback
                             } else {
                                 "$iframeEndpoint/"
-                            }
+                            },
                         )
                     }.build()
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -5,6 +5,7 @@ import android.util.Base64
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
+import aniyomi.lib.cloudflareinterceptor.CloudflareInterceptor
 import aniyomi.lib.doodextractor.DoodExtractor
 import aniyomi.lib.filemoonextractor.FilemoonExtractor
 import aniyomi.lib.gogostreamextractor.GogoStreamExtractor
@@ -29,18 +30,25 @@ import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.toJsonString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
+import uy.kohesive.injekt.api.get
+import uy.kohesive.injekt.injectLazy
 import java.security.MessageDigest
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
@@ -61,6 +69,15 @@ class AllAnime :
     override val supportsLatest = true
 
     private val preferences by getPreferencesLazy()
+    private val json: Json by injectLazy()
+
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .addInterceptor(CloudflareInterceptor(network.cloudflareClient))
+        .build()
+
+    override fun headersBuilder() = Headers.Builder()
+        .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0")
+        .add("Referer", "$baseUrl/")
 
     // ============================== Popular ===============================
 
@@ -260,19 +277,22 @@ class AllAnime :
     // ============================ Video Links =============================
 
     override fun videoListRequest(episode: SEpisode): Request {
-        val payload = episode.url
-            .toRequestBody("application/json; charset=utf-8".toMediaType())
+        val variables = episode.url.parseAs<JsonObject>()["variables"]!!.jsonObject
 
-        val postHeaders = headers.newBuilder().apply {
-            add("Accept", "*/*")
-            add("Content-Length", payload.contentLength().toString())
-            add("Content-Type", payload.contentType().toString())
-            add("Host", apiUrl.toHttpUrl().host)
-            add("Origin", GRAPHQL_ORIGIN)
-            add("Referer", "$GRAPHQL_ORIGIN/")
-        }.build()
+        val extensions = buildJsonObject {
+            putJsonObject("persistedQuery") {
+                put("version", 1)
+                put("sha256Hash", STREAM_HASH)
+            }
+        }
 
-        return POST("$apiUrl/api", headers = postHeaders, body = payload)
+        val url = apiUrl.toHttpUrl().newBuilder().apply {
+            addPathSegment("api")
+            addQueryParameter("variables", variables.toJsonString())
+            addQueryParameter("extensions", extensions.toJsonString())
+        }.build().toString()
+
+        return GET(url, headers)
     }
 
     private val allAnimeExtractor by lazy { AllAnimeExtractor(client, headers) }
@@ -295,10 +315,10 @@ class AllAnime :
 
         // 2. If encrypted, decrypt directly (errors surface to user); otherwise parse as plain text
         val sourceUrls = if (!tobeparsed.isNullOrBlank()) {
-            decryptTobeparsed(tobeparsed).parseAs<DecryptedEpisodeResult>().episode.sourceUrls
+            decryptTobeparsed(tobeparsed).parseAs<DecryptedEpisodeResult>().episode?.sourceUrls
         } else {
-            responseBody.parseAs<EpisodeResult>().data.episode.sourceUrls
-        }
+            responseBody.parseAs<EpisodeResult>().data.episode?.sourceUrls
+        } ?: emptyList()
 
         val hosterSelection = preferences.getHosters
         val altHosterSelection = preferences.getAltHosters
@@ -528,6 +548,14 @@ class AllAnime :
         // 5. Decrypt and return JSON string
         return String(cipher.doFinal(encryptedData), Charsets.UTF_8)
     }
+
+    private inline fun <reified T> Response.parseAs(): T = json.decodeFromString(bodyString())
+
+    private inline fun <reified T> String.parseAs(): T = json.decodeFromString(this)
+
+    private fun JsonObject.toJsonString(): String = json.encodeToString(this)
+
+    private fun String.toJsonBody() = toRequestBody("application/json; charset=utf-8".toMediaType())
 
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -5,7 +5,6 @@ import android.util.Base64
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
-import aniyomi.lib.cloudflareinterceptor.CloudflareInterceptor
 import aniyomi.lib.doodextractor.DoodExtractor
 import aniyomi.lib.filemoonextractor.FilemoonExtractor
 import aniyomi.lib.gogostreamextractor.GogoStreamExtractor
@@ -30,7 +29,6 @@ import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.toJsonString
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
@@ -39,12 +37,9 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
-import uy.kohesive.injekt.api.get
-import uy.kohesive.injekt.injectLazy
 import java.security.MessageDigest
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
@@ -65,14 +60,8 @@ class AllAnime :
     override val supportsLatest = true
 
     private val preferences by getPreferencesLazy()
-    private val json: Json by injectLazy()
-
-    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .addInterceptor(CloudflareInterceptor(network.cloudflareClient))
-        .build()
 
     override fun headersBuilder() = super.headersBuilder()
-        .set("User-Agent", USER_AGENT)
         .set("Referer", "$baseUrl/")
 
     // ============================== Popular ===============================
@@ -264,7 +253,6 @@ class AllAnime :
                         put("translationType", subPref)
                         put("episodeString", ep)
                     }
-                    put("query", STREAMS_QUERY)
                 }.toJsonString()
             }
         }
@@ -544,7 +532,7 @@ class AllAnime :
         // 5. Decrypt and return JSON string
         return String(cipher.doFinal(encryptedData), Charsets.UTF_8)
     }
-    
+
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API
         private const val GRAPHQL_ORIGIN = "https://youtu-chan.com"
@@ -635,8 +623,6 @@ class AllAnime :
         private val XOR_MASKS = XOR_KEYS.map { key ->
             key.fold(0) { mask, ch -> mask xor ch.code }
         }.toIntArray()
-
-        private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
     }
 
     // ============================== Settings ==============================

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -63,6 +63,11 @@ class AllAnime :
 
     private val preferences by getPreferencesLazy()
 
+    // ============================== Headers ===============================
+    override fun headersBuilder() = super.headersBuilder()
+        .add("Origin", GRAPHQL_ORIGIN)
+        .add("Referer", "$GRAPHQL_ORIGIN/")
+
     // ============================== Popular ===============================
 
     override fun popularAnimeRequest(page: Int): Request {
@@ -292,8 +297,6 @@ class AllAnime :
 
         val getHeaders = headers.newBuilder().apply {
             add("Accept", "*/*")
-            add("Origin", PREF_SITE_DOMAIN_DEFAULT)
-            add("Referer", "${PREF_SITE_DOMAIN_DEFAULT}/")
         }.build()
 
         return GET(url.toString(), headers = getHeaders)
@@ -564,7 +567,7 @@ class AllAnime :
 
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API
-        private const val GRAPHQL_ORIGIN = "https://youtu-chan.com"
+        private const val GRAPHQL_ORIGIN = "https://allmanga.to"
         private val INTERAL_HOSTER_NAMES = arrayOf(
             "Default", "Ac", "Ak", "Kir", "Rab", "Luf-mp4",
             "Si-Hls", "S-mp4", "Ac-Hls", "Uv-mp4", "Pn-Hls",

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -30,7 +30,6 @@ import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.toJsonString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -40,10 +39,8 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
 import uy.kohesive.injekt.api.get
@@ -547,15 +544,7 @@ class AllAnime :
         // 5. Decrypt and return JSON string
         return String(cipher.doFinal(encryptedData), Charsets.UTF_8)
     }
-
-    private inline fun <reified T> Response.parseAs(): T = json.decodeFromString(bodyString())
-
-    private inline fun <reified T> String.parseAs(): T = json.decodeFromString(this)
-
-    private fun JsonObject.toJsonString(): String = json.encodeToString(this)
-
-    private fun String.toJsonBody() = toRequestBody("application/json; charset=utf-8".toMediaType())
-
+    
     companion object {
         private const val PAGE_SIZE = 26 // number of items to retrieve when calling API
         private const val GRAPHQL_ORIGIN = "https://youtu-chan.com"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
@@ -117,7 +117,7 @@ data class EpisodeResult(
 ) {
     @Serializable
     data class DataEpisode(
-        val episode: Episode,
+        val episode: Episode? = null,
     ) {
         @Serializable
         data class Episode(
@@ -146,5 +146,5 @@ data class EncryptedEpisodeResult(
 
 @Serializable
 data class DecryptedEpisodeResult(
-    val episode: EpisodeResult.DataEpisode.Episode,
+    val episode: EpisodeResult.DataEpisode.Episode? = null,
 )

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
@@ -98,20 +98,5 @@ val EPISODES_QUERY = buildQuery {
     """
 }
 
-val STREAMS_QUERY = buildQuery {
-    """
-        query(
-            %showId: String!,
-            %translationType: VaildTranslationTypeEnumType!,
-            %episodeString: String!
-        ) {
-            episode(
-                showId: %showId
-                translationType: %translationType
-                episodeString: %episodeString
-            ) {
-                sourceUrls
-            }
-        }
-    """
-}
+// Persisted Query ID other one returns 403
+const val STREAMS_QUERY = "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
@@ -99,21 +99,3 @@ val EPISODES_QUERY = buildQuery {
         }
     """
 }
-
-val STREAMS_QUERY = buildQuery {
-    """
-        query(
-            %showId: String!,
-            %translationType: VaildTranslationTypeEnumType!,
-            %episodeString: String!
-        ) {
-            episode(
-                showId: %showId
-                translationType: %translationType
-                episodeString: %episodeString
-            ) {
-                sourceUrls
-            }
-        }
-    """
-}

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
@@ -4,6 +4,8 @@ fun buildQuery(queryAction: () -> String): String = queryAction()
     .trimIndent()
     .replace("%", "$")
 
+const val STREAM_HASH = "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
+
 val POPULAR_QUERY: String = buildQuery {
     """
         query(


### PR DESCRIPTION
Checklist:

- [X] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Closes https://github.com/yuzono/anime-extensions/issues/253

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Fix AllAnime extension playback crashes by switching streaming API requests to a new persisted-query GET endpoint and hardening JSON handling for missing episode data.

Bug Fixes:
- Prevent crashes when decrypted or API episode responses omit the episode object by making DTO fields nullable and defaulting missing source URLs to an empty list.
- Avoid JSON decoding issues by routing response parsing through the shared Json instance and updating helper parsing utilities accordingly.
- Mitigate Cloudflare-related access failures by using a Cloudflare-aware HTTP client and setting appropriate headers for AllAnime API calls.

Enhancements:
- Update AllAnime streaming requests to use querystring-based persisted GraphQL queries with the latest stream hash.
- Increment the AllAnime extension version code and add the Cloudflare interceptor library dependency.

## Summary by Sourcery

Update the AllAnime extension to use a new Cloudflare-aware streaming API flow and make episode parsing resilient to missing data.

Bug Fixes:
- Prevent playback crashes when decrypted or API episode responses omit the episode object by treating it as nullable and defaulting missing source URLs to an empty list.

Enhancements:
- Switch AllAnime streaming requests to a persisted-query GET endpoint using the latest stream hash and querystring variables.
- Use a Cloudflare-aware HTTP client with custom User-Agent and Referer headers for AllAnime API calls.
- Increment the AllAnime extension version code and add the Cloudflare interceptor library dependency.