### PR TITLE
Cineby [EN]: Update Domains

### DIFF
--- a/src/en/cineby/build.gradle
+++ b/src/en/cineby/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cineby'
     extClass = '.Cineby'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.animeextension.en.cineby
 
 import android.content.SharedPreferences
 import android.text.InputType
-import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -15,6 +14,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.addEditTextPreference
 import keiyoushi.utils.addListPreference
+import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.delegate
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
@@ -541,18 +541,16 @@ class Cineby :
 
         // Display "Name (Language)" but persist bare display names so
         // the catalog code can match them as keys.
-        screen.addPreference(
-            MultiSelectListPreference(screen.context).apply {
-                key = PREF_SERVERS_KEY
-                title = "Enabled Servers"
-                entries = CinebyExtractor.VIDEASY_SERVERS.map { server ->
-                    val lang = server.audioLabel ?: "Unknown"
-                    "${server.displayName} ($lang)"
-                }.toTypedArray()
-                entryValues = CinebyExtractor.SERVER_DISPLAY_NAMES.toTypedArray()
-                setDefaultValue(PREF_SERVERS_DEFAULT)
-                summary = "Select servers to enable. Languages shown per server."
+        screen.addSetPreference(
+            key = PREF_SERVERS_KEY,
+            title = "Enabled Servers",
+            entries = CinebyExtractor.VIDEASY_SERVERS.map { server ->
+                val lang = server.audioLabel ?: "Unknown"
+                "${server.displayName} ($lang)"
             },
+            entryValues = CinebyExtractor.SERVER_DISPLAY_NAMES,
+            default = PREF_SERVERS_DEFAULT,
+            summary = "Select servers to enable. Languages shown per server.",
         )
     }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -603,7 +603,7 @@ class Cineby :
         private const val MIN_VOTES_FOR_RECENT_SORT = "50"
 
         private const val PREF_DOMAIN_KEY = "pref_domain"
-        private val DOMAIN_ENTRIES = arrayOf("www.cineby.sc", "www.fmovies.gd", "www.bitcine.net")
+        private val DOMAIN_ENTRIES = arrayOf("www.cineby.sc", "www.fmovies.gd", "www.bitcine.tv")
         private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }
         private val PREF_DOMAIN_DEFAULT = DOMAIN_VALUES.first()
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Enhancements:
- Change Cineby domain list to replace the outdated bitcine.net host with bitcine.tv.