### PR TITLE
AnimeVerse [EN]: Simplify episode url

### DIFF
--- a/src/en/animeverse/build.gradle
+++ b/src/en/animeverse/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeVerse'
     extClass = '.AnimeVerse'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
@@ -359,8 +359,7 @@ class AnimeVerse :
         val slug = o.string("slug").orEmpty()
 
         return episodes
-            .map { it.jsonObject }
-            .groupBy { it.int("number") }
+            .groupBy { it.jsonObject.int("number") }
             .map { (num, _) ->
                 val payload = buildJsonObject {
                     put("slug", slug)

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
@@ -20,9 +20,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
@@ -363,21 +361,10 @@ class AnimeVerse :
         return episodes
             .map { it.jsonObject }
             .groupBy { it.int("number") }
-            .map { (num, variants) ->
+            .map { (num, _) ->
                 val payload = buildJsonObject {
                     put("slug", slug)
                     put("ep", num)
-                    put(
-                        "streams",
-                        buildJsonArray {
-                            variants.forEach { v ->
-                                addJsonObject {
-                                    put("k", v.string("kind") ?: "")
-                                    put("s", v.string("stream") ?: "")
-                                }
-                            }
-                        },
-                    )
                 }.toString()
                 SEpisode.create().apply {
                     episode_number = num.toFloat()


### PR DESCRIPTION
## Summary by Sourcery

Simplify how episode URLs are generated for AnimeVerse and bump the extension version code.

Enhancements:
- Stream variants are no longer embedded into the episode URL payload, leaving only slug and episode number.

Build:
- Increment AnimeVerse extension version code from 1 to 2.