### PR TITLE
Refactor UrlActivities to pass raw URLs

### DIFF
--- a/lib-multisrc/animestream/build.gradle.kts
+++ b/lib-multisrc/animestream/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/animestream/src/eu/kanade/tachiyomi/multisrc/animestream/AnimeStream.kt
+++ b/lib-multisrc/animestream/src/eu/kanade/tachiyomi/multisrc/animestream/AnimeStream.kt
@@ -27,6 +27,7 @@ import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okhttp3.Response
@@ -102,13 +103,25 @@ abstract class AnimeStream(
     override fun latestUpdatesNextPageSelector(): String? = searchAnimeNextPageSelector()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path"))
-            .awaitSuccess()
-            .use(::searchAnimeByPathParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val path = url.pathSegments.takeIf { it.isNotEmpty() }?.joinToString("/")
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$path", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path"))
+                .awaitSuccess()
+                .use(::searchAnimeByPathParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     protected open fun searchAnimeByPathParse(response: Response): AnimesPage {

--- a/lib-multisrc/animestream/src/eu/kanade/tachiyomi/multisrc/animestream/AnimeStreamUrlActivity.kt
+++ b/lib-multisrc/animestream/src/eu/kanade/tachiyomi/multisrc/animestream/AnimeStreamUrlActivity.kt
@@ -13,22 +13,17 @@ class AnimeStreamUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.isNotEmpty()) {
-            val path = pathSegments.joinToString("/")
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimeStream.PREFIX_SEARCH}$path")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/lib-multisrc/dooplay/build.gradle.kts
+++ b/lib-multisrc/dooplay/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 3
+baseVersionCode = 4

--- a/lib-multisrc/dooplay/src/eu/kanade/tachiyomi/multisrc/dooplay/DooPlay.kt
+++ b/lib-multisrc/dooplay/src/eu/kanade/tachiyomi/multisrc/dooplay/DooPlay.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -177,13 +178,27 @@ abstract class DooPlay(
         return AnimesPage(animes, hasNextPage)
     }
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path", headers))
-            .awaitSuccess()
-            .use(::searchAnimeByPathParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            val path = "${url.pathSegments[0]}/${url.pathSegments[1]}"
+            return getSearchAnime(page, "${PREFIX_SEARCH}$path", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path", headers))
+                .awaitSuccess()
+                .use(::searchAnimeByPathParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request = when {

--- a/lib-multisrc/dooplay/src/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayUrlActivity.kt
+++ b/lib-multisrc/dooplay/src/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayUrlActivity.kt
@@ -13,24 +13,17 @@ class DooPlayUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val path = pathSegments[0]
-            val slug = pathSegments[1]
-            val searchQuery = "$path/$slug"
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${DooPlay.PREFIX_SEARCH}$searchQuery")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/debridindex/build.gradle
+++ b/src/all/debridindex/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Debrid Index'
     extClass = '.DebridIndex'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/all/debridindex/src/eu/kanade/tachiyomi/animeextension/all/debridindex/DebirdIndexUrlActivity.kt
+++ b/src/all/debridindex/src/eu/kanade/tachiyomi/animeextension/all/debridindex/DebirdIndexUrlActivity.kt
@@ -16,22 +16,17 @@ class DebirdIndexUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${DebridIndex.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/debridindex/src/eu/kanade/tachiyomi/animeextension/all/debridindex/DebridIndex.kt
+++ b/src/all/debridindex/src/eu/kanade/tachiyomi/animeextension/all/debridindex/DebridIndex.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
@@ -70,6 +71,23 @@ class DebridIndex :
     // =============================== Latest ===============================
     override fun latestUpdatesRequest(page: Int): Request = throw Exception("Not used")
     override fun latestUpdatesParse(response: Response): AnimesPage = throw Exception("Not used")
+
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return super.getSearchAnime(page, id, filters)
+        }
+        return super.getSearchAnime(page, query, filters)
+    }
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val tokenKey = preferences.getString(PREF_TOKEN_KEY, null)

--- a/src/all/hentaitorrent/build.gradle
+++ b/src/all/hentaitorrent/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hentai Torrent (Torrent)'
     extClass = '.HentaiTorrent'
-    extVersionCode = 3
+    extVersionCode = 4
     isTorrent = true
     isNsfw = true
 }

--- a/src/all/hentaitorrent/src/eu/kanade/tachiyomi/animeextension/all/hentaitorrent/HentaiTorrent.kt
+++ b/src/all/hentaitorrent/src/eu/kanade/tachiyomi/animeextension/all/hentaitorrent/HentaiTorrent.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.torrentutils.TorrentUtils
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -64,16 +65,26 @@ class HentaiTorrent :
 
     override fun latestUpdatesFromElement(element: Element): SAnime = throw UnsupportedOperationException()
 
-    override fun latestUpdatesNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -138,7 +149,7 @@ class HentaiTorrent :
                         scanlator = convertBytesToReadable(file.size)
                     }
                 }.reversed()
-        } catch (e: SocketTimeoutException) {
+        } catch (_: SocketTimeoutException) {
             throw Exception("Dead Torrent \uD83D\uDE35")
         }
     }

--- a/src/all/hentaitorrent/src/eu/kanade/tachiyomi/animeextension/all/hentaitorrent/HentaiTorrentUrlActivity.kt
+++ b/src/all/hentaitorrent/src/eu/kanade/tachiyomi/animeextension/all/hentaitorrent/HentaiTorrentUrlActivity.kt
@@ -17,22 +17,17 @@ class HentaiTorrentUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${HentaiTorrent.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/javguru/build.gradle
+++ b/src/all/javguru/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jav Guru'
     extClass = '.JavGuru'
-    extVersionCode = 40
+    extVersionCode = 41
     isNsfw = true
 }
 

--- a/src/all/javguru/src/eu/kanade/tachiyomi/animeextension/all/javguru/JavGuru.kt
+++ b/src/all/javguru/src/eu/kanade/tachiyomi/animeextension/all/javguru/JavGuru.kt
@@ -119,6 +119,15 @@ class JavGuru :
     }
 
     override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(0)?.takeIf(String::isNotBlank)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_ID$id", filters)
+        }
         if (query.startsWith(PREFIX_ID)) {
             val id = query.substringAfter(PREFIX_ID)
             if (id.toIntOrNull() == null) {
@@ -130,7 +139,9 @@ class JavGuru :
                 val anime = it.apply { this.url = url }
                 AnimesPage(listOf(anime), false)
             }
-        } else if (query.isNotEmpty()) {
+        }
+
+        if (query.isNotEmpty()) {
             return client.newCall(searchAnimeRequest(page, query, filters))
                 .awaitSuccess()
                 .use(::searchAnimeParse)

--- a/src/all/javguru/src/eu/kanade/tachiyomi/animeextension/all/javguru/JavGuruUrlActivity.kt
+++ b/src/all/javguru/src/eu/kanade/tachiyomi/animeextension/all/javguru/JavGuruUrlActivity.kt
@@ -10,22 +10,17 @@ import kotlin.system.exitProcess
 class JavGuruUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[0]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${JavGuru.PREFIX_ID}$id")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e("JavGuruUrlActivity", e.toString())
-            }
-        } else {
-            Log.e("JavGuruUrlActivity", "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("JavGuruUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/nyaatorrent/build.gradle
+++ b/src/all/nyaatorrent/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nyaa (Torrent)'
     extClass = '.NyaaFactory'
-    extVersionCode = 3
+    extVersionCode = 4
     isTorrent = true
     isNsfw = true
 }

--- a/src/all/nyaatorrent/src/eu/kanade/tachiyomi/animeextension/all/nyaatorrent/NyaaTorrent.kt
+++ b/src/all/nyaatorrent/src/eu/kanade/tachiyomi/animeextension/all/nyaatorrent/NyaaTorrent.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.torrentutils.TorrentUtils
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -78,13 +79,23 @@ class NyaaTorrent(extName: String, private val extURL: String, private val extId
     override fun latestUpdatesNextPageSelector(): String = animeNextPageSelector
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -179,7 +190,7 @@ class NyaaTorrent(extName: String, private val extURL: String, private val extId
                     }
                 }.reversed()
                 .toMutableList()
-        } catch (e: SocketTimeoutException) {
+        } catch (_: SocketTimeoutException) {
             throw Exception("Dead Torrent \uD83D\uDE35")
         }
     }
@@ -195,9 +206,9 @@ class NyaaTorrent(extName: String, private val extURL: String, private val extId
         val gigabytes = megabytes / 1024.0
 
         return when {
-            gigabytes >= 1 -> String.format("%.2f GB", gigabytes)
-            megabytes >= 1 -> String.format("%.2f MB", megabytes)
-            else -> String.format("%.2f KB", kilobytes)
+            gigabytes >= 1 -> String.format(Locale.ROOT, "%.2f GB", gigabytes)
+            megabytes >= 1 -> String.format(Locale.ROOT, "%.2f MB", megabytes)
+            else -> String.format(Locale.ROOT, "%.2f KB", kilobytes)
         }
     }
 

--- a/src/all/nyaatorrent/src/eu/kanade/tachiyomi/animeextension/all/nyaatorrent/NyaaTorrentUrlActivity.kt
+++ b/src/all/nyaatorrent/src/eu/kanade/tachiyomi/animeextension/all/nyaatorrent/NyaaTorrentUrlActivity.kt
@@ -17,22 +17,17 @@ class NyaaTorrentUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${NyaaTorrent.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/ptorrent/build.gradle
+++ b/src/all/ptorrent/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'PTorrent (Torrent)'
     extClass = '.PTorrent'
-    extVersionCode = 3
+    extVersionCode = 4
     isTorrent = true
     isNsfw = true
 }

--- a/src/all/ptorrent/src/eu/kanade/tachiyomi/animeextension/all/ptorrent/PTorrent.kt
+++ b/src/all/ptorrent/src/eu/kanade/tachiyomi/animeextension/all/ptorrent/PTorrent.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.torrentutils.TorrentUtils
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -64,16 +65,28 @@ class PTorrent :
 
     override fun latestUpdatesFromElement(element: Element): SAnime = throw UnsupportedOperationException()
 
-    override fun latestUpdatesNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -138,7 +151,7 @@ class PTorrent :
                         scanlator = convertBytesToReadable(file.size)
                     }
                 }.reversed()
-        } catch (e: SocketTimeoutException) {
+        } catch (_: SocketTimeoutException) {
             throw Exception("Dead Torrent \uD83D\uDE35")
         }
     }

--- a/src/all/ptorrent/src/eu/kanade/tachiyomi/animeextension/all/ptorrent/PTorrentUrlActivity.kt
+++ b/src/all/ptorrent/src/eu/kanade/tachiyomi/animeextension/all/ptorrent/PTorrentUrlActivity.kt
@@ -17,22 +17,17 @@ class PTorrentUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${PTorrent.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/rouvideo/build.gradle
+++ b/src/all/rouvideo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'RouVideo'
     extClass = '.RouVideoFactory'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = true
 }
 

--- a/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideo.kt
+++ b/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideo.kt
@@ -155,6 +155,18 @@ class RouVideo(
     // =============================== Search ===============================
 
     override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val type = url.pathSegments.getOrNull(0)
+                ?: throw Exception("Unsupported url")
+            val item = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$type:$item", filters)
+        }
+
         // Handle direct ID search (no need for tag/hot search fetching)
         if (query.startsWith(PREFIX_ID)) {
             val id = query.removePrefix(PREFIX_ID)

--- a/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoUrlActivity.kt
+++ b/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoUrlActivity.kt
@@ -17,24 +17,17 @@ class RouVideoUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val type = pathSegments[0]
-            val item = pathSegments[1]
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "$type:$item")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/supjav/build.gradle
+++ b/src/all/supjav/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'SupJav'
     extClass = '.SupJavFactory'
-    extVersionCode = 27
+    extVersionCode = 28
     isNsfw = true
 }
 

--- a/src/all/supjav/src/eu/kanade/tachiyomi/animeextension/all/supjav/SupJav.kt
+++ b/src/all/supjav/src/eu/kanade/tachiyomi/animeextension/all/supjav/SupJav.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -68,16 +69,26 @@ class SupJav(override val lang: String = "en") :
 
     override fun latestUpdatesFromElement(element: Element): SAnime = throw UnsupportedOperationException()
 
-    override fun latestUpdatesNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val path = url.pathSegments.takeIf { it.isNotEmpty() }?.joinToString("/")
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$path", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/all/supjav/src/eu/kanade/tachiyomi/animeextension/all/supjav/SupJavUrlActivity.kt
+++ b/src/all/supjav/src/eu/kanade/tachiyomi/animeextension/all/supjav/SupJavUrlActivity.kt
@@ -17,22 +17,17 @@ class SupJavUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments ?: return
-        if (pathSegments.isNotEmpty()) {
-            val path = pathSegments.joinToString("/")
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${SupJav.PREFIX_SEARCH}$path")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/torrentio/build.gradle
+++ b/src/all/torrentio/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = false
 }
 

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -25,9 +25,9 @@ import keiyoushi.utils.applicationContext
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.toJsonRequestBody
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -65,37 +65,37 @@ class Torrentio :
     }
 
     // ============================== JustWatch Api Query ======================
-    private fun justWatchQuery(): String = """
+    private fun justWatchQuery(): String = $$"""
             query GetPopularTitles(
-              ${"$"}country: Country!,
-              ${"$"}first: Int!,
-              ${"$"}language: Language!,
-              ${"$"}offset: Int,
-              ${"$"}searchQuery: String,
-              ${"$"}packages: [String!]!,
-              ${"$"}objectTypes: [ObjectType!]!,
-              ${"$"}popularTitlesSortBy: PopularTitlesSorting!,
-              ${"$"}releaseYear: IntFilter
+              $country: Country!,
+              $first: Int!,
+              $language: Language!,
+              $offset: Int,
+              $searchQuery: String,
+              $packages: [String!]!,
+              $objectTypes: [ObjectType!]!,
+              $popularTitlesSortBy: PopularTitlesSorting!,
+              $releaseYear: IntFilter
             ) {
               popularTitles(
-                country: ${"$"}country
-                first: ${"$"}first
-                offset: ${"$"}offset
-                sortBy: ${"$"}popularTitlesSortBy
+                country: $country
+                first: $first
+                offset: $offset
+                sortBy: $popularTitlesSortBy
                 filter: {
-                  objectTypes: ${"$"}objectTypes,
-                  searchQuery: ${"$"}searchQuery,
-                  packages: ${"$"}packages,
+                  objectTypes: $objectTypes,
+                  searchQuery: $searchQuery,
+                  packages: $packages,
                   genres: [],
                   excludeGenres: [],
-                  releaseYear: ${"$"}releaseYear
+                  releaseYear: $releaseYear
                 }
               ) {
                 edges {
                   node {
                     id
                     objectType
-                    content(country: ${"$"}country, language: ${"$"}language) {
+                    content(country: $country, language: $language) {
                       fullPath
                       title
                       shortDescription
@@ -104,7 +104,7 @@ class Torrentio :
                       }
                       posterUrl
                       genres {
-                        translation(language: ${"$"}language)
+                        translation(language: $language)
                       }
                       credits {
                         name
@@ -192,13 +192,25 @@ class Torrentio :
     override fun latestUpdatesParse(response: Response) = throw UnsupportedOperationException()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -243,9 +255,9 @@ class Torrentio :
     // override suspend fun getAnimeDetails(anime: SAnime): SAnime = throw UnsupportedOperationException()
 
     override suspend fun getAnimeDetails(anime: SAnime): SAnime {
-        val query = """
-            query GetUrlTitleDetails(${"$"}fullPath: String!, ${"$"}country: Country!, ${"$"}language: Language!) {
-              urlV2(fullPath: ${"$"}fullPath) {
+        val query = $$"""
+            query GetUrlTitleDetails($fullPath: String!, $country: Country!, $language: Language!) {
+              urlV2(fullPath: $fullPath) {
                 node {
                   ...TitleDetails
                 }
@@ -256,7 +268,7 @@ class Torrentio :
               ... on MovieOrShowOrSeason {
                 id
                 objectType
-                content(country: ${"$"}country, language: ${"$"}language) {
+                content(country: $country, language: $language) {
                   title
                   shortDescription
                   externalIds {
@@ -264,7 +276,7 @@ class Torrentio :
                   }
                   posterUrl
                   genres {
-                    translation(language: ${"$"}language)
+                    translation(language: $language)
                   }
                 }
               }

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/TorrentioUrlActivity.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/TorrentioUrlActivity.kt
@@ -17,22 +17,17 @@ class TorrentioUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Torrentio.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/all/torrentioanime/build.gradle
+++ b/src/all/torrentioanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio Anime (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 17
+    extVersionCode = 18
     isNsfw = false
 }
 

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -34,10 +34,10 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
-import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -171,13 +171,25 @@ class Torrentio :
     }
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/TorrentioUrlActivity.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/TorrentioUrlActivity.kt
@@ -17,22 +17,17 @@ class TorrentioUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Torrentio.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
+++ b/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
@@ -197,7 +197,7 @@ class ArabSeed :
         )
 
     // =============================== Latest ===============================
-    override fun latestUpdatesNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
     override fun latestUpdatesFromElement(element: Element): SAnime = throw UnsupportedOperationException()
     override fun latestUpdatesRequest(page: Int): Request = throw UnsupportedOperationException()
     override fun latestUpdatesSelector(): String = throw UnsupportedOperationException()

--- a/src/ar/okanime/build.gradle
+++ b/src/ar/okanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Okanime'
     extClass = '.Okanime'
-    extVersionCode = 24
+    extVersionCode = 25
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/ar/okanime/src/eu/kanade/tachiyomi/animeextension/ar/okanime/Okanime.kt
+++ b/src/ar/okanime/src/eu/kanade/tachiyomi/animeextension/ar/okanime/Okanime.kt
@@ -21,6 +21,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.useAsJsoup
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -64,13 +65,25 @@ class Okanime :
     override fun latestUpdatesNextPageSelector() = "ul.pagination > li:last-child:not(.disabled)"
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/ar/okanime/src/eu/kanade/tachiyomi/animeextension/ar/okanime/OkanimeUrlActivity.kt
+++ b/src/ar/okanime/src/eu/kanade/tachiyomi/animeextension/ar/okanime/OkanimeUrlActivity.kt
@@ -17,22 +17,17 @@ class OkanimeUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Okanime.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/de/einfach/build.gradle
+++ b/src/de/einfach/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Einfach'
     extClass = '.Einfach'
-    extVersionCode = 30
+    extVersionCode = 31
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/de/einfach/src/eu/kanade/tachiyomi/animeextension/de/einfach/Einfach.kt
+++ b/src/de/einfach/src/eu/kanade/tachiyomi/animeextension/de/einfach/Einfach.kt
@@ -25,6 +25,7 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -73,13 +74,27 @@ class Einfach :
     override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path"))
-            .awaitSuccess()
-            .use(::searchAnimeByPathParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val type = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            val item = url.pathSegments.getOrNull(2)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$type/$item", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path"))
+                .awaitSuccess()
+                .use(::searchAnimeByPathParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByPathParse(response: Response): AnimesPage {

--- a/src/de/einfach/src/eu/kanade/tachiyomi/animeextension/de/einfach/EinfachUrlActivity.kt
+++ b/src/de/einfach/src/eu/kanade/tachiyomi/animeextension/de/einfach/EinfachUrlActivity.kt
@@ -17,23 +17,17 @@ class EinfachUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val type = pathSegments[1]
-            val item = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Einfach.PREFIX_SEARCH}$type/$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/cineby/build.gradle
+++ b/src/en/cineby/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cineby'
     extClass = '.Cineby'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -104,6 +104,19 @@ class Cineby :
         query: String,
         filters: AnimeFilterList,
     ): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val type = url.pathSegments.getOrNull(0)
+                ?: throw Exception("Unsupported url")
+            val rawId = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            if (type !in listOf("movie", "tv")) throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_ID}$type/$rawId", filters)
+        }
+
         // Deep link from CinebyUrlActivity: "id:<type>/<id>"
         if (query.startsWith(PREFIX_ID)) {
             val rawPath = query.substringAfter(PREFIX_ID)

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyUrlActivity.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyUrlActivity.kt
@@ -10,29 +10,17 @@ import kotlin.system.exitProcess
 class CinebyUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 2) {
-            val type = pathSegments[0]
-            val rawId = pathSegments[1]
-            val isValidType = "movie" == type || "tv" == type
 
-            if (isValidType) {
-                val mainIntent = Intent().apply {
-                    action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                    putExtra("query", "${Cineby.PREFIX_ID}$type/$rawId")
-                    putExtra("filter", packageName)
-                }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-                try {
-                    startActivity(mainIntent)
-                } catch (e: ActivityNotFoundException) {
-                    Log.e("CinebyUrlActivity", e.toString())
-                }
-            } else {
-                Log.e("CinebyUrlActivity", "unknown type segment: $type")
-            }
-        } else {
-            Log.e("CinebyUrlActivity", "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("CinebyUrlActivity", "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/hstream/build.gradle
+++ b/src/en/hstream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hstream'
     extClass = '.Hstream'
-    extVersionCode = 10
+    extVersionCode = 11
     isNsfw = true
 }
 

--- a/src/en/hstream/src/eu/kanade/tachiyomi/animeextension/en/hstream/Hstream.kt
+++ b/src/en/hstream/src/eu/kanade/tachiyomi/animeextension/en/hstream/Hstream.kt
@@ -18,13 +18,11 @@ import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonRequestBody
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import uy.kohesive.injekt.injectLazy
 import java.net.URLDecoder
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -40,8 +38,6 @@ class Hstream :
     override val lang = "en"
 
     override val supportsLatest = true
-
-    private val json: Json by injectLazy()
 
     // URLs from the old extension are invalid now, so we're bumping this to
     // make aniyomi interpret it as a new source, forcing old users to migrate.
@@ -75,13 +71,25 @@ class Hstream :
     // =============================== Search ===============================
     override fun getFilterList() = HstreamFilters.FILTER_LIST
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/hentai/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/hentai/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/en/hstream/src/eu/kanade/tachiyomi/animeextension/en/hstream/HstreamUrlActivity.kt
+++ b/src/en/hstream/src/eu/kanade/tachiyomi/animeextension/en/hstream/HstreamUrlActivity.kt
@@ -17,22 +17,17 @@ class HstreamUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Hstream.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'KickAssAnime'
     extClass = '.KickAssAnime'
-    extVersionCode = 59
+    extVersionCode = 60
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -273,7 +273,7 @@ class KickAssAnime :
     override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
         if (query.startsWith("https://")) {
             val url = query.toHttpUrl()
-            if (url.host != baseUrl.toHttpUrl().host) {
+            if (url.host != PREF_DOMAIN_DEFAULT.toHttpUrl().host) {
                 throw Exception("Unsupported url")
             }
             val slug = url.pathSegments.getOrNull(0)?.takeIf(String::isNotBlank)

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -270,14 +270,24 @@ class KickAssAnime :
         }
     }
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val slug = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$SEARCH_BASE_URL/api/show/$slug"))
-            .awaitSuccess()
-            .use(::searchAnimeBySlugParse)
-    } else {
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments.getOrNull(0)?.takeIf(String::isNotBlank)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$slug", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val slug = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$SEARCH_BASE_URL/api/show/$slug"))
+                .awaitSuccess()
+                .use(::searchAnimeBySlugParse)
+        }
         val params = KickAssAnimeFilters.getSearchParameters(filters)
-        client.newCall(searchAnimeRequest(page, query, params))
+        return client.newCall(searchAnimeRequest(page, query, params))
             .awaitSuccess()
             .use { response ->
                 searchAnimeParse(response, page)

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnimeUrlActivity.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnimeUrlActivity.kt
@@ -17,22 +17,17 @@ class KickAssAnimeUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 1) {
-            val slug = pathSegments[0]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${KickAssAnime.PREFIX_SEARCH}$slug")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/miruro/build.gradle
+++ b/src/en/miruro/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'Miruro.tv'
     extClass = '.Miruro'
     isNsfw = true
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/miruro/src/eu/kanade/tachiyomi/animeextension/en/miruro/Miruro.kt
+++ b/src/en/miruro/src/eu/kanade/tachiyomi/animeextension/en/miruro/Miruro.kt
@@ -162,6 +162,19 @@ class Miruro :
     // ============================== Search ===============================
 
     override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.getOrNull(0) != "watch") {
+                throw Exception("Unsupported url")
+            }
+            val anilistId = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$anilistId", filters)
+        }
+
         if (query.startsWith(PREFIX_SEARCH)) {
             val anilistId = query.removePrefix(PREFIX_SEARCH)
             val request = buildPipeRequest("info/$anilistId", "GET")

--- a/src/en/miruro/src/eu/kanade/tachiyomi/animeextension/en/miruro/MiruroUrlActivity.kt
+++ b/src/en/miruro/src/eu/kanade/tachiyomi/animeextension/en/miruro/MiruroUrlActivity.kt
@@ -17,24 +17,17 @@ class MiruroUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size >= 2 && pathSegments[0] == "watch") {
-            // URL format: https://miruro.tv/watch/{anilistId}/{slug}
-            // pathSegments[0] = "watch", pathSegments[1] = anilistId
-            val anilistId = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Miruro.PREFIX_SEARCH}$anilistId")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/myrunningman/build.gradle
+++ b/src/en/myrunningman/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'My Running Man'
     extClass = '.MyRunningMan'
-    extVersionCode = 11
+    extVersionCode = 12
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/myrunningman/src/eu/kanade/tachiyomi/animeextension/en/myrunningman/MyRunningMan.kt
+++ b/src/en/myrunningman/src/eu/kanade/tachiyomi/animeextension/en/myrunningman/MyRunningMan.kt
@@ -15,11 +15,10 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -32,8 +31,6 @@ class MyRunningMan : ParsedAnimeHttpSource() {
     override val lang = "en"
 
     override val supportsLatest = true
-
-    private val json: Json by injectLazy()
 
     // ============================== Popular ===============================
     override fun popularAnimeRequest(page: Int) = GET("$baseUrl/episodes/mostwatched/$page")
@@ -61,13 +58,25 @@ class MyRunningMan : ParsedAnimeHttpSource() {
     override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/ep/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/ep/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -91,7 +100,7 @@ class MyRunningMan : ParsedAnimeHttpSource() {
                 title = it.label
                 thumbnail_url = buildString {
                     append("$baseUrl/assets/epimg/${it.value.padStart(3, '0')}")
-                    if (it.value.toIntOrNull() ?: 1 > 396) append("_temp")
+                    if ((it.value.toIntOrNull() ?: 1) > 396) append("_temp")
                     append(".jpg")
                 }
             }

--- a/src/en/myrunningman/src/eu/kanade/tachiyomi/animeextension/en/myrunningman/MyRunningManUrlActivity.kt
+++ b/src/en/myrunningman/src/eu/kanade/tachiyomi/animeextension/en/myrunningman/MyRunningManUrlActivity.kt
@@ -17,22 +17,17 @@ class MyRunningManUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${MyRunningMan.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/en/rule34video/build.gradle
+++ b/src/en/rule34video/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Rule34Video'
     extClass = '.Rule34Video'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34Video.kt
+++ b/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34Video.kt
@@ -7,6 +7,7 @@ import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import eu.kanade.tachiyomi.animesource.model.AnimesPage
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
@@ -14,6 +15,7 @@ import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -76,6 +78,19 @@ class Rule34Video :
 
     // =============================== Search ===============================
     private inline fun <reified R> AnimeFilterList.getUriPart() = (find { it is R } as? UriPartFilter)?.toUriPart() ?: ""
+
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val slug = url.pathSegments.getOrNull(2)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$slug", filters)
+        }
+        return super.getSearchAnime(page, query, filters)
+    }
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val orderFilter = filters.getUriPart<OrderFilter>()
@@ -246,7 +261,6 @@ class Rule34Video :
             title = "Uploader ID"
             summary = "Enter the ID of the uploader (e.g., 98965). Requires \"Filter by Uploader\" to be enabled."
             dialogTitle = "Enter Uploader ID"
-            var dependency = PREF_UPLOADER_FILTER_ENABLED_KEY
             setOnPreferenceChangeListener { _, newValue ->
                 newValue?.toString().isNullOrBlank().not()
             }

--- a/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34VideoUrlActivity.kt
+++ b/src/en/rule34video/src/eu/kanade/tachiyomi/animeextension/en/rule34video/Rule34VideoUrlActivity.kt
@@ -13,22 +13,17 @@ class Rule34VideoUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val slug = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Rule34Video.PREFIX_SEARCH}$slug")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/es/azanimex/build.gradle
+++ b/src/es/azanimex/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'az-animex'
     extClass = '.Azanimex'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/es/azanimex/src/eu/kanade/tachiyomi/animeextension/es/azanimex/Azanimex.kt
+++ b/src/es/azanimex/src/eu/kanade/tachiyomi/animeextension/es/azanimex/Azanimex.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.animeextension.es.azanimex
 
 import android.util.Log
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import eu.kanade.tachiyomi.animesource.model.AnimesPage
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
@@ -9,6 +10,7 @@ import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -186,6 +188,22 @@ class Azanimex : ParsedAnimeHttpSource() {
 
     override fun searchAnimeSelector(): String = popularAnimeSelector()
 
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        } else if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return super.getSearchAnime(page, id, filters)
+        }
+        return super.getSearchAnime(page, query, filters)
+    }
+
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val url = if (page > 1) {
             "$baseUrl/page/$page/?s=$query"
@@ -216,7 +234,7 @@ class Azanimex : ParsedAnimeHttpSource() {
 
     override fun latestUpdatesFromElement(element: Element): SAnime = throw UnsupportedOperationException()
 
-    override fun latestUpdatesNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
 
     companion object {
         const val PREFIX_SEARCH = "id:"

--- a/src/es/azanimex/src/eu/kanade/tachiyomi/animeextension/es/azanimex/AzanimexUrlActivity.kt
+++ b/src/es/azanimex/src/eu/kanade/tachiyomi/animeextension/es/azanimex/AzanimexUrlActivity.kt
@@ -17,22 +17,17 @@ class AzanimexUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Azanimex.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/es/ennovelas/src/eu/kanade/tachiyomi/animeextension/es/ennovelas/EnNovelas.kt
+++ b/src/es/ennovelas/src/eu/kanade/tachiyomi/animeextension/es/ennovelas/EnNovelas.kt
@@ -203,7 +203,7 @@ class EnNovelas :
     }
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
         val id = query.removePrefix(PREFIX_SEARCH)
         client.newCall(GET("$baseUrl/search/$id", headers))
             .awaitSuccess()

--- a/src/es/hackstore/build.gradle
+++ b/src/es/hackstore/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hackstore'
     extClass = '.Hackstore'
-    extVersionCode = 37
+    extVersionCode = 38
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/Hackstore.kt
+++ b/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/Hackstore.kt
@@ -14,6 +14,7 @@ import aniyomi.lib.voeextractor.VoeExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import eu.kanade.tachiyomi.animesource.model.AnimesPage
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
@@ -25,6 +26,7 @@ import keiyoushi.utils.bodyString
 import keiyoushi.utils.catchingFlatMapBlocking
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -116,6 +118,22 @@ class Hackstore :
     override fun searchAnimeNextPageSelector(): String = popularAnimeNextPageSelector()
 
     override fun searchAnimeSelector(): String = popularAnimeSelector()
+
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        } else if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return super.getSearchAnime(page, id, filters)
+        }
+        return super.getSearchAnime(page, query, filters)
+    }
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val filterList = if (filters.isEmpty()) getFilterList() else filters

--- a/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/HackstoreUrlActivity.kt
+++ b/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/HackstoreUrlActivity.kt
@@ -17,22 +17,17 @@ class HackstoreUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Hackstore.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/es/verseriesonline/build.gradle
+++ b/src/es/verseriesonline/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'VerSeriesOnline'
     extClass = '.VerSeriesOnline'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/es/verseriesonline/src/eu/kanade/tachiyomi/animeextension/es/verseriesonline/VerSeriesOnline.kt
+++ b/src/es/verseriesonline/src/eu/kanade/tachiyomi/animeextension/es/verseriesonline/VerSeriesOnline.kt
@@ -25,6 +25,7 @@ import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.useAsJsoup
 import okhttp3.Cookie
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONObject
@@ -68,12 +69,22 @@ class VerSeriesOnline :
 
     override fun latestUpdatesNextPageSelector(): String = throw UnsupportedOperationException()
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/recherche?q=$id", headers))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/recherche?q=$id", headers))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
         val url = buildSearchUrl(query, page, filters)
         val document = client.newCall(GET(url, headers)).awaitSuccess().useAsJsoup()
         val animeList = document.select(searchAnimeSelector()).map { element ->
@@ -83,7 +94,7 @@ class VerSeriesOnline :
             document.select(it).isNotEmpty()
         }
 
-        AnimesPage(animeList, hasNextPage)
+        return AnimesPage(animeList, hasNextPage)
     }
 
     private fun buildSearchUrl(query: String, page: Int, filters: AnimeFilterList): String {

--- a/src/es/verseriesonline/src/eu/kanade/tachiyomi/animeextension/es/verseriesonline/VerSeriesOnlineUrlActivity.kt
+++ b/src/es/verseriesonline/src/eu/kanade/tachiyomi/animeextension/es/verseriesonline/VerSeriesOnlineUrlActivity.kt
@@ -17,22 +17,17 @@ class VerSeriesOnlineUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${VerSeriesOnline.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime-Sama'
     extClass = '.AnimeSama'
-    extVersionCode = 25
+    extVersionCode = 26
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -116,6 +116,24 @@ class AnimeSama :
     // =============================== Search ===============================
     override fun getFilterList() = AnimeSamaFilters.FILTER_LIST
 
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        } else if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            val animeUrl = if (id.startsWith("/")) "$baseUrl$id" else "$baseUrl/$id"
+            val seasons = fetchAnimeSeasons(animeUrl)
+            return AnimesPage(seasons, false)
+        }
+        return super.getSearchAnime(page, query, filters)
+    }
+
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val url = "$baseUrl/catalogue/".toHttpUrl().newBuilder()
         val params = AnimeSamaFilters.getSearchFilters(filters)

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSamaUrlActivity.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSamaUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimeSamaUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimeSama.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/fr/anisama/build.gradle
+++ b/src/fr/anisama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniSama'
     extClass = '.AniSama'
-    extVersionCode = 22
+    extVersionCode = 23
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
+++ b/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
@@ -85,11 +85,23 @@ class AniSama :
     // =============================== Search ===============================
     override fun getFilterList() = aniSamaFilters.getFilterList()
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id")).awaitSuccess().use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id")).awaitSuccess().use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSamaUrlActivity.kt
+++ b/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSamaUrlActivity.kt
@@ -17,22 +17,17 @@ class AniSamaUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AniSama.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/fr/franime/build.gradle
+++ b/src/fr/franime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'FRAnime'
     extClass = '.FrAnime'
-    extVersionCode = 25
+    extVersionCode = 26
     isNsfw = true
 }
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/fr/franime/src/eu/kanade/tachiyomi/animeextension/fr/franime/FrAnime.kt
+++ b/src/fr/franime/src/eu/kanade/tachiyomi/animeextension/fr/franime/FrAnime.kt
@@ -63,6 +63,16 @@ class FrAnime : AnimeHttpSource() {
 
     // =============================== Search ===============================
     override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, id, filters)
+        }
+
         val pages = database.filter {
             it.title.contains(query, true) ||
                 it.originalTitle.contains(query, true) ||

--- a/src/fr/franime/src/eu/kanade/tachiyomi/animeextension/fr/franime/FrAnimeUrlActivity.kt
+++ b/src/fr/franime/src/eu/kanade/tachiyomi/animeextension/fr/franime/FrAnimeUrlActivity.kt
@@ -13,21 +13,19 @@ class FrAnimeUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size == 2) {
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", pathSegments[1])
-                putExtra("filter", packageName)
-            }
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
         }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
+        }
+
         finish()
         exitProcess(0)
     }

--- a/src/id/nimegami/build.gradle
+++ b/src/id/nimegami/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NimeGami'
     extClass = '.NimeGami'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/id/nimegami/src/eu/kanade/tachiyomi/animeextension/id/nimegami/NimeGami.kt
+++ b/src/id/nimegami/src/eu/kanade/tachiyomi/animeextension/id/nimegami/NimeGami.kt
@@ -15,6 +15,7 @@ import keiyoushi.lib.jsunpacker.JsUnpacker
 import keiyoushi.utils.parallelFlatMapBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -62,13 +63,25 @@ class NimeGami : ParsedAnimeHttpSource() {
     override fun latestUpdatesNextPageSelector() = "ul.pagination > li > a:contains(Next)"
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.firstOrNull()?.takeIf(String::isNotBlank)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -152,7 +165,7 @@ class NimeGami : ParsedAnimeHttpSource() {
                     extractVideos(url, quality, episodeIndex)
                 }.getOrElse { emptyList() }
             }.flatten()
-        }.let { it }
+        }
     }
 
     private fun extractVideos(url: String, quality: String, episodeIndex: Int): List<Video> = with(url) {

--- a/src/id/nimegami/src/eu/kanade/tachiyomi/animeextension/id/nimegami/NimeGamiUrlActivity.kt
+++ b/src/id/nimegami/src/eu/kanade/tachiyomi/animeextension/id/nimegami/NimeGamiUrlActivity.kt
@@ -17,22 +17,17 @@ class NimeGamiUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size == 1) {
-            val item = pathSegments.first()
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${NimeGami.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/it/aniplay/build.gradle
+++ b/src/it/aniplay/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniPlay'
     extClass = '.AniPlay'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
+++ b/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
@@ -69,13 +69,25 @@ class AniPlay :
     // =============================== Search ===============================
     override fun getFilterList() = AniPlayFilters.FILTER_LIST
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/series/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/series/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -221,7 +233,7 @@ class AniPlay :
 
         private const val API_URL = "https://api.aniplay.co/api/series"
 
-        private val WRONG_KEY_REGEX by lazy { Regex("([a-zA-Z_]+):\\s?([\"|0-9|f|t|n|\\[|\\{])") }
+        private val WRONG_KEY_REGEX by lazy { Regex("""([a-zA-Z_]+):\s?(["0-9ftn\[{]+)""") }
 
         private val DATE_FORMATTER by lazy {
             SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)

--- a/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlayUrlActivity.kt
+++ b/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlayUrlActivity.kt
@@ -17,22 +17,17 @@ class AniPlayUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AniPlay.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animefire/build.gradle
+++ b/src/pt/animefire/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime Fire'
     extClass = '.AnimeFire'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AFUrlActivity.kt
+++ b/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AFUrlActivity.kt
@@ -17,23 +17,17 @@ class AFUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val id = pathSegments[1]
-            val searchQuery = AnimeFire.PREFIX_SEARCH + id
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", searchQuery)
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AnimeFire.kt
+++ b/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AnimeFire.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -72,13 +73,25 @@ class AnimeFire :
     override fun latestUpdatesNextPageSelector() = "ul.pagination img.seta-right"
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/animes/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/animes/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/pt/animeq/build.gradle
+++ b/src/pt/animeq/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeQ'
     extClass = '.AnimeQ'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/pt/animeq/src/eu/kanade/tachiyomi/animeextension/pt/animeq/AnimeQ.kt
+++ b/src/pt/animeq/src/eu/kanade/tachiyomi/animeextension/pt/animeq/AnimeQ.kt
@@ -67,13 +67,25 @@ class AnimeQ :
     override fun latestUpdatesNextPageSelector() = "div.ContainerEps a.next.page-numbers"
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(0)?.takeIf(String::isNotBlank)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -145,8 +157,8 @@ class AnimeQ :
         val document = response.asJsoup()
 
         return document.select("div.videoBox div.aba")
-            .parallelCatchingFlatMapBlocking {
-                val format = document.selectFirst("a[href=#" + it.attr("id") + "]")?.text()
+            .parallelCatchingFlatMapBlocking { div ->
+                val format = document.selectFirst("a[href=#" + div.attr("id") + "]")?.text()
                     ?: "default"
 
                 val quality = when (format) {
@@ -155,21 +167,21 @@ class AnimeQ :
                     "FHD" -> "1080p"
                     else -> format
                 }
-                val iframeSrc = it.selectFirst("iframe")?.tryGetAttr("data-litespeed-src", "src")
+                val iframeSrc = div.selectFirst("iframe")?.tryGetAttr("data-litespeed-src", "src")
                 if (!iframeSrc.isNullOrBlank()) {
                     return@parallelCatchingFlatMapBlocking getVideosFromURL(iframeSrc, quality)
                 }
-                it.select("script").mapNotNull {
-                    var javascript = it.attr("src")
-                        ?.substringAfter(";base64,")
-                        ?.substringBefore('"')
-                        ?.let { String(Base64.decode(it, Base64.DEFAULT)) }
+                div.select("script").mapNotNull { script ->
+                    var javascript = script.attr("src")
+                        .substringAfter(";base64,")
+                        .substringBefore('"')
+                        .let { String(Base64.decode(it, Base64.DEFAULT)) }
 
-                    if (javascript.isNullOrBlank()) {
-                        javascript = it.data()
+                    if (javascript.isBlank()) {
+                        javascript = script.data()
                     }
 
-                    if (javascript.isNullOrBlank() || "file:" !in javascript) {
+                    if (javascript.isBlank() || "file:" !in javascript) {
                         return@mapNotNull null
                     }
 
@@ -247,8 +259,8 @@ class AnimeQ :
     }
 
     private fun Element.tryGetAttr(vararg attributeKeys: String): String? {
-        val attributeKey = attributeKeys.first { hasAttr(it) }
-        return attributeKey?.let { attr(attributeKey) }
+        val attributeKey = attributeKeys.firstOrNull { hasAttr(it) }
+        return attributeKey?.let { attr(it) }
     }
 
     companion object {

--- a/src/pt/animeq/src/eu/kanade/tachiyomi/animeextension/pt/animeq/AnimeQUrlActivity.kt
+++ b/src/pt/animeq/src/eu/kanade/tachiyomi/animeextension/pt/animeq/AnimeQUrlActivity.kt
@@ -17,23 +17,17 @@ class AnimeQUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val searchQuery = pathSegments[0]
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimeQ.PREFIX_SEARCH}$searchQuery")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animescx/build.gradle
+++ b/src/pt/animescx/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animes CX'
     extClass = '.AnimesCX'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/pt/animescx/src/eu/kanade/tachiyomi/animeextension/pt/animescx/AnimesCX.kt
+++ b/src/pt/animescx/src/eu/kanade/tachiyomi/animeextension/pt/animescx/AnimesCX.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArrayBuilder
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.putJsonArray
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -62,7 +63,7 @@ class AnimesCX :
         thumbnail_url = element.selectFirst("img")?.absUrl("src")
     }
 
-    override fun popularAnimeNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun popularAnimeNextPageSelector() = throw UnsupportedOperationException()
 
     // =============================== Latest ===============================
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/doramas-em-lancamento/page/$page", headers)
@@ -73,16 +74,28 @@ class AnimesCX :
 
     override fun latestUpdatesFromElement(element: Element): SAnime = throw UnsupportedOperationException()
 
-    override fun latestUpdatesNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun latestUpdatesNextPageSelector() = throw UnsupportedOperationException()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path", headers))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val path = url.pathSegments.takeIf { it.isNotEmpty() }?.joinToString("/")
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$path", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path", headers))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/pt/animescx/src/eu/kanade/tachiyomi/animeextension/pt/animescx/AnimesCXUrlActivity.kt
+++ b/src/pt/animescx/src/eu/kanade/tachiyomi/animeextension/pt/animescx/AnimesCXUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimesCXUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val path = pathSegments.joinToString("/")
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimesCX.PREFIX_SEARCH}$path")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animesdigital/build.gradle
+++ b/src/pt/animesdigital/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animes Digital'
     extClass = '.AnimesDigital'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigital.kt
+++ b/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigital.kt
@@ -66,13 +66,25 @@ class AnimesDigital :
     // =============================== Search ===============================
     override fun getFilterList() = AnimesDigitalFilters.FILTER_LIST
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/a/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(2)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/a/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -136,7 +148,7 @@ class AnimesDigital :
         val total_page: Int,
     )
 
-    override fun searchAnimeNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun searchAnimeNextPageSelector() = throw UnsupportedOperationException()
 
     // =========================== Anime Details ============================
     override fun animeDetailsParse(document: Document) = SAnime.create().apply {

--- a/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigitalUrlActivity.kt
+++ b/src/pt/animesdigital/src/eu/kanade/tachiyomi/animeextension/pt/animesdigital/AnimesDigitalUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimesDigitalUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val item = pathSegments[2]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimesDigital.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animesgames/build.gradle
+++ b/src/pt/animesgames/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animes Games'
     extClass = '.AnimesGames'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/animesgames/src/eu/kanade/tachiyomi/animeextension/pt/animesgames/AnimesGames.kt
+++ b/src/pt/animesgames/src/eu/kanade/tachiyomi/animeextension/pt/animesgames/AnimesGames.kt
@@ -13,7 +13,6 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -21,7 +20,6 @@ import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -38,8 +36,6 @@ class AnimesGames : ParsedAnimeHttpSource() {
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", baseUrl)
         .add("Origin", baseUrl)
-
-    private val json: Json by injectLazy()
 
     // ============================== Popular ===============================
     override fun popularAnimeRequest(page: Int) = GET(baseUrl)
@@ -67,13 +63,25 @@ class AnimesGames : ParsedAnimeHttpSource() {
     override fun latestUpdatesNextPageSelector() = "ol.pagination > a:contains(>)"
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/animes/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/animes/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -143,7 +151,7 @@ class AnimesGames : ParsedAnimeHttpSource() {
         thumbnail_url = element.selectFirst("img")!!.getImageUrl()
     }
 
-    override fun searchAnimeNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun searchAnimeNextPageSelector() = throw UnsupportedOperationException()
 
     // =========================== Anime Details ============================
     override fun animeDetailsParse(document: Document) = SAnime.create().apply {
@@ -260,7 +268,7 @@ class AnimesGames : ParsedAnimeHttpSource() {
      * Tries to get the image url via various possible attributes.
      * Taken from Tachiyomi's Madara multisrc.
      */
-    protected open fun Element.getImageUrl(): String? = when {
+    private fun Element.getImageUrl(): String = when {
         hasAttr("data-src") -> attr("abs:data-src")
         hasAttr("data-lazy-src") -> attr("abs:data-lazy-src")
         hasAttr("srcset") -> attr("abs:srcset").substringBefore(" ")

--- a/src/pt/animesgames/src/eu/kanade/tachiyomi/animeextension/pt/animesgames/AnimesGamesUrlActivity.kt
+++ b/src/pt/animesgames/src/eu/kanade/tachiyomi/animeextension/pt/animesgames/AnimesGamesUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimesGamesUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimesGames.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animesonlinevip/build.gradle
+++ b/src/pt/animesonlinevip/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimesOnlineVip'
     extClass = '.AnimesOnlineVip'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/pt/animesonlinevip/src/eu/kanade/tachiyomi/animeextension/pt/animesonlinevip/AnimesOnlineVip.kt
+++ b/src/pt/animesonlinevip/src/eu/kanade/tachiyomi/animeextension/pt/animesonlinevip/AnimesOnlineVip.kt
@@ -65,13 +65,29 @@ class AnimesOnlineVip :
         page: Int,
         query: String,
         filters: AnimeFilterList,
-    ): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    ): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val searchQuery = if (url.pathSegments.size > 1) {
+                "${url.pathSegments[0]}/${url.pathSegments[1]}"
+            } else {
+                url.pathSegments.getOrNull(0)?.takeIf(String::isNotBlank)
+                    ?: throw Exception("Unsupported url")
+            }
+            return getSearchAnime(page, "${PREFIX_SEARCH}$searchQuery", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/pt/animesonlinevip/src/eu/kanade/tachiyomi/animeextension/pt/animesonlinevip/AnimesOnlineVipUrlActivity.kt
+++ b/src/pt/animesonlinevip/src/eu/kanade/tachiyomi/animeextension/pt/animesonlinevip/AnimesOnlineVipUrlActivity.kt
@@ -17,27 +17,17 @@ class AnimesOnlineVipUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val searchQuery = if (pathSegments.size > 1) {
-                "${pathSegments[0]}/${pathSegments[1]}"
-            } else {
-                pathSegments[0]
-            }
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimesOnlineVip.PREFIX_SEARCH}$searchQuery")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animesotaku/build.gradle
+++ b/src/pt/animesotaku/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeCore'
     extClass = '.AnimeCore'
-    extVersionCode = 4
+    extVersionCode = 5
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/animesotaku/src/eu/kanade/tachiyomi/animeextension/pt/animesotaku/AnimeCore.kt
+++ b/src/pt/animesotaku/src/eu/kanade/tachiyomi/animeextension/pt/animesotaku/AnimeCore.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -67,13 +68,25 @@ class AnimeCore : AnimeHttpSource() {
         page: Int,
         query: String,
         filters: AnimeFilterList,
-    ): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    ): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/pt/animesotaku/src/eu/kanade/tachiyomi/animeextension/pt/animesotaku/AnimeCoreUrlActivity.kt
+++ b/src/pt/animesotaku/src/eu/kanade/tachiyomi/animeextension/pt/animesotaku/AnimeCoreUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimeCoreUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimeCore.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/animesroll/build.gradle
+++ b/src/pt/animesroll/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimesROLL'
     extClass = '.AnimesROLL'
-    extVersionCode = 5
+    extVersionCode = 6
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/animesroll/src/eu/kanade/tachiyomi/animeextension/pt/animesroll/AnimesROLL.kt
+++ b/src/pt/animesroll/src/eu/kanade/tachiyomi/animeextension/pt/animesroll/AnimesROLL.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -65,14 +66,29 @@ class AnimesROLL : AnimeHttpSource() {
         return AnimesPage(listOf(details), false)
     }
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path"))
-            .awaitSuccess()
-            .use(::searchAnimeByPathParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            val path = "${url.pathSegments[0]}/${url.pathSegments[1]}"
+            return getSearchAnime(page, "${PREFIX_SEARCH}$path", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path"))
+                .awaitSuccess()
+                .use(::searchAnimeByPathParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
+
     override fun searchAnimeParse(response: Response): AnimesPage {
         val results = response.parseAs<SearchResultsDto>()
         val animes = (results.animes + results.movies).map { it.toSAnime() }
@@ -116,7 +132,7 @@ class AnimesROLL : AnimeHttpSource() {
         } else {
             val anime = doc.parseAs<AnimeDataDto>()
 
-            return fetchEpisodesRecursively(anime.id).map { episode ->
+            fetchEpisodesRecursively(anime.id).map { episode ->
                 val urlStart = if (episode.sePgad == 1) {
                     "https://cdn-zenitsu-2-gamabunta.b-cdn.net/cf/hls/animes/${anime.slug}"
                 } else {

--- a/src/pt/animesroll/src/eu/kanade/tachiyomi/animeextension/pt/animesroll/AnimesROLLUrlActivity.kt
+++ b/src/pt/animesroll/src/eu/kanade/tachiyomi/animeextension/pt/animesroll/AnimesROLLUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimesROLLUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val path = "${pathSegments[0]}/${pathSegments[1]}"
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimesROLL.PREFIX_SEARCH}$path")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/anitube/build.gradle
+++ b/src/pt/anitube/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anitube'
     extClass = '.Anitube'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/Anitube.kt
+++ b/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/Anitube.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -83,13 +84,27 @@ class Anitube :
         page: Int,
         query: String,
         filters: AnimeFilterList,
-    ): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    ): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            if (url.pathSegments.size < 2) {
+                throw Exception("Unsupported url")
+            }
+            val path = "${url.pathSegments[0]}/${url.pathSegments[1]}"
+            return getSearchAnime(page, "${PREFIX_SEARCH}$path", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -196,7 +211,7 @@ class Anitube :
 
         val links = mutableListOf(document.location())
 
-        if (preferences.getBoolean(PREF_FILE4GO_KEY, PREF_FILE4GO_DEFAULT)!!) {
+        if (preferences.getBoolean(PREF_FILE4GO_KEY, PREF_FILE4GO_DEFAULT)) {
             document.selectFirst("div.abaItemDown > a")?.attr("href")?.let {
                 links.add(it)
             }

--- a/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/AnitubeUrlActivity.kt
+++ b/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/AnitubeUrlActivity.kt
@@ -17,23 +17,17 @@ class AnitubeUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val searchQuery = "${pathSegments[0]}/${pathSegments[1]}"
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Anitube.PREFIX_SEARCH}$searchQuery")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/betteranime/build.gradle
+++ b/src/pt/betteranime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Better Anime'
     extClass = '.BetterAnime'
-    extVersionCode = 12
+    extVersionCode = 13
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BAUrlActivity.kt
+++ b/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BAUrlActivity.kt
@@ -17,25 +17,17 @@ class BAUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 2) {
-            val type = pathSegments[0]
-            val lang = pathSegments[1]
-            val item = pathSegments[2]
-            val searchQuery = "$type/$lang/$item"
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${BetterAnime.PREFIX_SEARCH_PATH}$searchQuery")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BetterAnime.kt
+++ b/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BetterAnime.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -85,13 +86,30 @@ class BetterAnime :
     // =============================== Search ===============================
     override fun getFilterList() = BAFilters.FILTER_LIST
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH_PATH)) {
-        val path = query.removePrefix(PREFIX_SEARCH_PATH)
-        client.newCall(GET("$baseUrl/$path", headers))
-            .awaitSuccess()
-            .use(::searchAnimeByPathParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val type = url.pathSegments.getOrNull(0)
+                ?: throw Exception("Unsupported url")
+            val lang = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            val item = url.pathSegments.getOrNull(2)
+                ?: throw Exception("Unsupported url")
+            val searchQuery = "$type/$lang/$item"
+            return getSearchAnime(page, "${PREFIX_SEARCH_PATH}$searchQuery", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH_PATH)) {
+            val path = query.removePrefix(PREFIX_SEARCH_PATH)
+            return client.newCall(GET("$baseUrl/$path", headers))
+                .awaitSuccess()
+                .use(::searchAnimeByPathParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByPathParse(response: Response): AnimesPage {

--- a/src/pt/donghuanosekai/build.gradle
+++ b/src/pt/donghuanosekai/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Donghua no Sekai'
     extClass = '.DonghuaNoSekai'
-    extVersionCode = 3
+    extVersionCode = 4
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/donghuanosekai/src/eu/kanade/tachiyomi/animeextension/pt/donghuanosekai/DonghuaNoSekai.kt
+++ b/src/pt/donghuanosekai/src/eu/kanade/tachiyomi/animeextension/pt/donghuanosekai/DonghuaNoSekai.kt
@@ -19,7 +19,6 @@ import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -27,7 +26,6 @@ import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -46,8 +44,6 @@ class DonghuaNoSekai :
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", baseUrl)
         .add("Origin", baseUrl)
-
-    private val json: Json by injectLazy()
 
     private val preferences by getPreferencesLazy()
 
@@ -78,13 +74,25 @@ class DonghuaNoSekai :
     override fun latestUpdatesNextPageSelector() = "ul.content-pagination > li.next"
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -152,7 +160,7 @@ class DonghuaNoSekai :
 
     override fun searchAnimeFromElement(element: Element) = latestUpdatesFromElement(element)
 
-    override fun searchAnimeNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun searchAnimeNextPageSelector() = throw UnsupportedOperationException()
 
     // =========================== Anime Details ============================
     override fun animeDetailsParse(document: Document) = SAnime.create().apply {

--- a/src/pt/donghuanosekai/src/eu/kanade/tachiyomi/animeextension/pt/donghuanosekai/DonghuaNoSekaiUrlActivity.kt
+++ b/src/pt/donghuanosekai/src/eu/kanade/tachiyomi/animeextension/pt/donghuanosekai/DonghuaNoSekaiUrlActivity.kt
@@ -17,22 +17,17 @@ class DonghuaNoSekaiUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${DonghuaNoSekai.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/doramogo/build.gradle
+++ b/src/pt/doramogo/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Doramogo'
     extClass = '.Doramogo'
-    extVersionCode = 16
+    extVersionCode = 17
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/doramogo/src/eu/kanade/tachiyomi/animeextension/pt/doramogo/Doramogo.kt
+++ b/src/pt/doramogo/src/eu/kanade/tachiyomi/animeextension/pt/doramogo/Doramogo.kt
@@ -59,13 +59,25 @@ class Doramogo : ParsedAnimeHttpSource() {
     override fun latestUpdatesNextPageSelector() = null
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/dorama/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/dorama/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/pt/doramogo/src/eu/kanade/tachiyomi/animeextension/pt/doramogo/DoramogoUrlActivity.kt
+++ b/src/pt/doramogo/src/eu/kanade/tachiyomi/animeextension/pt/doramogo/DoramogoUrlActivity.kt
@@ -17,22 +17,17 @@ class DoramogoUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Doramogo.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/goyabu/build.gradle
+++ b/src/pt/goyabu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Goyabu'
     extClass = '.Goyabu'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = true
 }
 

--- a/src/pt/goyabu/src/eu/kanade/tachiyomi/animeextension/pt/goyabu/Goyabu.kt
+++ b/src/pt/goyabu/src/eu/kanade/tachiyomi/animeextension/pt/goyabu/Goyabu.kt
@@ -62,13 +62,29 @@ class Goyabu :
     override fun latestUpdatesNextPageSelector(): String? = null
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) {
-        val path = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$path"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val searchQuery = if (url.pathSegments.size > 1) {
+                "${url.pathSegments[0]}/${url.pathSegments[1]}"
+            } else {
+                url.pathSegments.getOrNull(0)?.takeIf(String::isNotBlank)
+                    ?: throw Exception("Unsupported url")
+            }
+            return getSearchAnime(page, "${PREFIX_SEARCH}$searchQuery", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val path = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$path"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -103,7 +119,7 @@ class Goyabu :
             title = doc.selectFirst("div.animeInfos h1")!!.text()
             thumbnail_url = doc.selectFirst("div.animecapa img")?.attr("src")
             description = doc.selectFirst("div.sinopse")?.text()
-            genre = doc.select("ul.genres li").eachText()?.joinToString(", ")
+            genre = doc.select("ul.genres li").eachText().joinToString(", ")
         }
     }
 

--- a/src/pt/goyabu/src/eu/kanade/tachiyomi/animeextension/pt/goyabu/GoyabuUrlActivity.kt
+++ b/src/pt/goyabu/src/eu/kanade/tachiyomi/animeextension/pt/goyabu/GoyabuUrlActivity.kt
@@ -17,27 +17,17 @@ class GoyabuUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val searchQuery = if (pathSegments.size > 1) {
-                "${pathSegments[0]}/${pathSegments[1]}"
-            } else {
-                pathSegments[0]
-            }
 
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Goyabu.PREFIX_SEARCH}$searchQuery")
-                putExtra("filter", packageName)
-            }
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/pt/hentaistube/build.gradle
+++ b/src/pt/hentaistube/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HentaisTube'
     extClass = '.HentaisTube'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/pt/hentaistube/src/eu/kanade/tachiyomi/animeextension/pt/hentaistube/HentaisTube.kt
+++ b/src/pt/hentaistube/src/eu/kanade/tachiyomi/animeextension/pt/hentaistube/HentaisTube.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -78,12 +79,22 @@ class HentaisTube :
             .asSequence()
     }
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(0)?.takeIf(String::isNotBlank)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
         val params = HentaisTubeFilters.getSearchParameters(filters).apply {
             animeName = query
         }
@@ -101,7 +112,7 @@ class HentaisTube :
                 }
             }
         }
-        AnimesPage(currentPage, hasNextPage)
+        return AnimesPage(currentPage, hasNextPage)
     }
 
     override fun getFilterList(): AnimeFilterList = HentaisTubeFilters.FILTER_LIST
@@ -121,7 +132,7 @@ class HentaisTube :
 
     override fun searchAnimeFromElement(element: Element): SAnime = throw UnsupportedOperationException()
 
-    override fun searchAnimeNextPageSelector(): String? = throw UnsupportedOperationException()
+    override fun searchAnimeNextPageSelector() = throw UnsupportedOperationException()
 
     // =========================== Anime Details ============================
     override fun animeDetailsParse(document: Document) = SAnime.create().apply {

--- a/src/pt/hentaistube/src/eu/kanade/tachiyomi/animeextension/pt/hentaistube/HentaisTubeUrlActivity.kt
+++ b/src/pt/hentaistube/src/eu/kanade/tachiyomi/animeextension/pt/hentaistube/HentaisTubeUrlActivity.kt
@@ -17,22 +17,17 @@ class HentaisTubeUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val item = pathSegments[0]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${HentaisTube.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/sr/animesrbija/build.gradle
+++ b/src/sr/animesrbija/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime Srbija'
     extClass = '.AnimeSrbija'
-    extVersionCode = 19
+    extVersionCode = 20
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/sr/animesrbija/src/eu/kanade/tachiyomi/animeextension/sr/animesrbija/AnimeSrbija.kt
+++ b/src/sr/animesrbija/src/eu/kanade/tachiyomi/animeextension/sr/animesrbija/AnimeSrbija.kt
@@ -17,8 +17,8 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -124,13 +124,25 @@ class AnimeSrbija : AnimeHttpSource() {
         return GET(url)
     }
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/sr/animesrbija/src/eu/kanade/tachiyomi/animeextension/sr/animesrbija/AnimeSrbijaUrlActivity.kt
+++ b/src/sr/animesrbija/src/eu/kanade/tachiyomi/animeextension/sr/animesrbija/AnimeSrbijaUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimeSrbijaUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${AnimeSrbija.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/tr/animeler/build.gradle
+++ b/src/tr/animeler/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animeler'
     extClass = '.Animeler'
-    extVersionCode = 29
+    extVersionCode = 30
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
+++ b/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
@@ -89,13 +89,25 @@ class Animeler :
     override fun latestUpdatesParse(response: Response) = popularAnimeParse(response)
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/AnimelerUrlActivity.kt
+++ b/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/AnimelerUrlActivity.kt
@@ -17,22 +17,17 @@ class AnimelerUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Animeler.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/tr/anizm/build.gradle
+++ b/src/tr/anizm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anizm'
     extClass = '.Anizm'
-    extVersionCode = 40
+    extVersionCode = 41
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/Anizm.kt
+++ b/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/Anizm.kt
@@ -32,6 +32,7 @@ import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -91,12 +92,22 @@ class Anizm :
 
     override fun getFilterList(): AnimeFilterList = AnizmFilters.FILTER_LIST
 
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.firstOrNull()?.takeIf(String::isNotBlank)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "$PREFIX_SEARCH$id", filters)
+        }
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
         val params = AnizmFilters.getSearchParameters(filters).apply {
             animeName = query
         }
@@ -114,7 +125,7 @@ class Anizm :
                 }
             }
         }
-        AnimesPage(currentPage, hasNextPage)
+        return AnimesPage(currentPage, hasNextPage)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/AnizmUrlActivity.kt
+++ b/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/AnizmUrlActivity.kt
@@ -17,22 +17,17 @@ class AnizmUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 0) {
-            val item = pathSegments.first()
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${Anizm.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/tr/hdfilmcehennemi/build.gradle
+++ b/src/tr/hdfilmcehennemi/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HDFilmCehennemi'
     extClass = '.HDFilmCehennemi'
-    extVersionCode = 31
+    extVersionCode = 32
     isNsfw = true
 }
 

--- a/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/HDFilmCehennemi.kt
+++ b/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/HDFilmCehennemi.kt
@@ -22,6 +22,7 @@ import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MultipartBody
 import okhttp3.Request
 import okhttp3.Response
@@ -91,13 +92,25 @@ class HDFilmCehennemi :
         page: Int,
         query: String,
         filters: AnimeFilterList,
-    ): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    ): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.firstOrNull()?.takeIf(String::isNotBlank)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/HDFilmCehennemiUrlActivity.kt
+++ b/src/tr/hdfilmcehennemi/src/eu/kanade/tachiyomi/animeextension/tr/hdfilmcehennemi/HDFilmCehennemiUrlActivity.kt
@@ -17,22 +17,17 @@ class HDFilmCehennemiUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size == 1) {
-            val item = pathSegments.first()
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${HDFilmCehennemi.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/tr/hentaizm/build.gradle
+++ b/src/tr/hentaizm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'HentaiZM'
     extClass = '.HentaiZM'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/tr/hentaizm/src/eu/kanade/tachiyomi/animeextension/tr/hentaizm/HentaiZM.kt
+++ b/src/tr/hentaizm/src/eu/kanade/tachiyomi/animeextension/tr/hentaizm/HentaiZM.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -99,13 +100,25 @@ class HentaiZM :
     override fun latestUpdatesNextPageSelector() = "a[rel=next]:contains(Sonraki Sayfa)"
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/hentai-detay/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/hentai-detay/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {

--- a/src/tr/hentaizm/src/eu/kanade/tachiyomi/animeextension/tr/hentaizm/HentaiZMUrlActivity.kt
+++ b/src/tr/hentaizm/src/eu/kanade/tachiyomi/animeextension/tr/hentaizm/HentaiZMUrlActivity.kt
@@ -17,22 +17,17 @@ class HentaiZMUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${HentaiZM.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()

--- a/src/tr/tranimeizle/build.gradle
+++ b/src/tr/tranimeizle/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'TR Anime Izle'
     extClass = '.TRAnimeIzle'
-    extVersionCode = 32
+    extVersionCode = 33
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/tr/tranimeizle/src/eu/kanade/tachiyomi/animeextension/tr/tranimeizle/TRAnimeIzle.kt
+++ b/src/tr/tranimeizle/src/eu/kanade/tachiyomi/animeextension/tr/tranimeizle/TRAnimeIzle.kt
@@ -30,6 +30,7 @@ import keiyoushi.utils.bodyString
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.toJsonRequestBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -87,13 +88,25 @@ class TRAnimeIzle :
     override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
 
     // =============================== Search ===============================
-    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage = if (query.startsWith(PREFIX_SEARCH)) { // URL intent handler
-        val id = query.removePrefix(PREFIX_SEARCH)
-        client.newCall(GET("$baseUrl/anime/$id"))
-            .awaitSuccess()
-            .use(::searchAnimeByIdParse)
-    } else {
-        super.getSearchAnime(page, query, filters)
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
+        if (query.startsWith("https://")) {
+            val url = query.toHttpUrl()
+            if (url.host != baseUrl.toHttpUrl().host) {
+                throw Exception("Unsupported url")
+            }
+            val id = url.pathSegments.getOrNull(1)
+                ?: throw Exception("Unsupported url")
+            return getSearchAnime(page, "${PREFIX_SEARCH}$id", filters)
+        }
+
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return client.newCall(GET("$baseUrl/anime/$id"))
+                .awaitSuccess()
+                .use(::searchAnimeByIdParse)
+        }
+
+        return super.getSearchAnime(page, query, filters)
     }
 
     private fun searchAnimeByIdParse(response: Response): AnimesPage {
@@ -130,7 +143,7 @@ class TRAnimeIzle :
             infosDiv.select("dd, dt").forEach {
                 // Ignore non-wanted info
                 it.selectFirst("dd:contains(Puanlama), dd:contains(Anime Türü), dt:has(i.fa-star), dt:has(a.genre)")
-                    ?.let { return@forEach }
+                    ?.run { return@forEach }
 
                 val text = it.text()
                 // yes

--- a/src/tr/tranimeizle/src/eu/kanade/tachiyomi/animeextension/tr/tranimeizle/TRAnimeIzleUrlActivity.kt
+++ b/src/tr/tranimeizle/src/eu/kanade/tachiyomi/animeextension/tr/tranimeizle/TRAnimeIzleUrlActivity.kt
@@ -17,22 +17,17 @@ class TRAnimeIzleUrlActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size > 1) {
-            val item = pathSegments[1]
-            val mainIntent = Intent().apply {
-                action = "eu.kanade.tachiyomi.ANIMESEARCH"
-                putExtra("query", "${TRAnimeIzle.PREFIX_SEARCH}$item")
-                putExtra("filter", packageName)
-            }
 
-            try {
-                startActivity(mainIntent)
-            } catch (e: ActivityNotFoundException) {
-                Log.e(tag, e.toString())
-            }
-        } else {
-            Log.e(tag, "could not parse uri from intent $intent")
+        val mainIntent = Intent().apply {
+            action = "eu.kanade.tachiyomi.ANIMESEARCH"
+            putExtra("query", intent.data.toString())
+            putExtra("filter", packageName)
+        }
+
+        try {
+            startActivity(mainIntent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e(tag, "Unable to launch activity", e)
         }
 
         finish()


### PR DESCRIPTION
Refactors deep-link handling across multiple anime extensions by passing the raw intent URL directly to the search query instead of parsing path segments in the activity. This delegates URL parsing to the source's `getSearchAnime` method, simplifying the activity classes.