### PR TITLE
Fix Google Drive local anime metadata

### DIFF
--- a/src/all/googledrive/build.gradle
+++ b/src/all/googledrive/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Google Drive'
     extClass = '.GoogleDrive'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
+++ b/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
@@ -203,7 +203,7 @@ class GoogleDrive :
 
         findDriveItem(driveDocument, folderId, DETAILS_FILE_NAME)
             ?.let { downloadDriveFile(it.id) }
-            ?.let { json.decodeFromString<DetailsJson>(it) }
+            .parseJsonOrNull<DetailsJson>()
             ?.let { t ->
                 t.title?.let { anime.title = it }
                 t.author?.let { anime.author = it }
@@ -260,7 +260,7 @@ class GoogleDrive :
             var pageToken: String? = ""
             val episodeDetails = findDriveItem(driveDocument, folderId, EPISODES_FILE_NAME)
                 ?.let { downloadDriveFile(it.id) }
-                ?.let { json.decodeFromString<List<EpisodeDetailsJson>>(it) }
+                .parseJsonOrNull<List<EpisodeDetailsJson>>()
                 .orEmpty()
                 .associateBy { it.episodeNumber }
             var counter = 1
@@ -441,6 +441,12 @@ class GoogleDrive :
         }
 
         if (parsed.items == null) throw Exception("Failed to load items, please log in through webview")
+        val coverUrlsByFolderId = findDriveItems(driveDocument, folderId, COVER_FILE_NAME, IMAGE_MIMETYPE)
+            .flatMap { cover ->
+                cover.parents.orEmpty().map { parent -> parent.id to cover.toThumbnailUrl() }
+            }
+            .toMap()
+
         parsed.items.forEach {
             if (it.isSupportedEpisodeFile()) {
                 animeList.add(
@@ -466,9 +472,7 @@ class GoogleDrive :
                             "https://drive.google.com/drive/folders/${it.id}$recurDepth",
                             "multi",
                         ).toJsonString()
-                        thumbnail_url = findDriveItem(driveDocument, it.id, COVER_FILE_NAME, IMAGE_MIMETYPE)
-                            ?.toThumbnailUrl()
-                            ?: ""
+                        thumbnail_url = coverUrlsByFolderId[it.id] ?: ""
                     },
                 )
             }
@@ -529,18 +533,25 @@ class GoogleDrive :
         folderId: String,
         title: String,
         mimeType: String = "",
-    ): PostResponse.ResponseItem? {
+    ): PostResponse.ResponseItem? = findDriveItems(document, folderId, title, mimeType)
+        .firstOrNull { it.title.equals(title, ignoreCase = true) }
+
+    private fun findDriveItems(
+        document: Document,
+        folderId: String,
+        title: String,
+        mimeType: String = "",
+    ): List<PostResponse.ResponseItem> {
         val response = runCatching {
             client.newCall(
                 createPost(document, folderId, "", searchReqWithType(folderId, title, mimeType)),
             ).execute().parseAs<PostResponse> { JSON_REGEX.find(it)!!.groupValues[1] }
         }.getOrNull()
 
-        return response?.items?.firstOrNull { it.title.equals(title, ignoreCase = true) }
-            ?: response?.items?.firstOrNull()
+        return response?.items.orEmpty()
     }
 
-    private fun downloadDriveFile(fileId: String): String {
+    private fun downloadDriveFile(fileId: String): String? = runCatching {
         val newPostHeaders = getHeaders.newBuilder().apply {
             add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
             set("Host", "drive.usercontent.google.com")
@@ -554,7 +565,14 @@ class GoogleDrive :
 
         val newResponse = client.newCall(
             POST(newPostUrl, headers = newPostHeaders, body = commonEmptyRequestBody),
-        ).execute().parseAs<DownloadResponse> { JSON_REGEX.find(it)!!.groupValues[1] }
+        ).execute().use { response ->
+            if (!response.isSuccessful) return null
+
+            val responseBody = response.body.string()
+            val jsonBody = JSON_REGEX.find(responseBody)?.groupValues?.get(1) ?: return null
+
+            json.decodeFromString<DownloadResponse>(jsonBody)
+        }
 
         val downloadHeaders = headers.newBuilder().apply {
             add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
@@ -563,10 +581,12 @@ class GoogleDrive :
             add("Host", "drive.usercontent.google.com")
         }.build()
 
-        return client.newCall(
+        client.newCall(
             GET(newResponse.downloadUrl, headers = downloadHeaders),
-        ).execute().body.string()
-    }
+        ).execute().use { response ->
+            if (response.isSuccessful) response.body.string() else null
+        }
+    }.getOrNull()
 
     private fun PostResponse.ResponseItem.toThumbnailUrl(): String = "https://drive.google.com/thumbnail?id=$id&sz=w500"
 
@@ -576,8 +596,11 @@ class GoogleDrive :
     }
 
     private fun String.toEpisodeDate(): Long = runCatching {
-        episodeDateFormat.parse(this)?.time ?: -1L
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).parse(this)?.time ?: -1L
     }.getOrDefault(-1L)
+
+    private inline fun <reified T> String?.parseJsonOrNull(): T? =
+        this?.let { runCatching { json.decodeFromString<T>(it) }.getOrNull() }
 
     private fun LinkData.toJsonString(): String = json.encodeToString(this)
 
@@ -659,9 +682,6 @@ class GoogleDrive :
         private const val COVER_FILE_NAME = "cover.jpg"
         private const val DETAILS_FILE_NAME = "details.json"
         private const val EPISODES_FILE_NAME = "episodes.json"
-        private val episodeDateFormat by lazy {
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
-        }
     }
 
     private val SharedPreferences.domainList

--- a/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
+++ b/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
@@ -36,6 +36,8 @@ import org.jsoup.nodes.Document
 import uy.kohesive.injekt.injectLazy
 import java.net.URLEncoder
 import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class GoogleDrive :
     AnimeHttpSource(),
@@ -194,56 +196,22 @@ class GoogleDrive :
             null
         } ?: return anime
 
-        // Get cover
-
-        val coverResponse = client.newCall(
-            createPost(driveDocument, folderId, nextPageToken, searchReqWithType(folderId, "cover", IMAGE_MIMETYPE)),
-        ).execute().parseAs<PostResponse> { JSON_REGEX.find(it)!!.groupValues[1] }
-
-        coverResponse.items?.firstOrNull()?.let {
-            anime.thumbnail_url = "https://drive.google.com/uc?id=${it.id}"
-        }
+        findDriveItem(driveDocument, folderId, COVER_FILE_NAME, IMAGE_MIMETYPE)
+            ?.let { anime.thumbnail_url = it.toThumbnailUrl() }
 
         // Get details
 
-        val detailsResponse = client.newCall(
-            createPost(driveDocument, folderId, nextPageToken, searchReqWithType(folderId, "details.json", "")),
-        ).execute().parseAs<PostResponse> { JSON_REGEX.find(it)!!.groupValues[1] }
-
-        detailsResponse.items?.firstOrNull()?.let {
-            val newPostHeaders = getHeaders.newBuilder().apply {
-                add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
-                set("Host", "drive.usercontent.google.com")
-                add("Origin", "https://drive.google.com")
-                add("Referer", "https://drive.google.com/")
-                add("X-Drive-First-Party", "DriveWebUi")
-                add("X-Json-Requested", "true")
-            }.build()
-
-            val newPostUrl = "https://drive.usercontent.google.com/uc?id=${it.id}&authuser=0&export=download"
-
-            val newResponse = client.newCall(
-                POST(newPostUrl, headers = newPostHeaders, body = commonEmptyRequestBody),
-            ).execute().parseAs<DownloadResponse> { JSON_REGEX.find(it)!!.groupValues[1] }
-
-            val downloadHeaders = headers.newBuilder().apply {
-                add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
-                add("Connection", "keep-alive")
-                add("Cookie", getCookie("https://drive.usercontent.google.com"))
-                add("Host", "drive.usercontent.google.com")
-            }.build()
-
-            client.newCall(
-                GET(newResponse.downloadUrl, headers = downloadHeaders),
-            ).execute().parseAs<DetailsJson>().let { t ->
+        findDriveItem(driveDocument, folderId, DETAILS_FILE_NAME)
+            ?.let { downloadDriveFile(it.id) }
+            ?.let { json.decodeFromString<DetailsJson>(it) }
+            ?.let { t ->
                 t.title?.let { anime.title = it }
                 t.author?.let { anime.author = it }
                 t.artist?.let { anime.artist = it }
                 t.description?.let { anime.description = it }
                 t.genre?.let { anime.genre = it.joinToString(", ") }
-                t.status?.let { anime.status = it.toIntOrNull() ?: SAnime.UNKNOWN }
+                t.statusAsInt()?.let { anime.status = it }
             }
-        }
 
         return anime
     }
@@ -290,6 +258,11 @@ class GoogleDrive :
             if (driveDocument.selectFirst("title:contains(Error 404 \\(Not found\\))") != null) return
 
             var pageToken: String? = ""
+            val episodeDetails = findDriveItem(driveDocument, folderId, EPISODES_FILE_NAME)
+                ?.let { downloadDriveFile(it.id) }
+                ?.let { json.decodeFromString<List<EpisodeDetailsJson>>(it) }
+                .orEmpty()
+                .associateBy { it.episodeNumber }
             var counter = 1
 
             while (pageToken != null) {
@@ -302,14 +275,14 @@ class GoogleDrive :
                 }
 
                 if (parsed.items == null) throw Exception("Failed to load items, please log in through webview")
-                parsed.items.forEachIndexed { index, it ->
-                    if (it.mimeType.startsWith("video")) {
+                parsed.items.forEach { it ->
+                    if (it.isSupportedEpisodeFile()) {
                         val size = it.fileSize?.toLongOrNull()?.let { formatBytes(it) } ?: ""
                         val pathName = if (preferences.trimEpisodeInfo) path.trimInfo() else path
 
                         if (start != null && maxRecursionDepth == 1 && counter < start) {
                             counter++
-                            return@forEachIndexed
+                            return@forEach
                         }
                         if (stop != null && maxRecursionDepth == 1 && counter > stop) return
 
@@ -320,12 +293,17 @@ class GoogleDrive :
                                 url = "https://drive.google.com/uc?id=${it.id}"
                                 episode_number =
                                     ITEM_NUMBER_REGEX.find(it.title.trimInfo())?.groupValues?.get(1)
-                                        ?.toFloatOrNull() ?: (index + 1).toFloat()
+                                        ?.toFloatOrNull() ?: counter.toFloat()
                                 date_upload = -1L
                                 scanlator = if (preferences.scanlatorOrder) {
                                     "/$pathName • $size"
                                 } else {
                                     "$size • /$pathName"
+                                }
+                                episodeDetails[episode_number]?.let { details ->
+                                    details.name?.let { name = it }
+                                    details.dateUpload?.let { date_upload = it.toEpisodeDate() }
+                                    details.scanlator?.let { scanlator = it }
                                 }
                             },
                         )
@@ -463,8 +441,8 @@ class GoogleDrive :
         }
 
         if (parsed.items == null) throw Exception("Failed to load items, please log in through webview")
-        parsed.items.forEachIndexed { index, it ->
-            if (it.mimeType.startsWith("video")) {
+        parsed.items.forEach {
+            if (it.isSupportedEpisodeFile()) {
                 animeList.add(
                     SAnime.create().apply {
                         title = if (preferences.trimAnimeInfo) it.title.trimInfo() else it.title
@@ -488,7 +466,9 @@ class GoogleDrive :
                             "https://drive.google.com/drive/folders/${it.id}$recurDepth",
                             "multi",
                         ).toJsonString()
-                        thumbnail_url = ""
+                        thumbnail_url = findDriveItem(driveDocument, it.id, COVER_FILE_NAME, IMAGE_MIMETYPE)
+                            ?.toThumbnailUrl()
+                            ?: ""
                     },
                 )
             }
@@ -543,6 +523,61 @@ class GoogleDrive :
             ""
         }
     }
+
+    private fun findDriveItem(
+        document: Document,
+        folderId: String,
+        title: String,
+        mimeType: String = "",
+    ): PostResponse.ResponseItem? {
+        val response = runCatching {
+            client.newCall(
+                createPost(document, folderId, "", searchReqWithType(folderId, title, mimeType)),
+            ).execute().parseAs<PostResponse> { JSON_REGEX.find(it)!!.groupValues[1] }
+        }.getOrNull()
+
+        return response?.items?.firstOrNull { it.title.equals(title, ignoreCase = true) }
+            ?: response?.items?.firstOrNull()
+    }
+
+    private fun downloadDriveFile(fileId: String): String {
+        val newPostHeaders = getHeaders.newBuilder().apply {
+            add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+            set("Host", "drive.usercontent.google.com")
+            add("Origin", "https://drive.google.com")
+            add("Referer", "https://drive.google.com/")
+            add("X-Drive-First-Party", "DriveWebUi")
+            add("X-Json-Requested", "true")
+        }.build()
+
+        val newPostUrl = "https://drive.usercontent.google.com/uc?id=$fileId&authuser=0&export=download"
+
+        val newResponse = client.newCall(
+            POST(newPostUrl, headers = newPostHeaders, body = commonEmptyRequestBody),
+        ).execute().parseAs<DownloadResponse> { JSON_REGEX.find(it)!!.groupValues[1] }
+
+        val downloadHeaders = headers.newBuilder().apply {
+            add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+            add("Connection", "keep-alive")
+            add("Cookie", getCookie("https://drive.usercontent.google.com"))
+            add("Host", "drive.usercontent.google.com")
+        }.build()
+
+        return client.newCall(
+            GET(newResponse.downloadUrl, headers = downloadHeaders),
+        ).execute().body.string()
+    }
+
+    private fun PostResponse.ResponseItem.toThumbnailUrl(): String = "https://drive.google.com/thumbnail?id=$id&sz=w500"
+
+    private fun PostResponse.ResponseItem.isSupportedEpisodeFile(): Boolean {
+        val lowerTitle = title.lowercase(Locale.ROOT)
+        return mimeType.startsWith("video/") && SUPPORTED_VIDEO_EXTENSIONS.any { lowerTitle.endsWith(it) }
+    }
+
+    private fun String.toEpisodeDate(): Long = runCatching {
+        episodeDateFormat.parse(this)?.time ?: -1L
+    }.getOrDefault(-1L)
 
     private fun LinkData.toJsonString(): String = json.encodeToString(this)
 
@@ -620,6 +655,13 @@ class GoogleDrive :
         private const val BOUNDARY = "=====vc17a3rwnndj====="
 
         private val ITEM_NUMBER_REGEX = Regex(""" - (?:S\d+E)?(\d+)\b""")
+        private val SUPPORTED_VIDEO_EXTENSIONS = listOf(".mp4", ".mkv")
+        private const val COVER_FILE_NAME = "cover.jpg"
+        private const val DETAILS_FILE_NAME = "details.json"
+        private const val EPISODES_FILE_NAME = "episodes.json"
+        private val episodeDateFormat by lazy {
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+        }
     }
 
     private val SharedPreferences.domainList

--- a/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDriveDto.kt
+++ b/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDriveDto.kt
@@ -16,7 +16,13 @@ data class PostResponse(
         val title: String,
         val mimeType: String,
         val fileSize: String? = null,
-    )
+        val parents: List<Parent>? = null,
+    ) {
+        @Serializable
+        data class Parent(
+            val id: String,
+        )
+    }
 }
 
 @Serializable

--- a/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDriveDto.kt
+++ b/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDriveDto.kt
@@ -1,6 +1,9 @@
 package eu.kanade.tachiyomi.animeextension.all.googledrive
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 data class PostResponse(
@@ -41,5 +44,17 @@ data class DetailsJson(
     val artist: String? = null,
     val description: String? = null,
     val genre: List<String>? = null,
-    val status: String? = null,
+    val status: JsonElement? = null,
+) {
+    fun statusAsInt(): Int? = (status as? JsonPrimitive)?.content?.toIntOrNull()
+}
+
+@Serializable
+data class EpisodeDetailsJson(
+    @SerialName("episode_number")
+    val episodeNumber: Float,
+    val name: String? = null,
+    @SerialName("date_upload")
+    val dateUpload: String? = null,
+    val scanlator: String? = null,
 )


### PR DESCRIPTION
## Summary

Fixes the Google Drive extension so folders can use Local Anime-style metadata files.

- Load cover.jpg from anime folders and show covers in browse/details pages.
- Load details.json robustly when status is encoded as a number or string.
- Filter episode entries to supported Local Anime video formats only: .mp4 and .mkv.
- Keep fallback episode numbering based on supported videos only, avoiding Missing X items when metadata/cover files are present.
- Add episodes.json support for episode-level name, date_upload, and scanlator overrides.

## Root cause

The extension searched broad Drive results for cover/details files, exposed covers through an unreliable uc URL, and decoded details.json status as String only. Episode fallback numbers also came from the raw folder item index, so non-video files like cover.jpg and details.json created numbering gaps.

## Validation

- Built the extension with ./gradlew src:all:googledrive:assembleDebug on Termux using android-34 and native aapt2 override.
- Installed and tested the generated debug APK in Aniyomi.
- Confirmed covers, details metadata, genres, and status now load from Google Drive folders.
- Confirmed non-video metadata files no longer create Missing X items.

Checklist:

- [x] Updated extVersionCode value in build.gradle for individual extensions
- [ ] Updated overrideVersionCode or baseVersionCode as needed for all multisrc extensions (N/A)
- [ ] Referenced all related issues in the PR body (N/A)
- [ ] Added the isNsfw = true flag in build.gradle when appropriate (N/A)
- [x] Have not changed source names
- [ ] Have explicitly kept the id if a source's name or language were changed (N/A)
- [x] Have tested the modifications by compiling and running the extension through Android Studio (compiled via Gradle CLI on Termux and ran in Aniyomi)
- [ ] Have removed web_hi_res_512.png when adding a new extension (N/A)
- [x] Have made sure all the icons are in png format