### PR TITLE
AnimePahe [EN]: Trying to bypass Cloudflare looop

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 43
+    extVersionCode = 44
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
+import keiyoushi.utils.addEditTextPreference
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSwitchPreference
 import keiyoushi.utils.getPreferencesLazy
@@ -43,7 +44,7 @@ class AnimePahe :
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")
 
-    private val interceptor = DdosGuardInterceptor(network.client)
+    private val interceptor = DdosGuardInterceptor(network.client) { cfBypassUserAgent }
 
     override val client = network.client.newBuilder()
         .addInterceptor(interceptor)
@@ -333,12 +334,13 @@ class AnimePahe :
         }
 
         val useHLS = preferences.getBoolean(PREF_LINK_TYPE_KEY, PREF_LINK_TYPE_DEFAULT)
+        val cfUA = cfBypassUserAgent // Get the custom UA once
 
         val videos = if (!useHLS) {
             links.mapNotNull { (_, paheWinLink, quality) ->
                 if (paheWinLink.isNullOrBlank()) return@mapNotNull null
                 runCatching {
-                    KwikExtractor(client, headers).getStreamVideo(context, paheWinLink, quality)
+                    KwikExtractor(client, headers, cfUA).getStreamVideo(context, paheWinLink, quality)
                 }.getOrNull()
             }
         } else {
@@ -348,7 +350,7 @@ class AnimePahe :
         return videos.ifEmpty {
             links.parallelMapNotNullBlocking { (kwikLink, _, quality) ->
                 runCatching {
-                    KwikExtractor(client, headers).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
+                    KwikExtractor(client, headers, cfUA).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
                 }.getOrNull()
             }
         }
@@ -420,6 +422,12 @@ class AnimePahe :
             summary = PREF_AV1_SUMMARY,
             default = PREF_AV1_DEFAULT,
         )
+        screen.addEditTextPreference(
+            key = PREF_CF_UA_KEY,
+            title = PREF_CF_UA_TITLE,
+            summary = PREF_CF_UA_SUMMARY,
+            default = PREF_CF_UA_DEFAULT,
+        )
     }
 
     // ============================= Utilities ==============================
@@ -446,6 +454,12 @@ class AnimePahe :
 
     private fun SAnime.getId() = newAnimeIdRegex.find(url)?.let { it.groupValues[1] }
         ?: oldAnimeIdRegex.find(url)?.let { it.groupValues[1] }
+
+    private val cfBypassUserAgent: String
+        get() = preferences.getString(PREF_CF_UA_KEY, PREF_CF_UA_DEFAULT)
+            ?.trim()
+            .takeIf { !it.isNullOrBlank() }
+            ?: PREF_CF_UA_DEFAULT
 
     companion object {
         private val DATE_FORMATTER by lazy {
@@ -491,6 +505,12 @@ class AnimePahe :
             |Turn off to never select av1 as preferred codec
             """.trimMargin()
         }
-        const val UA_MOBILE = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36"
+        const val UA = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36"
+        private const val PREF_CF_UA_KEY = "cf_bypass_ua"
+        private const val PREF_CF_UA_TITLE = "Custom User-Agent"
+        private const val PREF_CF_UA_DEFAULT = UA
+        private val PREF_CF_UA_SUMMARY = """Custom User-Agent string for the Cloudflare WebView bypass.
+|Leave blank to use the default.
+        """.trimMargin()
     }
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
-import android.app.Application
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.EpisodeDto
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.LatestAnimeDto
@@ -19,7 +18,6 @@ import eu.kanade.tachiyomi.network.GET
 import keiyoushi.utils.addEditTextPreference
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSwitchPreference
-import keiyoushi.utils.applicationContext
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelMapNotNullBlocking
 import keiyoushi.utils.parseAs
@@ -41,14 +39,10 @@ class AnimePahe :
 
     private val preferences by getPreferencesLazy()
 
-    // Use applicationContext from the NetworkHelper instead of injectLazy
-    private val context: Application
-        get() = applicationContext
-
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")
 
-    private val interceptor = DdosGuardInterceptor(network.client, context) { cfBypassUserAgent }
+    private val interceptor = DdosGuardInterceptor(network.client) { cfBypassUserAgent }
     override val client = network.client.newBuilder()
         .addInterceptor(interceptor)
         .build()
@@ -491,27 +485,23 @@ class AnimePahe :
         private const val PREF_LINK_TYPE_KEY = "preferred_link_type"
         private const val PREF_LINK_TYPE_TITLE = "Use HLS links"
         private const val PREF_LINK_TYPE_DEFAULT = true
-        private val PREF_LINK_TYPE_SUMMARY by lazy {
-            """Enable this if you are having Cloudflare issues.
+        private val PREF_LINK_TYPE_SUMMARY = """Enable this if you are having Cloudflare issues.
             |Note that this will break the ability to seek inside of the video unless the episode is downloaded in advance.
-            """.trimMargin()
-        }
+        """.trimMargin()
 
         // Big slap to whoever misspelled `preferred`
         private const val PREF_AV1_KEY = "preferred_av1"
         private const val PREF_AV1_TITLE = "Use AV1 codec"
         private const val PREF_AV1_DEFAULT = false
-        private val PREF_AV1_SUMMARY by lazy {
-            """Enable to use AV1 if available
+        private val PREF_AV1_SUMMARY = """Enable to use AV1 if available
             |Turn off to never select av1 as preferred codec
-            """.trimMargin()
-        }
+        """.trimMargin()
         const val UA = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36"
         private const val PREF_CF_UA_KEY = "cf_bypass_ua"
         private const val PREF_CF_UA_TITLE = "Custom User-Agent"
         private const val PREF_CF_UA_DEFAULT = UA
         private val PREF_CF_UA_SUMMARY = """Custom User-Agent string for the Cloudflare WebView bypass.
-|Leave blank to use the default.
+            |Leave blank to use the default.
         """.trimMargin()
     }
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -41,7 +41,6 @@ class AnimePahe :
     private val preferences by getPreferencesLazy()
 
     override fun headersBuilder() = super.headersBuilder()
-        .set("User-Agent", UA_MOBILE)
         .set("Referer", "$baseUrl/")
 
     private val interceptor = DdosGuardInterceptor(network.client)

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -19,7 +19,7 @@ import keiyoushi.utils.addEditTextPreference
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSwitchPreference
 import keiyoushi.utils.getPreferencesLazy
-import keiyoushi.utils.parallelMapNotNullBlocking
+import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.tryParse
 import keiyoushi.utils.useAsJsoup
@@ -332,21 +332,19 @@ class AnimePahe :
         val cfUA = cfBypassUserAgent // Get the custom UA once
 
         val videos = if (!useHLS) {
-            links.mapNotNull { (_, paheWinLink, quality) ->
-                if (paheWinLink.isNullOrBlank()) return@mapNotNull null
-                runCatching {
-                    KwikExtractor(client, headers, cfUA).getStreamVideo(context, paheWinLink, quality)
-                }.getOrNull()
+            links.parallelCatchingFlatMapBlocking { (_, paheWinLink, quality) ->
+                if (paheWinLink.isNullOrBlank()) return@parallelCatchingFlatMapBlocking emptyList()
+                KwikExtractor(client, headers, cfUA).getStreamVideo(paheWinLink, quality)
+                    .let(::listOf)
             }
         } else {
             emptyList()
         }
 
         return videos.ifEmpty {
-            links.parallelMapNotNullBlocking { (kwikLink, _, quality) ->
-                runCatching {
-                    KwikExtractor(client, headers, cfUA).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
-                }.getOrNull()
+            links.parallelCatchingFlatMapBlocking { (kwikLink, _, quality) ->
+                KwikExtractor(client, headers, cfUA).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
+                    .let(::listOf)
             }
         }
     }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.network.GET
 import keiyoushi.utils.addEditTextPreference
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSwitchPreference
+import keiyoushi.utils.applicationContext
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelMapNotNullBlocking
 import keiyoushi.utils.parseAs
@@ -28,7 +29,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
-import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.math.ceil
@@ -41,7 +41,9 @@ class AnimePahe :
 
     private val preferences by getPreferencesLazy()
 
-    private val context: Application by injectLazy()
+    // Use applicationContext from the NetworkHelper instead of injectLazy
+    private val context: Application
+        get() = applicationContext
 
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -41,16 +41,15 @@ class AnimePahe :
 
     private val preferences by getPreferencesLazy()
 
+    private val context: Application by injectLazy()
+
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")
 
-    private val interceptor = DdosGuardInterceptor(network.client) { cfBypassUserAgent }
-
+    private val interceptor = DdosGuardInterceptor(network.client, context) { cfBypassUserAgent }
     override val client = network.client.newBuilder()
         .addInterceptor(interceptor)
         .build()
-
-    private val context: Application by injectLazy()
 
     override val name = "AnimePahe"
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
@@ -52,7 +52,7 @@ class DdosGuardInterceptor(
                 val newCookieHeader = (oldCookie + newCookie).joinToString("; ") {
                     "${it.name}=${it.value}"
                 }
-                return chain.proceed(originalRequest.newBuilder().addHeader("cookie", newCookieHeader).build())
+                return chain.proceed(originalRequest.newBuilder().addHeader("Cookie", newCookieHeader).build())
             }
         }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
@@ -1,44 +1,81 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
+import android.app.Application
 import android.webkit.CookieManager
+import eu.kanade.tachiyomi.animeextension.en.animepahe.extractor.CloudflareBypass
 import eu.kanade.tachiyomi.network.GET
 import okhttp3.Cookie
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
-class DdosGuardInterceptor(private val client: OkHttpClient) : Interceptor {
+class DdosGuardInterceptor(
+    private val client: OkHttpClient,
+    private val cfBypassUserAgentProvider: () -> String = { AnimePahe.UA }, // Inject custom UA provider
+) : Interceptor {
 
     private val cookieManager by lazy { CookieManager.getInstance() }
+    private val context by lazy { Injekt.get<Application>() }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val response = chain.proceed(originalRequest)
 
-        // Check if DDos-GUARD is on
-        if (response.code !in ERROR_CODES || response.header("Server") !in SERVER_CHECK) {
+        // Check if we are blocked (DDos-GUARD or Cloudflare)
+        if (response.code !in ERROR_CODES) {
             return response
         }
 
+        val isDdosGuard = response.header("Server") in SERVER_CHECK
+        val isCloudflare = response.header("cf-ray") != null // Detect Cloudflare
+
         response.close()
-        val cookies = cookieManager.getCookie(originalRequest.url.toString())
-        val oldCookie = if (cookies != null && cookies.isNotEmpty()) {
-            cookies.split(";").mapNotNull { Cookie.parse(originalRequest.url, it) }
-        } else {
-            emptyList()
-        }
-        val ddg2Cookie = oldCookie.firstOrNull { it.name == "__ddg2_" }
-        if (!ddg2Cookie?.value.isNullOrEmpty()) {
-            return chain.proceed(originalRequest)
+
+        // Try standard DDoS-Guard bypass first if it's a DDos-Guard 403
+        if (isDdosGuard) {
+            val cookies = cookieManager.getCookie(originalRequest.url.toString())
+            val oldCookie = if (cookies != null && cookies.isNotEmpty()) {
+                cookies.split(";").mapNotNull { Cookie.parse(originalRequest.url, it) }
+            } else {
+                emptyList()
+            }
+            val ddg2Cookie = oldCookie.firstOrNull { it.name == "__ddg2_" }
+            if (!ddg2Cookie?.value.isNullOrEmpty()) {
+                return chain.proceed(originalRequest)
+            }
+
+            val newCookie = getNewCookie(originalRequest.url)
+            if (newCookie != null) {
+                val newCookieHeader = (oldCookie + newCookie).joinToString("; ") {
+                    "${it.name}=${it.value}"
+                }
+                return chain.proceed(originalRequest.newBuilder().addHeader("cookie", newCookieHeader).build())
+            }
         }
 
-        val newCookie = getNewCookie(originalRequest.url) ?: return chain.proceed(originalRequest)
-        val newCookieHeader = (oldCookie + newCookie).joinToString("; ") {
-            "${it.name}=${it.value}"
+        // Fallback to WebView Cloudflare/DDos-Guard bypass using the custom User-Agent
+        if (isCloudflare || isDdosGuard) {
+            val customUA = cfBypassUserAgentProvider()
+            val bypassResult = CloudflareBypass(context).getCookies(
+                pageUrl = originalRequest.url.toString(),
+                customUserAgent = customUA,
+            )
+
+            if (bypassResult != null) {
+                return chain.proceed(
+                    originalRequest.newBuilder()
+                        .header("Cookie", bypassResult.cookies)
+                        .header("User-Agent", bypassResult.userAgent) // Use the UA that solved the challenge
+                        .build(),
+                )
+            }
         }
 
-        return chain.proceed(originalRequest.newBuilder().addHeader("cookie", newCookieHeader).build())
+        // If all bypasses fail, proceed with the original request anyway
+        return chain.proceed(originalRequest)
     }
 
     fun getNewCookie(url: HttpUrl): Cookie? {
@@ -64,7 +101,7 @@ class DdosGuardInterceptor(private val client: OkHttpClient) : Interceptor {
 
     companion object {
         private const val WELL_KNOWN_URL = "https://check.ddos-guard.net/check.js"
-        private val ERROR_CODES = listOf(403)
+        private val ERROR_CODES = listOf(403, 503) // Added 503 for Cloudflare challenges
         private val SERVER_CHECK = listOf("ddos-guard")
     }
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.animeextension.en.animepahe
 import android.webkit.CookieManager
 import eu.kanade.tachiyomi.animeextension.en.animepahe.extractor.CloudflareBypass
 import eu.kanade.tachiyomi.network.GET
+import keiyoushi.utils.bodyString
 import okhttp3.Cookie
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
@@ -86,13 +87,13 @@ class DdosGuardInterceptor(
             return ddg2Cookie
         }
         val wellKnown = client.newCall(GET(WELL_KNOWN_URL))
-            .execute().body.string()
+            .execute().bodyString()
             .substringAfter("'", "")
             .substringBefore("'", "")
         val checkUrl = "${url.scheme}://${url.host + wellKnown}"
-        return client.newCall(GET(checkUrl)).execute().header("set-cookie")?.let {
-            Cookie.parse(url, it)
-        }
+        return client.newCall(GET(checkUrl)).execute()
+            .use { it.header("set-cookie") }
+            ?.let { Cookie.parse(url, it) }
     }
 
     companion object {

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
-import android.app.Application
 import android.webkit.CookieManager
 import eu.kanade.tachiyomi.animeextension.en.animepahe.extractor.CloudflareBypass
 import eu.kanade.tachiyomi.network.GET
@@ -12,7 +11,6 @@ import okhttp3.Response
 
 class DdosGuardInterceptor(
     private val client: OkHttpClient,
-    private val context: Application,
     private val cfBypassUserAgentProvider: () -> String = { AnimePahe.UA },
 ) : Interceptor {
 
@@ -57,7 +55,7 @@ class DdosGuardInterceptor(
         // Fallback to WebView Cloudflare/DDos-Guard bypass using the custom User-Agent
         if (isCloudflare || isDdosGuard) {
             val customUA = cfBypassUserAgentProvider()
-            val bypassResult = CloudflareBypass(context).getCookies(
+            val bypassResult = CloudflareBypass().getCookies(
                 pageUrl = originalRequest.url.toString(),
                 customUserAgent = customUA,
             )

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/DdosGuardInterceptor.kt
@@ -9,16 +9,14 @@ import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 class DdosGuardInterceptor(
     private val client: OkHttpClient,
-    private val cfBypassUserAgentProvider: () -> String = { AnimePahe.UA }, // Inject custom UA provider
+    private val context: Application,
+    private val cfBypassUserAgentProvider: () -> String = { AnimePahe.UA },
 ) : Interceptor {
 
     private val cookieManager by lazy { CookieManager.getInstance() }
-    private val context by lazy { Injekt.get<Application>() }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
@@ -101,7 +99,7 @@ class DdosGuardInterceptor(
 
     companion object {
         private const val WELL_KNOWN_URL = "https://check.ddos-guard.net/check.js"
-        private val ERROR_CODES = listOf(403, 503) // Added 503 for Cloudflare challenges
+        private val ERROR_CODES = listOf(403, 503)
         private val SERVER_CHECK = listOf("ddos-guard")
     }
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe.extractor
 
 import android.annotation.SuppressLint
-import android.content.Context
+import android.app.Application
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -18,7 +18,7 @@ data class CloudFlareBypassResult(
     val userAgent: String,
 )
 
-class CloudflareBypass(private val context: Context) {
+class CloudflareBypass(private val context: Application) {
 
     @SuppressLint("SetJavaScriptEnabled")
     fun getCookies(pageUrl: String, customUserAgent: String? = null): CloudFlareBypassResult? {

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
@@ -38,11 +38,10 @@ class CloudflareBypass(private val context: Context) {
             webView.settings.javaScriptEnabled = true
             webView.settings.domStorageEnabled = true
             webView.settings.userAgentString = userAgentToUse
-            val defaultUserAgent = webView.settings.userAgentString
 
             webView.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, loadedUrl: String) {
-                    pollForClearance(pageUrl, defaultUserAgent, cancelled) { bypassResult ->
+                    pollForClearance(pageUrl, userAgentToUse, cancelled) { bypassResult ->
                         result = bypassResult
                         latch.countDown()
                     }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
@@ -21,6 +21,7 @@ data class CloudFlareBypassResult(
 class CloudflareBypass {
 
     @SuppressLint("SetJavaScriptEnabled")
+    @Synchronized
     fun getCookies(pageUrl: String, customUserAgent: String? = null): CloudFlareBypassResult? {
         // Only clear cookies for the target domain instead of hardcoding unrelated domains.
         clearCookiesForUrl(pageUrl)

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
@@ -8,7 +8,7 @@ import android.os.Looper
 import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import eu.kanade.tachiyomi.animeextension.en.animepahe.AnimePahe.Companion.UA_MOBILE
+import eu.kanade.tachiyomi.animeextension.en.animepahe.AnimePahe.Companion.UA
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -21,7 +21,7 @@ data class CloudFlareBypassResult(
 class CloudflareBypass(private val context: Context) {
 
     @SuppressLint("SetJavaScriptEnabled")
-    fun getCookies(pageUrl: String): CloudFlareBypassResult? {
+    fun getCookies(pageUrl: String, customUserAgent: String? = null): CloudFlareBypassResult? {
         // Only clear cookies for the target domain instead of hardcoding unrelated domains.
         clearCookiesForUrl(pageUrl)
 
@@ -30,14 +30,15 @@ class CloudflareBypass(private val context: Context) {
         var webView: WebView? = null
         val cancelled = AtomicBoolean(false)
 
+        val userAgentToUse = customUserAgent ?: UA
+
         // We MUST jump to the Main Thread because WebView is UI-bound
         Handler(Looper.getMainLooper()).post {
             webView = WebView(context)
             webView.settings.javaScriptEnabled = true
             webView.settings.domStorageEnabled = true
-            webView.settings.userAgentString = UA_MOBILE
+            webView.settings.userAgentString = userAgentToUse
             val defaultUserAgent = webView.settings.userAgentString
-                ?: UA_MOBILE
 
             webView.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, loadedUrl: String) {

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/CloudflareBypass.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe.extractor
 
 import android.annotation.SuppressLint
-import android.app.Application
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -9,6 +8,7 @@ import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import eu.kanade.tachiyomi.animeextension.en.animepahe.AnimePahe.Companion.UA
+import keiyoushi.utils.applicationContext
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -18,7 +18,7 @@ data class CloudFlareBypassResult(
     val userAgent: String,
 )
 
-class CloudflareBypass(private val context: Application) {
+class CloudflareBypass {
 
     @SuppressLint("SetJavaScriptEnabled")
     fun getCookies(pageUrl: String, customUserAgent: String? = null): CloudFlareBypassResult? {
@@ -34,7 +34,7 @@ class CloudflareBypass(private val context: Application) {
 
         // We MUST jump to the Main Thread because WebView is UI-bound
         Handler(Looper.getMainLooper()).post {
-            webView = WebView(context)
+            webView = WebView(applicationContext)
             webView.settings.javaScriptEnabled = true
             webView.settings.domStorageEnabled = true
             webView.settings.userAgentString = userAgentToUse

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -30,9 +30,11 @@ package eu.kanade.tachiyomi.animeextension.en.animepahe.extractor
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
-import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.lib.jsunpacker.JsUnpacker
+import keiyoushi.utils.bodyString
+import keiyoushi.utils.useAsJsoup
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.OkHttpClient
@@ -78,7 +80,7 @@ class KwikExtractor(
 
     suspend fun getHlsStreamUrl(kwikUrl: String, referer: String): String {
         val eContent = client.newCall(GET(kwikUrl, headers.newBuilder().set("Referer", referer).build()))
-            .awaitSuccess().asJsoup()
+            .awaitSuccess().useAsJsoup()
         val script = eContent.selectFirst("script:containsData(eval\\(function)")?.data()
             ?.substringAfterLast("eval(function(")
             ?: throw KwikException.ExtractionException("JsUnpacker not found.")
@@ -87,7 +89,7 @@ class KwikExtractor(
         return unpacked.substringAfter("const source=\\'").substringBefore("\\';")
     }
 
-    fun getStreamVideo(paheUrl: String, quality: String = ""): Video {
+    suspend fun getStreamVideo(paheUrl: String, quality: String = ""): Video {
         val videoUrl = getStreamUrlFromKwik(paheUrl)
 
         return Video(
@@ -98,8 +100,8 @@ class KwikExtractor(
         )
     }
 
-    fun getStreamUrlFromKwik(paheUrl: String): String {
-        val kwikUrl = noRedirectClient.newCall(GET("$paheUrl/i", headers)).execute().use { response ->
+    suspend fun getStreamUrlFromKwik(paheUrl: String): String {
+        val kwikUrl = noRedirectClient.newCall(GET("$paheUrl/i", headers)).await().use { response ->
             val location = response.header("location")
                 ?: throw KwikException.ExtractionException("Pahe redirect failed: No location header found.")
             "https://" + location.substringAfterLast("https://")
@@ -136,7 +138,7 @@ class KwikExtractor(
 
             noRedirectClient.newCall(
                 POST(uri, headersBuilder.build(), FormBody.Builder().add("_token", tok).build()),
-            ).execute().use { response ->
+            ).await().use { response ->
                 code = response.code
                 kwikLocation = response.header("location")
             }
@@ -159,8 +161,8 @@ class KwikExtractor(
         return kwikLocation ?: throw KwikException.ExtractionException("Failed to extract stream URI after $tries attempts.")
     }
 
-    private fun fetchKwikHtml(kwikUrl: String): KwikContent {
-        fun attemptKwikFetch(cfResult: CloudFlareBypassResult?): KwikContent? {
+    private suspend fun fetchKwikHtml(kwikUrl: String): KwikContent {
+        suspend fun attemptKwikFetch(cfResult: CloudFlareBypassResult?): KwikContent? {
             // Use `Headers.Builder()` because we want to use the default User-Agent from the app,
             // since that would be the one used when open webview manually
             val headers = Headers.Builder()
@@ -177,8 +179,8 @@ class KwikExtractor(
             // Use the base client directly so all interceptors are preserved.
             return try {
                 // try-catch the `Failed to bypass Cloudflare` exception
-                client.newCall(GET(kwikUrl, headers)).execute().use { resp ->
-                    val html = resp.body.string()
+                client.newCall(GET(kwikUrl, headers)).awaitSuccess().use { resp ->
+                    val html = resp.bodyString()
                     if (html.contains("eval(function(")) {
                         val respCookies = resp.extractCookies()
                         val finalCookies =

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -27,7 +27,6 @@ SOFTWARE.
 
 package eu.kanade.tachiyomi.animeextension.en.animepahe.extractor
 
-import android.app.Application
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
@@ -88,8 +87,8 @@ class KwikExtractor(
         return unpacked.substringAfter("const source=\\'").substringBefore("\\';")
     }
 
-    fun getStreamVideo(context: Application, paheUrl: String, quality: String = ""): Video {
-        val videoUrl = getStreamUrlFromKwik(context, paheUrl)
+    fun getStreamVideo(paheUrl: String, quality: String = ""): Video {
+        val videoUrl = getStreamUrlFromKwik(paheUrl)
 
         return Video(
             videoUrl,
@@ -99,14 +98,14 @@ class KwikExtractor(
         )
     }
 
-    fun getStreamUrlFromKwik(context: Application, paheUrl: String): String {
+    fun getStreamUrlFromKwik(paheUrl: String): String {
         val kwikUrl = noRedirectClient.newCall(GET("$paheUrl/i", headers)).execute().use { response ->
             val location = response.header("location")
                 ?: throw KwikException.ExtractionException("Pahe redirect failed: No location header found.")
             "https://" + location.substringAfterLast("https://")
         }
 
-        var (fContentCookies, fContentString, fContentUrl) = fetchKwikHtml(context, kwikUrl)
+        var (fContentCookies, fContentString, fContentUrl) = fetchKwikHtml(kwikUrl)
 
         // Extract JS Parameters
         val match = kwikParamsRegex.find(fContentString)
@@ -145,7 +144,7 @@ class KwikExtractor(
             // Cloudflare/Session Timeout Handling
             if (code == 403 || code == 419) {
                 // Pass the custom User-Agent to the bypass
-                cloudFlareBypassResult = CloudflareBypass(context).getCookies(kwikUrl, cfBypassUserAgent)
+                cloudFlareBypassResult = CloudflareBypass().getCookies(kwikUrl, cfBypassUserAgent)
                     ?: throw KwikException.CloudflareBlockedException("Cloudflare bypass failed to return result.")
 
                 // Prevent stacking multiple cf_clearance cookies
@@ -160,7 +159,7 @@ class KwikExtractor(
         return kwikLocation ?: throw KwikException.ExtractionException("Failed to extract stream URI after $tries attempts.")
     }
 
-    private fun fetchKwikHtml(context: Application, kwikUrl: String): KwikContent {
+    private fun fetchKwikHtml(kwikUrl: String): KwikContent {
         fun attemptKwikFetch(cfResult: CloudFlareBypassResult?): KwikContent? {
             // Use `Headers.Builder()` because we want to use the default User-Agent from the app,
             // since that would be the one used when open webview manually
@@ -198,7 +197,7 @@ class KwikExtractor(
         attemptKwikFetch(null)?.let { return it }
 
         // 2. Try Cloudflare Bypass (Always fresh) with the custom User-Agent
-        val cfResult = CloudflareBypass(context).getCookies(kwikUrl, cfBypassUserAgent)
+        val cfResult = CloudflareBypass().getCookies(kwikUrl, cfBypassUserAgent)
             ?: throw KwikException.CloudflareBlockedException("Bypass returned null result.")
 
         attemptKwikFetch(cfResult)?.let { return it }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -44,6 +44,7 @@ data class KwikContent(val cookies: String, val html: String, val finalUrl: Stri
 class KwikExtractor(
     private val client: OkHttpClient,
     private val headers: Headers,
+    private val cfBypassUserAgent: String? = null, // Added custom User-Agent parameter
 ) {
     private val kwikParamsRegex by lazy { Regex("""\("(\w+)",\d+,"(\w+)",(\d+),(\d+),\d+\)""") }
     private val kwikDUrl by lazy { Regex("action=\"([^\"]+)\"") }
@@ -143,7 +144,8 @@ class KwikExtractor(
 
             // Cloudflare/Session Timeout Handling
             if (code == 403 || code == 419) {
-                cloudFlareBypassResult = CloudflareBypass(context).getCookies(kwikUrl)
+                // Pass the custom User-Agent to the bypass
+                cloudFlareBypassResult = CloudflareBypass(context).getCookies(kwikUrl, cfBypassUserAgent)
                     ?: throw KwikException.CloudflareBlockedException("Cloudflare bypass failed to return result.")
 
                 // Prevent stacking multiple cf_clearance cookies
@@ -195,8 +197,8 @@ class KwikExtractor(
         // 1. Try standard fetch without bypass
         attemptKwikFetch(null)?.let { return it }
 
-        // 2. Try Cloudflare Bypass (Always fresh)
-        val cfResult = CloudflareBypass(context).getCookies(kwikUrl)
+        // 2. Try Cloudflare Bypass (Always fresh) with the custom User-Agent
+        val cfResult = CloudflareBypass(context).getCookies(kwikUrl, cfBypassUserAgent)
             ?: throw KwikException.CloudflareBlockedException("Bypass returned null result.")
 
         attemptKwikFetch(cfResult)?.let { return it }


### PR DESCRIPTION
Closes #421.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve AnimePahe extension’s handling of DDoS/Cloudflare protection while making the Cloudflare bypass user agent configurable and updating the extension version.

New Features:
- Add a user-configurable User-Agent preference used for Cloudflare WebView bypass and Kwik extraction requests.

Bug Fixes:
- Handle both DDoS-Guard and Cloudflare 4xx/5xx protection flows more robustly to reduce access failures when fetching content.
- Ensure Cloudflare bypass uses and propagates the actual User-Agent that solved the challenge instead of a hardcoded value.

Enhancements:
- Refine DDoS interceptor logic to distinguish DDoS-Guard from Cloudflare responses, attempt cookie-based bypass first, and fall back to WebView-based bypass when needed.
- Use the shared application context helper instead of lazy injection in the AnimePahe extension setup.
- Propagate a custom Cloudflare bypass User-Agent through KwikExtractor to reuse the same configuration across video and HLS fetching.

Build:
- Bump AnimePahe extension version code to 44.