### PR TITLE
Cineby [EN]: Update Domains

### DIFF
--- a/src/en/cineby/build.gradle
+++ b/src/en/cineby/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cineby'
     extClass = '.Cineby'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -1,7 +1,9 @@
 package eu.kanade.tachiyomi.animeextension.en.cineby
 
 import android.content.SharedPreferences
+import android.os.Build
 import android.text.InputType
+import androidx.annotation.RequiresApi
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -447,6 +449,7 @@ class Cineby :
     override fun episodeListParse(response: Response): List<SEpisode> = throw UnsupportedOperationException("Not used")
 
     // ============================ Video Links ============================
+    @RequiresApi(Build.VERSION_CODES.N)
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
         val (path, extraDataEncoded) = episode.url.split("#", limit = 2)
         val (title, year, imdbId) =

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -614,7 +614,7 @@ class Cineby :
         private const val MIN_VOTES_FOR_RECENT_SORT = "50"
 
         private const val PREF_DOMAIN_KEY = "pref_domain"
-        private val DOMAIN_ENTRIES = arrayOf("www.cineby.at", "www.fmovies.gd", "www.bitcine.tv")
+        private val DOMAIN_ENTRIES = arrayOf("www.cineby.at", "www.cineplay.to", "www.fmovies.nz")
         private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }
         private val PREF_DOMAIN_DEFAULT = DOMAIN_VALUES.first()
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -43,7 +43,7 @@ class Cineby :
         get() = preferences.domainPref
 
     // Cineby/Videasy proxy
-    private val apiUrl = "https://db.videasy.net/3"
+    private val apiUrl = "https://db.videasy.to/3"
 
     private fun apiOrigin(url: String): String = url.replace(Regex("""https?://www\."""), "https://")
 
@@ -614,7 +614,7 @@ class Cineby :
         private const val MIN_VOTES_FOR_RECENT_SORT = "50"
 
         private const val PREF_DOMAIN_KEY = "pref_domain"
-        private val DOMAIN_ENTRIES = arrayOf("www.cineby.sc", "www.fmovies.gd", "www.bitcine.tv")
+        private val DOMAIN_ENTRIES = arrayOf("www.cineby.at", "www.fmovies.gd", "www.bitcine.tv")
         private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }
         private val PREF_DOMAIN_DEFAULT = DOMAIN_VALUES.first()
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.animeextension.en.cineby
 
+import android.os.Build
 import android.util.LruCache
+import androidx.annotation.RequiresApi
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
@@ -55,6 +57,7 @@ class CinebyExtractor(
         .removePrefix("https://www.").removePrefix("http://www.")
         .let { if (it.startsWith("http")) it else "https://$it" }
 
+    @RequiresApi(Build.VERSION_CODES.N)
     suspend fun videosFromUrl(
         path: String,
         title: String,

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -368,28 +368,28 @@ class CinebyExtractor(
         private val qualityRegex = Regex("""(\d{3,4})[pP]?""")
 
         //   Official servers (verified against website JS + reference table)
-        //   Neon    = mb-flix                                (api.videasy.net)
-        //   Yoru    = cdn          [MOVIE ONLY, MAY HAVE 4K] (api.videasy.net)
-        //   Cypher  = downloader2                            (api.videasy.net)
-        //   Sage    = 1movies                                (api.videasy.net)
-        //   Breach  = m4uhd                                  (api.videasy.net)
-        //   Vyse    = hdmovie      [FILTERS quality=English] (api.videasy.net)
-        //   Killjoy = meine ?lang=german  - German          (api.videasy.net)
-        //   Harbor  = meine ?lang=italian - Italian         (api.videasy.net)
-        //   Chamber = meine ?lang=french  - French [MOVIE ONLY] (api.videasy.net)
-        //   Fade    = hdmovie      [FILTERS quality=Hindi]  (api.videasy.net)
-        //   Omen    = lamovie             - Spanish          (api.videasy.net)
-        //   Raze    = superflix           - Portuguese       (api.videasy.net)
+        //   Neon    = mb-flix                                (api.videasy.to)
+        //   Yoru    = cdn          [MOVIE ONLY, MAY HAVE 4K] (api.videasy.to)
+        //   Cypher  = downloader2                            (api.videasy.to)
+        //   Sage    = 1movies                                (api.videasy.to)
+        //   Breach  = m4uhd                                  (api.videasy.to)
+        //   Vyse    = hdmovie      [FILTERS quality=English] (api.videasy.to)
+        //   Killjoy = meine ?lang=german  - German          (api.videasy.to)
+        //   Harbor  = meine ?lang=italian - Italian         (api.videasy.to)
+        //   Chamber = meine ?lang=french  - French [MOVIE ONLY] (api.videasy.to)
+        //   Fade    = hdmovie      [FILTERS quality=Hindi]  (api.videasy.to)
+        //   Omen    = lamovie             - Spanish          (api.videasy.to)
+        //   Raze    = superflix           - Portuguese       (api.videasy.to)
         val VIDEASY_SERVERS = listOf(
             VideasyServer(
                 "Neon",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "mb-flix",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Yoru",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "cdn",
                 movieOnly = true,
                 mayHave4K = true,
@@ -397,46 +397,46 @@ class CinebyExtractor(
             ),
             VideasyServer(
                 "Cypher",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "downloader2",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Sage",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "1movies",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Breach",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "m4uhd",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Vyse",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "hdmovie",
                 qualityFilter = "English",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Killjoy",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "meine",
                 language = "german",
                 audioLabel = "German",
             ),
             VideasyServer(
                 "Harbor",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "meine",
                 language = "italian",
                 audioLabel = "Italian",
             ),
             VideasyServer(
                 "Chamber",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "meine",
                 language = "french",
                 movieOnly = true,
@@ -444,20 +444,20 @@ class CinebyExtractor(
             ),
             VideasyServer(
                 "Fade",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "hdmovie",
                 qualityFilter = "Hindi",
                 audioLabel = "Hindi",
             ),
             VideasyServer(
                 "Omen",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "lamovie",
                 audioLabel = "Spanish",
             ),
             VideasyServer(
                 "Raze",
-                "https://api.videasy.net",
+                "https://api.videasy.to",
                 "superflix",
                 audioLabel = "Portuguese",
             ),


### PR DESCRIPTION
Closes #436.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update Cineby extension to use the new Videasy API/domain endpoints and bump its version code.

Bug Fixes:
- Point Cineby Videasy API proxy and server configurations to the updated videasy.to domain to restore functionality.

Enhancements:
- Update Cineby default domain entry to the current primary site hostname.

Build:
- Increment Cineby extension version code to reflect the domain and API updates.