### PR TITLE
AnimePahe [EN]: Fix Episode Numbering For Correct Tracking

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 39
+    extVersionCode = 40
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.network.GET
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSwitchPreference
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parallelMapNotNullBlocking
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
 import keiyoushi.utils.useAsJsoup
@@ -347,7 +348,7 @@ class AnimePahe :
         }
 
         return videos.ifEmpty {
-            links.mapNotNull { (kwikLink, _, quality) ->
+            links.parallelMapNotNullBlocking { (kwikLink, _, quality) ->
                 runCatching {
                     KwikExtractor(client, headers).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
                 }.getOrNull()

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -476,7 +476,7 @@ class AnimePahe :
 
         private const val PREF_LINK_TYPE_KEY = "preferred_link_type"
         private const val PREF_LINK_TYPE_TITLE = "Use HLS links"
-        private const val PREF_LINK_TYPE_DEFAULT = false
+        private const val PREF_LINK_TYPE_DEFAULT = true
         private val PREF_LINK_TYPE_SUMMARY by lazy {
             """Enable this if you are having Cloudflare issues.
             |Note that this will break the ability to seek inside of the video unless the episode is downloaded in advance.

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -19,7 +19,6 @@ import eu.kanade.tachiyomi.network.GET
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSwitchPreference
 import keiyoushi.utils.getPreferencesLazy
-import keiyoushi.utils.parallelMapNotNullBlocking
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
 import keiyoushi.utils.useAsJsoup
@@ -279,9 +278,11 @@ class AnimePahe :
         recursivePages(episodeList, response, session)
 
         return episodeList
+            .sortedBy { it.date_upload }
             .mapIndexed { index, episode ->
                 episode.apply {
                     episode_number = (index + 1).toFloat()
+                    name = "Episode ${index + 1}"
                 }
             }
             .reversed()
@@ -346,7 +347,7 @@ class AnimePahe :
         }
 
         return videos.ifEmpty {
-            links.parallelMapNotNullBlocking { (kwikLink, _, quality) ->
+            links.mapNotNull { (kwikLink, _, quality) ->
                 runCatching {
                     KwikExtractor(client, headers).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
                 }.getOrNull()

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -32,6 +32,7 @@ import aniyomi.lib.jsunpacker.JsUnpacker
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.FormBody
 import okhttp3.Headers
@@ -64,7 +65,7 @@ class KwikExtractor(
             .build()
     }
 
-    fun getHlsVideo(kwikUrl: String, referer: String, quality: String = ""): Video {
+    suspend fun getHlsVideo(kwikUrl: String, referer: String, quality: String = ""): Video {
         val videoUrl = getHlsStreamUrl(kwikUrl, referer)
 
         return Video(
@@ -75,9 +76,9 @@ class KwikExtractor(
         )
     }
 
-    fun getHlsStreamUrl(kwikUrl: String, referer: String): String {
+    suspend fun getHlsStreamUrl(kwikUrl: String, referer: String): String {
         val eContent = client.newCall(GET(kwikUrl, headers.newBuilder().set("Referer", referer).build()))
-            .execute().asJsoup()
+            .awaitSuccess().asJsoup()
         val script = eContent.selectFirst("script:containsData(eval\\(function)")?.data()
             ?.substringAfterLast("eval(function(")
             ?: throw KwikException.ExtractionException("JsUnpacker not found.")

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -32,7 +32,6 @@ import aniyomi.lib.jsunpacker.JsUnpacker
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.FormBody
 import okhttp3.Headers
@@ -65,7 +64,7 @@ class KwikExtractor(
             .build()
     }
 
-    suspend fun getHlsVideo(kwikUrl: String, referer: String, quality: String = ""): Video {
+    fun getHlsVideo(kwikUrl: String, referer: String, quality: String = ""): Video {
         val videoUrl = getHlsStreamUrl(kwikUrl, referer)
 
         return Video(
@@ -76,9 +75,9 @@ class KwikExtractor(
         )
     }
 
-    suspend fun getHlsStreamUrl(kwikUrl: String, referer: String): String {
+    fun getHlsStreamUrl(kwikUrl: String, referer: String): String {
         val eContent = client.newCall(GET(kwikUrl, headers.newBuilder().set("Referer", referer).build()))
-            .awaitSuccess().asJsoup()
+            .execute().asJsoup()
         val script = eContent.selectFirst("script:containsData(eval\\(function)")?.data()
             ?.substringAfterLast("eval(function(")
             ?: throw KwikException.ExtractionException("JsUnpacker not found.")


### PR DESCRIPTION
Adjusted multi season episode numbering, fixing episode tracking with AniList, MyAnimeList... (Episode 13/12)
Bump to version 40.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Fix AnimePahe episode ordering and metadata for correct tracking and adjust Kwik video extraction behavior.

Bug Fixes:
- Correct multi-season episode numbering and titles so episodes are ordered by upload date and track properly with external services.

Enhancements:
- Change Kwik HLS extraction to use synchronous requests and non-suspending methods, simplifying its usage from the source.
- Replace parallel video link processing with sequential mapping in AnimePahe to align with the updated extractor API.

Build:
- Bump AnimePahe extension version code to 40.