### PR TITLE
feat: Add Pixeldrain Extractor

### DIFF
--- a/lib/pixeldrainextractor/build.gradle.kts
+++ b/lib/pixeldrainextractor/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("lib-android")
+}

--- a/lib/pixeldrainextractor/src/aniyomi/lib/pixeldrainextractor/PixelDrainExtractor.kt
+++ b/lib/pixeldrainextractor/src/aniyomi/lib/pixeldrainextractor/PixelDrainExtractor.kt
@@ -1,0 +1,20 @@
+package aniyomi.lib.pixeldrainextractor
+
+import eu.kanade.tachiyomi.animesource.model.Video
+import okhttp3.OkHttpClient
+
+class PixelDrainExtractor(private val client: OkHttpClient) {
+
+    companion object {
+        private val mIdRegex by lazy { Regex("""/u/(.*)""") }
+    }
+
+    fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
+        val mId = mIdRegex.find(url)?.groupValues?.getOrNull(1)
+        return if (mId.isNullOrEmpty()) {
+            listOf(Video(url, "${prefix}PixelDrain", url))
+        } else {
+            listOf(Video("https://pixeldrain.com/api/file/${mId}?download", "${prefix}PixelDrain", "https://pixeldrain.com/api/file/${mId}?download"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a Pixeldrain video extractor library module and wire it into the Android library build.

New Features:
- Introduce a PixelDrainExtractor helper that converts PixelDrain URLs into playable video entries.

Build:
- Add Gradle configuration for the new pixeldrainextractor Android library module.