### PR TITLE
Hanime [EN]: Fix episode titles

### DIFF
--- a/src/en/hanime/build.gradle
+++ b/src/en/hanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'hanime.tv'
     extClass = '.Hanime'
-    extVersionCode = 19
+    extVersionCode = 20
     isNsfw = true
 }
 

--- a/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
+++ b/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
@@ -1119,31 +1119,32 @@ class Hanime :
         private const val PREF_CUSTOM_CDN_DEFAULT = ""
 
         private const val PREF_EP_TITLE_FORMAT_KEY = "episode_title_format"
-        private const val PREF_EP_TITLE_FORMAT_DEFAULT = "clean"
-        private val EP_TITLE_FORMAT_LIST = arrayOf("clean", "full")
+        private val EP_TITLE_FORMAT_ENTRIES = listOf("Clean (Episode N)", "Full (Series Name N)")
+        private val EP_TITLE_FORMAT_LIST = listOf("clean", "full")
+        private val PREF_EP_TITLE_FORMAT_DEFAULT = EP_TITLE_FORMAT_LIST.first()
 
         // Hoisted Regex constants — compiled once, reused on every call
 
         /** Matches HTML tags for description sanitization. */
-        private val HTML_TAG_REGEX = Regex("<[^>]*>")
+        private val HTML_TAG_REGEX by lazy { Regex("<[^>]*>") }
 
         /** Matches a trailing episode suffix: a space followed by 1–3 digits at end of string. */
-        private val EPISODE_SUFFIX_REGEX = Regex("""\s(\d{1,3})$""")
+        private val EPISODE_SUFFIX_REGEX by lazy { Regex("""\s(\d{1,3})$""") }
 
         /** Matches "Season N" at end of a title (case-insensitive). */
-        private val SEASON_PATTERN_REGEX = Regex("""\s+Season\s+(\d{1,3})$""", RegexOption.IGNORE_CASE)
+        private val SEASON_PATTERN_REGEX by lazy { Regex("""\s+Season\s+(\d{1,3})$""", RegexOption.IGNORE_CASE) }
 
         /** Matches "Ep N" at end of a title (case-insensitive). */
-        private val EP_PATTERN_REGEX = Regex("""\s+Ep\s+(\d{1,3})$""", RegexOption.IGNORE_CASE)
+        private val EP_PATTERN_REGEX by lazy { Regex("""\s+Ep\s+(\d{1,3})$""", RegexOption.IGNORE_CASE) }
 
         /** Matches a trailing number at end of a title: one or more spaces then 1–3 digits. */
-        private val TRAILING_NUMBER_REGEX = Regex("""\s+(\d{1,3})$""")
+        private val TRAILING_NUMBER_REGEX by lazy { Regex("""\s+(\d{1,3})$""") }
 
         /** Matches compound prefixes before a number (e.g. "x 3", "- 3", "× 3") that should NOT be stripped. */
-        private val PREFIX_REGEX = Regex("""[\s\-×x]$""", RegexOption.IGNORE_CASE)
+        private val PREFIX_REGEX by lazy { Regex("""[\s\-×x]$""", RegexOption.IGNORE_CASE) }
 
         /** Extracts numeric quality value from a quality label like "1080p". */
-        private val QUALITY_RESOLUTION_REGEX = Regex("""(\d+)p""")
+        private val QUALITY_RESOLUTION_REGEX by lazy { Regex("""(\d+)p""") }
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
@@ -1215,8 +1216,8 @@ class Hanime :
         screen.addListPreference(
             key = PREF_EP_TITLE_FORMAT_KEY,
             title = "Episode title format",
-            entries = listOf("Clean (Episode N)", "Full (Series Name N)"),
-            entryValues = EP_TITLE_FORMAT_LIST.toList(),
+            entries = EP_TITLE_FORMAT_ENTRIES,
+            entryValues = EP_TITLE_FORMAT_LIST,
             default = PREF_EP_TITLE_FORMAT_DEFAULT,
             summary = "%s",
         )

--- a/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
+++ b/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
@@ -371,7 +371,7 @@ class Hanime :
                 trimmed
             }
             // Don't strip if the number is part of a compound like "x 3" or "- 3"
-            else if (Regex("""[xX\-–]$""").containsMatchIn(beforeNumber)) {
+            else if (PREFIX_REGEX.containsMatchIn(beforeNumber)) {
                 trimmed
             } else {
                 beforeNumber.trim()

--- a/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
+++ b/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
@@ -361,21 +361,54 @@ class Hanime :
             return trimmed.split(" Ep ")[0].trim()
         }
         // Only strip trailing number if it's a standalone episode number
-        // (1-3 digits at the end, preceded by a space, NOT preceded by 'x' connector)
+        // (1-3 digits at the end, preceded by a space)
         val episodeSuffixRegex = Regex("""\s(\d{1,3})$""")
         val match = episodeSuffixRegex.find(trimmed)
         return if (match != null) {
             val beforeNumber = trimmed.substring(0, match.range.first)
-            // Don't strip if the number is part of a compound like "x 3" or "- 3"
-            val prefixRegex = Regex("""[xX\-–]$""")
-            if (!prefixRegex.containsMatchIn(beforeNumber)) {
-                beforeNumber.trim()
-            } else {
+            // Don't strip if the number is part of "Season N" (the N is a season label, not an episode number)
+            if (beforeNumber.trimEnd().endsWith("Season", ignoreCase = true)) {
                 trimmed
+            }
+            // Don't strip if the number is part of a compound like "x 3" or "- 3"
+            else if (Regex("""[xX\-–]$""").containsMatchIn(beforeNumber)) {
+                trimmed
+            } else {
+                beforeNumber.trim()
             }
         } else {
             trimmed
         }
+    }
+
+    private fun formatEpisodeTitle(rawName: String?, seriesName: String, index: Int, format: String): String {
+        val fallback = "Episode ${index + 1}"
+        if (rawName == null) return fallback
+        if (format == "full") return rawName
+
+        val trimmed = rawName.trim()
+        // Try "Title Season N" pattern first (e.g. "Modaete yo, Adam-kun Season 1")
+        val seasonMatch = Regex("""\s+Season\s+(\d{1,3})$""", RegexOption.IGNORE_CASE).find(trimmed)
+        if (seasonMatch != null) {
+            val seasonNum = seasonMatch.groupValues[1]
+            return "Season $seasonNum - $fallback"
+        }
+        // Try "Title Ep N" pattern (e.g. "Some Title Ep 3")
+        val epMatch = Regex("""\s+Ep\s+(\d{1,3})$""", RegexOption.IGNORE_CASE).find(trimmed)
+        if (epMatch != null) {
+            return "Episode ${epMatch.groupValues[1]}"
+        }
+        // Try "Title N" pattern (e.g. "Enjo Kouhai 1")
+        val numMatch = Regex("""\s+(\d{1,3})$""").find(trimmed)
+        if (numMatch != null) {
+            val beforeNumber = trimmed.substring(0, numMatch.range.first)
+            // Only extract if the text before the number matches the series name
+            if (beforeNumber.trim().equals(seriesName, ignoreCase = true)) {
+                return "Episode ${numMatch.groupValues[1]}"
+            }
+        }
+        // No recognizable pattern — use the raw name
+        return trimmed
     }
 
     // ── Anime Details ──────────────────────────────────────────────────
@@ -702,28 +735,31 @@ class Hanime :
             .filter { getTitle(it.name ?: "") == currentSeriesName }
 
         if (seriesVideos.isEmpty()) {
-            // No matching series found in franchise; return just the current video as a single episode
-            val currentVideo = videoModel.hentaiVideo ?: return emptyList()
-            return listOf(
-                SEpisode.create().apply {
-                    episode_number = 1f
-                    name = currentVideo.name ?: "Episode 1"
-                    date_upload = (currentVideo.releasedAtUnix ?: 0) * 1000
-                    val hvidParam = currentVideo.id?.let { id -> "&hvid=$id" } ?: ""
-                    setUrlWithoutDomain("$baseUrl/api/v8/video?id=${currentVideo.slug}$hvidParam")
-                },
-            )
+        // No matching series found in franchise; return just the current video as a single episode
+        val currentVideo = videoModel.hentaiVideo ?: return emptyList()
+        val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
+        return listOf(
+            SEpisode.create().apply {
+                episode_number = 1f
+                name = formatEpisodeTitle(currentVideo.name, currentSeriesName, 0, titleFormat)
+                date_upload = (currentVideo.releasedAtUnix ?: 0) * 1000
+                val hvidParam = currentVideo.id?.let { id -> "&hvid=$id" } ?: ""
+                setUrlWithoutDomain("$baseUrl/api/v8/video?id=${currentVideo.slug}$hvidParam")
+            },
+        )
         }
 
-        return seriesVideos.mapIndexed { idx, it ->
-            SEpisode.create().apply {
-                episode_number = idx + 1f
-                name = it.name ?: "Episode ${idx + 1}"
-                date_upload = (it.releasedAtUnix ?: 0) * 1000
-                val hvidParam = it.id?.let { id -> "&hvid=$id" } ?: ""
-                url = "$baseUrl/api/v8/video?id=${it.slug}$hvidParam"
-            }
-        }.reversed()
+    val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
+
+    return seriesVideos.mapIndexed { idx, it ->
+        SEpisode.create().apply {
+            episode_number = idx + 1f
+            name = formatEpisodeTitle(it.name, currentSeriesName, idx, titleFormat)
+            date_upload = (it.releasedAtUnix ?: 0) * 1000
+            val hvidParam = it.id?.let { id -> "&hvid=$id" } ?: ""
+            url = "$baseUrl/api/v8/video?id=${it.slug}$hvidParam"
+        }
+    }.reversed()
     }
 
     // ── URL Helpers ───────────────────────────────────────────────────
@@ -1084,6 +1120,10 @@ class Hanime :
 
         private const val PREF_CUSTOM_CDN_KEY = "custom_cdn"
         private const val PREF_CUSTOM_CDN_DEFAULT = ""
+
+        private const val PREF_EP_TITLE_FORMAT_KEY = "episode_title_format"
+        private const val PREF_EP_TITLE_FORMAT_DEFAULT = "clean"
+        private val EP_TITLE_FORMAT_LIST = arrayOf("clean", "full")
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
@@ -1149,6 +1189,16 @@ class Hanime :
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI,
             validate = { it.isBlank() || it.toHttpUrlOrNull() != null },
             validationMessage = { "Must be a valid HTTP/HTTPS URL or empty" },
+        )
+
+        // Episode Title Format
+        screen.addListPreference(
+            key = PREF_EP_TITLE_FORMAT_KEY,
+            title = "Episode title format",
+            entries = listOf("Clean (Episode N)", "Full (Series Name N)"),
+            entryValues = EP_TITLE_FORMAT_LIST.toList(),
+            default = PREF_EP_TITLE_FORMAT_DEFAULT,
+            summary = "%s",
         )
     }
 }

--- a/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
+++ b/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
@@ -258,7 +258,7 @@ class Hanime :
             title = getTitle(item.name)
             thumbnail_url = item.coverUrl
             author = item.brand
-            description = item.description?.replace(Regex("<[^>]*>"), "")
+            description = item.description?.replace(HTML_TAG_REGEX, "")
             status = SAnime.UNKNOWN
             genre = item.tags.joinToString { it }
             initialized = true
@@ -362,8 +362,7 @@ class Hanime :
         }
         // Only strip trailing number if it's a standalone episode number
         // (1-3 digits at the end, preceded by a space)
-        val episodeSuffixRegex = Regex("""\s(\d{1,3})$""")
-        val match = episodeSuffixRegex.find(trimmed)
+        val match = EPISODE_SUFFIX_REGEX.find(trimmed)
         return if (match != null) {
             val beforeNumber = trimmed.substring(0, match.range.first)
             // Don't strip if the number is part of "Season N" (the N is a season label, not an episode number)
@@ -388,18 +387,18 @@ class Hanime :
 
         val trimmed = rawName.trim()
         // Try "Title Season N" pattern first (e.g. "Modaete yo, Adam-kun Season 1")
-        val seasonMatch = Regex("""\s+Season\s+(\d{1,3})$""", RegexOption.IGNORE_CASE).find(trimmed)
+        val seasonMatch = SEASON_PATTERN_REGEX.find(trimmed)
         if (seasonMatch != null) {
             val seasonNum = seasonMatch.groupValues[1]
             return "Season $seasonNum - $fallback"
         }
         // Try "Title Ep N" pattern (e.g. "Some Title Ep 3")
-        val epMatch = Regex("""\s+Ep\s+(\d{1,3})$""", RegexOption.IGNORE_CASE).find(trimmed)
+        val epMatch = EP_PATTERN_REGEX.find(trimmed)
         if (epMatch != null) {
             return "Episode ${epMatch.groupValues[1]}"
         }
         // Try "Title N" pattern (e.g. "Enjo Kouhai 1")
-        val numMatch = Regex("""\s+(\d{1,3})$""").find(trimmed)
+        val numMatch = TRAILING_NUMBER_REGEX.find(trimmed)
         if (numMatch != null) {
             val beforeNumber = trimmed.substring(0, numMatch.range.first)
             // Only extract if the text before the number matches the series name
@@ -712,7 +711,7 @@ class Hanime :
         return this.sortedWith(
             compareBy(
                 { it.quality.contains(quality) },
-                { Regex("""(\d+)p""").find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
+                { QUALITY_RESOLUTION_REGEX.find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
             ),
         ).reversed()
     }
@@ -730,6 +729,7 @@ class Hanime :
 
         val currentSeriesName = getTitle(videoModel.hentaiVideo?.name ?: "")
         val allFranchiseVideos = videoModel.hentaiFranchiseHentaiVideos ?: return emptyList()
+        val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
 
         val seriesVideos = allFranchiseVideos
             .filter { getTitle(it.name ?: "") == currentSeriesName }
@@ -737,7 +737,6 @@ class Hanime :
         if (seriesVideos.isEmpty()) {
             // No matching series found in franchise; return just the current video as a single episode
             val currentVideo = videoModel.hentaiVideo ?: return emptyList()
-            val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
             return listOf(
                 SEpisode.create().apply {
                     episode_number = 1f
@@ -748,8 +747,6 @@ class Hanime :
                 },
             )
         }
-
-        val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
 
         return seriesVideos.mapIndexed { idx, it ->
             SEpisode.create().apply {
@@ -1124,6 +1121,29 @@ class Hanime :
         private const val PREF_EP_TITLE_FORMAT_KEY = "episode_title_format"
         private const val PREF_EP_TITLE_FORMAT_DEFAULT = "clean"
         private val EP_TITLE_FORMAT_LIST = arrayOf("clean", "full")
+
+        // Hoisted Regex constants — compiled once, reused on every call
+
+        /** Matches HTML tags for description sanitization. */
+        private val HTML_TAG_REGEX = Regex("<[^>]*>")
+
+        /** Matches a trailing episode suffix: a space followed by 1–3 digits at end of string. */
+        private val EPISODE_SUFFIX_REGEX = Regex("""\s(\d{1,3})$""")
+
+        /** Matches "Season N" at end of a title (case-insensitive). */
+        private val SEASON_PATTERN_REGEX = Regex("""\s+Season\s+(\d{1,3})$""", RegexOption.IGNORE_CASE)
+
+        /** Matches "Ep N" at end of a title (case-insensitive). */
+        private val EP_PATTERN_REGEX = Regex("""\s+Ep\s+(\d{1,3})$""", RegexOption.IGNORE_CASE)
+
+        /** Matches a trailing number at end of a title: one or more spaces then 1–3 digits. */
+        private val TRAILING_NUMBER_REGEX = Regex("""\s+(\d{1,3})$""")
+
+        /** Matches compound prefixes before a number (e.g. "x 3", "- 3", "× 3") that should NOT be stripped. */
+        private val PREFIX_REGEX = Regex("""[\s\-×x]$""", RegexOption.IGNORE_CASE)
+
+        /** Extracts numeric quality value from a quality label like "1080p". */
+        private val QUALITY_RESOLUTION_REGEX = Regex("""(\d+)p""")
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
+++ b/src/en/hanime/src/eu/kanade/tachiyomi/animeextension/en/hanime/Hanime.kt
@@ -735,31 +735,31 @@ class Hanime :
             .filter { getTitle(it.name ?: "") == currentSeriesName }
 
         if (seriesVideos.isEmpty()) {
-        // No matching series found in franchise; return just the current video as a single episode
-        val currentVideo = videoModel.hentaiVideo ?: return emptyList()
+            // No matching series found in franchise; return just the current video as a single episode
+            val currentVideo = videoModel.hentaiVideo ?: return emptyList()
+            val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
+            return listOf(
+                SEpisode.create().apply {
+                    episode_number = 1f
+                    name = formatEpisodeTitle(currentVideo.name, currentSeriesName, 0, titleFormat)
+                    date_upload = (currentVideo.releasedAtUnix ?: 0) * 1000
+                    val hvidParam = currentVideo.id?.let { id -> "&hvid=$id" } ?: ""
+                    setUrlWithoutDomain("$baseUrl/api/v8/video?id=${currentVideo.slug}$hvidParam")
+                },
+            )
+        }
+
         val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
-        return listOf(
+
+        return seriesVideos.mapIndexed { idx, it ->
             SEpisode.create().apply {
-                episode_number = 1f
-                name = formatEpisodeTitle(currentVideo.name, currentSeriesName, 0, titleFormat)
-                date_upload = (currentVideo.releasedAtUnix ?: 0) * 1000
-                val hvidParam = currentVideo.id?.let { id -> "&hvid=$id" } ?: ""
-                setUrlWithoutDomain("$baseUrl/api/v8/video?id=${currentVideo.slug}$hvidParam")
-            },
-        )
-        }
-
-    val titleFormat = preferences.getString(PREF_EP_TITLE_FORMAT_KEY, PREF_EP_TITLE_FORMAT_DEFAULT) ?: PREF_EP_TITLE_FORMAT_DEFAULT
-
-    return seriesVideos.mapIndexed { idx, it ->
-        SEpisode.create().apply {
-            episode_number = idx + 1f
-            name = formatEpisodeTitle(it.name, currentSeriesName, idx, titleFormat)
-            date_upload = (it.releasedAtUnix ?: 0) * 1000
-            val hvidParam = it.id?.let { id -> "&hvid=$id" } ?: ""
-            url = "$baseUrl/api/v8/video?id=${it.slug}$hvidParam"
-        }
-    }.reversed()
+                episode_number = idx + 1f
+                name = formatEpisodeTitle(it.name, currentSeriesName, idx, titleFormat)
+                date_upload = (it.releasedAtUnix ?: 0) * 1000
+                val hvidParam = it.id?.let { id -> "&hvid=$id" } ?: ""
+                url = "$baseUrl/api/v8/video?id=${it.slug}$hvidParam"
+            }
+        }.reversed()
     }
 
     // ── URL Helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Closes #309

## Summary by Sourcery

Improve Hanime episode title handling and add a user preference for episode title formatting.

New Features:
- Add a configurable preference to choose between clean or full episode title formats for Hanime episodes.

Bug Fixes:
- Correct Hanime episode title parsing to avoid stripping season numbers and to better infer episode numbers from common naming patterns.

Enhancements:
- Refine episode title generation to produce more consistent and readable names when series or episode metadata is incomplete or variably formatted.

Build:
- Bump the Hanime extension version code to 20.