### PR TITLE
Animetsu [Multi]: Fix 403, Use M3u8Server & Server Update

### DIFF
--- a/src/all/animetsu/build.gradle
+++ b/src/all/animetsu/build.gradle
@@ -9,4 +9,5 @@ apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(":lib:playlistutils"))
+    implementation(project(":lib:m3u8server"))
 }

--- a/src/all/animetsu/build.gradle
+++ b/src/all/animetsu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animetsu'
     extClass = '.Animetsu'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -1,7 +1,9 @@
 package eu.kanade.tachiyomi.animeextension.all.animetsu
 
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.preference.PreferenceScreen
+import aniyomi.lib.m3u8server.M3u8ServerManager
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -18,13 +20,13 @@ import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.addSwitchPreference
 import keiyoushi.utils.firstInstanceOrNull
-import keiyoushi.utils.flatMapCatching
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parallelFlatMap
 import keiyoushi.utils.parseAs
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import java.util.concurrent.TimeUnit
@@ -48,6 +50,17 @@ class Animetsu :
     override val lang = "all"
 
     override val supportsLatest = true
+
+    // Custom client for Dio to avoid HTTP/2 stream timeout and allow longer reads
+    private val dioClient by lazy {
+        client.newBuilder()
+            .readTimeout(30, TimeUnit.SECONDS)
+            .protocols(listOf(Protocol.HTTP_1_1))
+            .build()
+    }
+
+    // M3u8ServerManager uses the dioClient to ensure the local server also fetches segments via HTTP/1.1
+    private val m3u8ServerManager by lazy { M3u8ServerManager(dioClient) }
 
     private val titleLanguage: String
         get() = preferences.getString(PREF_TITLE_LANG_KEY, PREF_TITLE_LANG_DEFAULT) ?: PREF_TITLE_LANG_DEFAULT
@@ -301,37 +314,139 @@ class Animetsu :
                     else -> ""
                 }
 
-                dto.sources.flatMapCatching { source ->
+                val isDio = server.id.equals("dio", ignoreCase = true)
+
+                val videos = mutableListOf<Video>()
+
+                dto.sources.forEach { source ->
                     val fullUrl = when {
                         source.needProxy -> "$proxyUrl${source.url}"
                         source.url.startsWith("http") -> source.url
                         else -> "$baseUrl${source.url}"
                     }
 
-                    when {
-                        source.type?.contains("mp4") == true ->
-                            Video(
-                                fullUrl,
-                                "${server.id.uppercase()}: ${source.quality} ($audioLabel)$subLabel",
-                                fullUrl,
-                                videoHeaders(watchReferer),
-                                subtitleTracks,
-                            ).let(::listOf)
-                        source.type?.contains("mpegurl") == true ->
-                            playlistUtils.extractFromHls(
-                                playlistUrl = fullUrl,
-                                videoNameGen = { quality ->
-                                    val cleanQuality = quality.substringBefore(" ").let { q ->
+                    try {
+                        if (isDio && source.type?.contains("mpegurl") == true) {
+                            val body = dioClient.newCall(GET(fullUrl, videoHeaders(watchReferer))).awaitSuccess().body.string()
+                            val m3u8Start = body.indexOf("#EXTM3U")
+                            if (m3u8Start == -1) return@forEach
+                            val m3u8Content = body.substring(m3u8Start)
+
+                            val subPlaylists = mutableListOf<Pair<String, String>>()
+                            val lines = m3u8Content.lines()
+                            for (i in lines.indices) {
+                                if (lines[i].startsWith("#EXT-X-STREAM-INF:")) {
+                                    val resolution = Regex("RESOLUTION=(\\d+x\\d+)").find(lines[i])?.groupValues?.get(1)
+                                    val bandwidth = Regex("BANDWIDTH=(\\d+)").find(lines[i])?.groupValues?.get(1)
+                                    val name = Regex("NAME=\"(.*?)\"").find(lines[i])?.groupValues?.get(1)
+                                    val qualityStr = name ?: buildString {
+                                        if (resolution != null) {
+                                            append(resolution.substringAfter("x"))
+                                            append("p")
+                                        }
+                                        if (bandwidth != null) {
+                                            if (isNotEmpty()) append(" ")
+                                            append(bandwidth)
+                                        }
+                                        if (isEmpty()) append("Unknown")
+                                    }
+                                    if (i + 1 < lines.size && lines[i + 1].isNotBlank() && !lines[i + 1].startsWith("#")) {
+                                        val subUrl = lines[i + 1].trim()
+                                        val absoluteSubUrl = when {
+                                            subUrl.startsWith("http") -> subUrl
+                                            subUrl.startsWith("//") -> {
+                                                val httpUrl = fullUrl.toHttpUrl()
+                                                "${httpUrl.scheme}://$subUrl"
+                                            }
+                                            subUrl.startsWith("/") -> {
+                                                val httpUrl = fullUrl.toHttpUrl()
+                                                "${httpUrl.scheme}://${httpUrl.host}$subUrl"
+                                            }
+                                            else -> fullUrl.substringBeforeLast("/") + "/" + subUrl
+                                        }
+                                        subPlaylists.add(qualityStr to absoluteSubUrl)
+                                    }
+                                }
+                            }
+
+                            val dioVideos = if (subPlaylists.isEmpty()) {
+                                listOf(
+                                    Video(
+                                        fullUrl,
+                                        "${server.id.uppercase()}: Unknown ($audioLabel)$subLabel",
+                                        fullUrl,
+                                        videoHeaders(watchReferer),
+                                        subtitleTracks,
+                                    ),
+                                )
+                            } else {
+                                subPlaylists.map { (qualityStr, url) ->
+                                    val cleanQuality = qualityStr.substringBefore(" ").let { q ->
                                         if (q.endsWith("P")) q.lowercase() else q
                                     }
-                                    "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel"
+                                    Video(
+                                        url,
+                                        "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel",
+                                        url,
+                                        videoHeaders(watchReferer),
+                                        subtitleTracks,
+                                    )
+                                }
+                            }
+                            if (!m3u8ServerManager.isRunning()) {
+                                try {
+                                    m3u8ServerManager.startServer()
+                                } catch (e: Exception) {
+                                    Log.e("Animetsu", "Failed to start M3U8 server: ${e.message}")
+                                }
+                            }
+                            videos.addAll(
+                                dioVideos.map { video ->
+                                    val processedUrl = m3u8ServerManager.processM3u8Url(video.url)
+                                    if (processedUrl != null) {
+                                        Video(
+                                            url = processedUrl,
+                                            quality = video.quality,
+                                            videoUrl = processedUrl,
+                                            headers = video.headers,
+                                            subtitleTracks = video.subtitleTracks,
+                                            audioTracks = video.audioTracks,
+                                        )
+                                    } else {
+                                        video
+                                    }
                                 },
-                                referer = "$baseUrl/",
-                                subtitleList = subtitleTracks,
                             )
-                        else -> emptyList()
+                        } else if (source.type?.contains("mp4") == true) {
+                            videos.add(
+                                Video(
+                                    fullUrl,
+                                    "${server.id.uppercase()}: ${source.quality} ($audioLabel)$subLabel",
+                                    fullUrl,
+                                    videoHeaders(watchReferer),
+                                    subtitleTracks,
+                                ),
+                            )
+                        } else if (source.type?.contains("mpegurl") == true) {
+                            videos.addAll(
+                                playlistUtils.extractFromHls(
+                                    playlistUrl = fullUrl,
+                                    videoNameGen = { quality ->
+                                        val cleanQuality = quality.substringBefore(" ").let { q ->
+                                            if (q.endsWith("P")) q.lowercase() else q
+                                        }
+                                        "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel"
+                                    },
+                                    referer = "$baseUrl/",
+                                    subtitleList = subtitleTracks,
+                                ),
+                            )
+                        }
+                    } catch (_: Exception) {
                     }
                 }
+
+                videos
             }
         }
     }

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -109,6 +109,9 @@ class Animetsu :
     private val showTrailer: Boolean
         get() = preferences.getBoolean(PREF_SHOW_TRAILER_KEY, PREF_SHOW_TRAILER_DEFAULT)
 
+    private val showBanner: Boolean
+        get() = preferences.getBoolean(PREF_SHOW_BANNER_KEY, PREF_SHOW_BANNER_DEFAULT)
+
     private val showEpStats: Boolean
         get() = preferences.getBoolean(PREF_SHOW_EP_STATS_KEY, PREF_SHOW_EP_STATS_DEFAULT)
 
@@ -210,6 +213,7 @@ class Animetsu :
             showRelations = showRelations,
             showTrackers = showTrackers,
             showTrailer = showTrailer,
+            showBanner = showBanner,
         ),
     )!!
 
@@ -365,7 +369,6 @@ class Animetsu :
     override fun List<Video>.sort(): List<Video> {
         val quality = preferredQuality
         val server = preferredServer
-        val type = preferredAudioType
         val qualitiesList = PREF_QUALITY_ENTRIES.reversed()
 
         return sortedWith(
@@ -498,6 +501,13 @@ class Animetsu :
         )
 
         screen.addSwitchPreference(
+            key = PREF_SHOW_BANNER_KEY,
+            title = "Show Banner",
+            summary = "Shows anime banner image in description.",
+            default = PREF_SHOW_BANNER_DEFAULT,
+        )
+
+        screen.addSwitchPreference(
             key = PREF_SHOW_EP_STATS_KEY,
             title = "Show Episode Stats",
             summary = "Shows Views, Likes, and Dislikes in the scanlator field.",
@@ -626,7 +636,7 @@ class Animetsu :
         if (invalidHosters || invalidServer || oldAudioTypes != null) {
             edit().also { editor ->
                 if (invalidHosters) editor.putStringSet(PREF_HOSTER_EXCLUDE_KEY, hostExclusion.filter { it in SERVER_VALUES }.toSet())
-                if (invalidServer) editor.putStringSet(PREF_PREFERRED_SERVER_KEY, PREF_HOSTER_EXCLUDE_DEFAULT)
+                if (invalidServer) editor.putString(PREF_PREFERRED_SERVER_KEY, PREF_PREFERRED_SERVER_DEFAULT)
                 if (oldAudioTypes != null) {
                     val newExclusion = AUDIO_TYPE_VALUES.toSet() - oldAudioTypes
                     editor.putStringSet(PREF_AUDIO_TYPE_EXCLUDE_KEY, newExclusion)
@@ -691,6 +701,8 @@ class Animetsu :
         private const val PREF_SHOW_TRAILER_DEFAULT = true
         private const val PREF_SHOW_EP_STATS_KEY = "show_ep_stats"
         private const val PREF_SHOW_EP_STATS_DEFAULT = true
+        private const val PREF_SHOW_BANNER_KEY = "show_banner"
+        private const val PREF_SHOW_BANNER_DEFAULT = true
 
         fun parseStatus(status: String?): Int = when (status) {
             "RELEASING" -> SAnime.ONGOING

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -281,7 +281,7 @@ class Animetsu :
         val sortedAudioTypes = enabledAudioTypes
             .sortedByDescending { type -> type == preferredAudioType }
 
-        val playlistUtils = PlaylistUtils(client, videoHeaders())
+        val playlistUtils = PlaylistUtils(client, videoHeaders(watchReferer))
 
         return servers.parallelFlatMap { server ->
             sortedAudioTypes.parallelCatchingFlatMap { sourceType ->
@@ -314,7 +314,7 @@ class Animetsu :
                                 fullUrl,
                                 "${server.id.uppercase()}: ${source.quality} ($audioLabel)$subLabel",
                                 fullUrl,
-                                videoHeaders(),
+                                videoHeaders(watchReferer),
                                 subtitleTracks,
                             ).let(::listOf)
                         source.type?.contains("mpegurl") == true ->

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -282,7 +282,7 @@ class Animetsu :
         val sortedAudioTypes = enabledAudioTypes
             .sortedByDescending { type -> type == preferredAudioType }
 
-        val playlistUtils = PlaylistUtils(client, videoHeaders()) // ← changed
+        val playlistUtils = PlaylistUtils(client, videoHeaders())
 
         return servers.parallelFlatMap { server ->
             sortedAudioTypes.parallelCatchingFlatMap { sourceType ->

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -4,7 +4,6 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.preference.PreferenceScreen
 import aniyomi.lib.m3u8server.M3u8ServerManager
-import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -53,16 +52,16 @@ class Animetsu :
 
     override val supportsLatest = true
 
-    // Custom client for Dio to avoid HTTP/2 stream timeout and allow longer reads
-    private val dioClient by lazy {
+    // Custom client to avoid HTTP/2 stream timeout and allow longer reads
+    private val m3u8Client by lazy {
         client.newBuilder()
             .readTimeout(30, TimeUnit.SECONDS)
             .protocols(listOf(Protocol.HTTP_1_1))
             .build()
     }
 
-    // M3u8ServerManager uses the dioClient to ensure the local server also fetches segments via HTTP/1.1
-    private val m3u8ServerManager by lazy { M3u8ServerManager(dioClient) }
+    // M3u8ServerManager uses the m3u8Client to ensure the local server also fetches segments via HTTP/1.1
+    private val m3u8ServerManager by lazy { M3u8ServerManager(m3u8Client) }
 
     private val titleLanguage: String
         get() = preferences.getString(PREF_TITLE_LANG_KEY, PREF_TITLE_LANG_DEFAULT) ?: PREF_TITLE_LANG_DEFAULT
@@ -115,21 +114,20 @@ class Animetsu :
     private val showEpStats: Boolean
         get() = preferences.getBoolean(PREF_SHOW_EP_STATS_KEY, PREF_SHOW_EP_STATS_DEFAULT)
 
-    private fun apiHeaders(referer: String = "$baseUrl/browse"): Headers = Headers.Builder()
-        .add("Accept", "application/json, text/plain, */*")
-        .add("Accept-Language", "en-US,en;q=0.9")
-        .add("Referer", referer)
-        .add("Sec-Fetch-Dest", "empty")
-        .add("Sec-Fetch-Mode", "cors")
-        .add("Sec-Fetch-Site", "same-origin")
+    private fun apiHeaders(referer: String = "$baseUrl/browse"): Headers = headersBuilder()
+        .set("Accept", "application/json, text/plain, */*")
+        .set("Accept-Language", "en-US,en;q=0.9")
+        .set("Referer", referer)
+        .set("Sec-Fetch-Dest", "empty")
+        .set("Sec-Fetch-Mode", "cors")
+        .set("Sec-Fetch-Site", "same-origin")
         .build()
 
     // Builds video headers from API headers, overriding only the specific fields needed for video streams
     private fun videoHeaders(referer: String = "$baseUrl/"): Headers = apiHeaders(referer).newBuilder()
         .set("Accept", "*/*")
         .set("Sec-Fetch-Site", "cross-site")
-        .add("Origin", baseUrl)
-        .add("User-Agent", "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36")
+        .set("Origin", baseUrl)
         .build()
 
     private val rateLimit = 5
@@ -298,12 +296,9 @@ class Animetsu :
         val sortedAudioTypes = enabledAudioTypes
             .sortedByDescending { type -> type == preferredAudioType }
 
-        val playlistUtils = PlaylistUtils(client, videoHeaders(watchReferer))
-
         return servers.parallelFlatMap { server ->
             sortedAudioTypes.parallelCatchingFlatMap { sourceType ->
                 val audioLabel = sourceType.uppercase()
-                val isDio = server.id.equals("dio", ignoreCase = true)
 
                 val sourceResponse = client.newCall(
                     GET("$apiUrl/anime/oppai/$animeId/$epNum?server=${server.id}&source_type=$sourceType", apiHeaders(watchReferer)),
@@ -315,8 +310,8 @@ class Animetsu :
                 }.orEmpty()
 
                 val subLabel = when (server.id.lowercase()) {
-                    "baku", "dio", "meg" -> " [Hard Subs]"
-                    "kite" -> " [Soft Subs]"
+                    "baku", "dio", "meg" -> "[Hard Subs]"
+                    "kite" -> "[Soft Subs]"
                     else -> ""
                 }
 
@@ -324,7 +319,7 @@ class Animetsu :
                     val cleanQuality = quality.substringBefore(" ").let { q ->
                         if (q.endsWith("P")) q.lowercase() else q
                     }
-                    "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel"
+                    "${server.id.uppercase()}: $cleanQuality ($audioLabel) $subLabel"
                 }
 
                 dto.sources.parallelCatchingFlatMap { source ->
@@ -335,9 +330,6 @@ class Animetsu :
                     }
 
                     when {
-                        isDio && source.type?.contains("mpegurl") == true ->
-                            processDioHls(fullUrl, hlsNameGen, watchReferer, subtitleTracks)
-
                         source.type?.contains("mp4") == true ->
                             listOf(
                                 Video(
@@ -350,12 +342,7 @@ class Animetsu :
                             )
 
                         source.type?.contains("mpegurl") == true ->
-                            playlistUtils.extractFromHls(
-                                playlistUrl = fullUrl,
-                                videoNameGen = hlsNameGen,
-                                referer = "$baseUrl/",
-                                subtitleList = subtitleTracks,
-                            )
+                            processHls(fullUrl, hlsNameGen, watchReferer, subtitleTracks)
 
                         else -> emptyList()
                     }
@@ -519,28 +506,28 @@ class Animetsu :
     // ============================= Utilities ==============================
 
     /**
-     * Dedicated helper for fetching, parsing, and enforcing the local M3U8 server for Dio.
+     * Dedicated helper for fetching, parsing, and enforcing the local M3U8 server for all HLS sources.
      *
-     * Dio responses have non-M3U8 content before the actual playlist (garbage prefix),
-     * which PlaylistUtils.extractFromHls cannot handle since it fetches URLs internally.
-     * This method pre-fetches with dioClient, strips the garbage, then parses manually.
+     * Some server responses may have non-M3U8 content before the actual playlist (garbage prefix),
+     * which standard extractors cannot handle since they fetch URLs internally.
+     * This method pre-fetches with m3u8Client, strips any garbage, then parses manually.
      */
-    private suspend fun processDioHls(
+    private suspend fun processHls(
         fullUrl: String,
         videoNameGen: (String) -> String,
         watchReferer: String,
         subtitleTracks: List<Track>,
     ): List<Video> {
-        val body = dioClient.newCall(GET(fullUrl, videoHeaders(watchReferer)))
+        val body = m3u8Client.newCall(GET(fullUrl, videoHeaders(watchReferer)))
             .awaitSuccess().body.string()
         val m3u8Start = body.indexOf("#EXTM3U")
         if (m3u8Start == -1) return emptyList()
 
         val m3u8Content = body.substring(m3u8Start)
         val headers = videoHeaders(watchReferer)
-        val subPlaylists = parseDioSubPlaylists(m3u8Content, fullUrl)
+        val subPlaylists = parseSubPlaylists(m3u8Content, fullUrl)
 
-        val dioVideos = if (subPlaylists.isEmpty()) {
+        val videos = if (subPlaylists.isEmpty()) {
             listOf(Video(fullUrl, videoNameGen("Unknown"), fullUrl, headers, subtitleTracks))
         } else {
             subPlaylists.map { (quality, url) ->
@@ -548,8 +535,8 @@ class Animetsu :
             }
         }
 
-        // ENFORCE M3U8 SERVER FOR DIO: proxy through local server, drop if it fails
-        return dioVideos.mapNotNull { video ->
+        // ENFORCE M3U8 SERVER: proxy through local server, drop if it fails
+        return videos.mapNotNull { video ->
             val processedUrl = getProcessedM3u8Url(video.url) ?: return@mapNotNull null
             Video(
                 url = processedUrl,
@@ -563,9 +550,9 @@ class Animetsu :
     }
 
     /**
-     * Parses sub-playlists from a Dio M3U8 master playlist.
+     * Parses sub-playlists from an M3U8 master playlist.
      */
-    private fun parseDioSubPlaylists(m3u8Content: String, baseUrl: String): List<Pair<String, String>> {
+    private fun parseSubPlaylists(m3u8Content: String, baseUrl: String): List<Pair<String, String>> {
         val lines = m3u8Content.lines()
         val result = mutableListOf<Pair<String, String>>()
 
@@ -573,9 +560,9 @@ class Animetsu :
             if (!lines[i].startsWith("#EXT-X-STREAM-INF:")) continue
 
             val line = lines[i]
-            val name = DIO_NAME_REGEX.find(line)?.groupValues?.get(1)
-            val resolution = DIO_RESOLUTION_REGEX.find(line)?.groupValues?.get(1)
-            val bandwidth = DIO_BANDWIDTH_REGEX.find(line)?.groupValues?.get(1)
+            val name = M3U8_NAME_REGEX.find(line)?.groupValues?.get(1)
+            val resolution = M3U8_RESOLUTION_REGEX.find(line)?.groupValues?.get(1)
+            val bandwidth = M3U8_BANDWIDTH_REGEX.find(line)?.groupValues?.get(1)
 
             val qualityStr = name ?: buildString {
                 resolution?.let { append(it.substringAfter("x")).append("p") }
@@ -712,9 +699,9 @@ class Animetsu :
             else -> SAnime.UNKNOWN
         }
 
-        private val DIO_NAME_REGEX by lazy { Regex("""NAME="(.*?)"""") }
-        private val DIO_RESOLUTION_REGEX by lazy { Regex("""RESOLUTION=(\d+x\d+)""") }
-        private val DIO_BANDWIDTH_REGEX by lazy { Regex("""BANDWIDTH=(\d+)""") }
+        private val M3U8_NAME_REGEX by lazy { Regex("""NAME="(.*?)"""") }
+        private val M3U8_RESOLUTION_REGEX by lazy { Regex("""RESOLUTION=(\d+x\d+)""") }
+        private val M3U8_BANDWIDTH_REGEX by lazy { Regex("""BANDWIDTH=(\d+)""") }
 
         val newLineRegex by lazy { Regex("""<br\s*/?>""", RegexOption.IGNORE_CASE) }
         val textStyleRegex by lazy { Regex("""</?(i|b|em)>""", RegexOption.IGNORE_CASE) }

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
+import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.addSwitchPreference
@@ -297,6 +298,8 @@ class Animetsu :
         return servers.parallelFlatMap { server ->
             sortedAudioTypes.parallelCatchingFlatMap { sourceType ->
                 val audioLabel = sourceType.uppercase()
+                val isDio = server.id.equals("dio", ignoreCase = true)
+
                 val sourceResponse = client.newCall(
                     GET("$apiUrl/anime/oppai/$animeId/$epNum?server=${server.id}&source_type=$sourceType", apiHeaders(watchReferer)),
                 ).awaitSuccess()
@@ -312,24 +315,26 @@ class Animetsu :
                     else -> ""
                 }
 
-                val isDio = server.id.equals("dio", ignoreCase = true)
+                val hlsNameGen: (String) -> String = { quality ->
+                    val cleanQuality = quality.substringBefore(" ").let { q ->
+                        if (q.endsWith("P")) q.lowercase() else q
+                    }
+                    "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel"
+                }
 
-                val videos = mutableListOf<Video>()
-
-                dto.sources.forEach { source ->
+                dto.sources.parallelCatchingFlatMap { source ->
                     val fullUrl = when {
                         source.needProxy -> "$proxyUrl${source.url}"
                         source.url.startsWith("http") -> source.url
                         else -> "$baseUrl${source.url}"
                     }
 
-                    try {
-                        if (isDio && source.type?.contains("mpegurl") == true) {
-                            videos.addAll(
-                                parseDioM3u8Playlists(fullUrl, server.id, audioLabel, subLabel, watchReferer, subtitleTracks),
-                            )
-                        } else if (source.type?.contains("mp4") == true) {
-                            videos.add(
+                    when {
+                        isDio && source.type?.contains("mpegurl") == true ->
+                            processDioHls(fullUrl, hlsNameGen, watchReferer, subtitleTracks)
+
+                        source.type?.contains("mp4") == true ->
+                            listOf(
                                 Video(
                                     fullUrl,
                                     "${server.id.uppercase()}: ${source.quality} ($audioLabel)$subLabel",
@@ -338,27 +343,18 @@ class Animetsu :
                                     subtitleTracks,
                                 ),
                             )
-                        } else if (source.type?.contains("mpegurl") == true) {
-                            videos.addAll(
-                                playlistUtils.extractFromHls(
-                                    playlistUrl = fullUrl,
-                                    videoNameGen = { quality ->
-                                        val cleanQuality = quality.substringBefore(" ").let { q ->
-                                            if (q.endsWith("P")) q.lowercase() else q
-                                        }
-                                        "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel"
-                                    },
-                                    referer = "$baseUrl/",
-                                    subtitleList = subtitleTracks,
-                                ),
+
+                        source.type?.contains("mpegurl") == true ->
+                            playlistUtils.extractFromHls(
+                                playlistUrl = fullUrl,
+                                videoNameGen = hlsNameGen,
+                                referer = "$baseUrl/",
+                                subtitleList = subtitleTracks,
                             )
-                        }
-                    } catch (e: Exception) {
-                        Log.w("Animetsu", "Failed to fetch or parse sources", e)
+
+                        else -> emptyList()
                     }
                 }
-
-                videos
             }
         }
     }
@@ -513,127 +509,106 @@ class Animetsu :
 
     /**
      * Dedicated helper for fetching, parsing, and enforcing the local M3U8 server for Dio.
-     * Extracts the complex logic out of the main video list flow.
+     *
+     * Dio responses have non-M3U8 content before the actual playlist (garbage prefix),
+     * which PlaylistUtils.extractFromHls cannot handle since it fetches URLs internally.
+     * This method pre-fetches with dioClient, strips the garbage, then parses manually.
      */
-    private suspend fun parseDioM3u8Playlists(
+    private suspend fun processDioHls(
         fullUrl: String,
-        serverId: String,
-        audioLabel: String,
-        subLabel: String,
+        videoNameGen: (String) -> String,
         watchReferer: String,
         subtitleTracks: List<Track>,
     ): List<Video> {
-        val body = dioClient.newCall(GET(fullUrl, videoHeaders(watchReferer))).awaitSuccess().body.string()
+        val body = dioClient.newCall(GET(fullUrl, videoHeaders(watchReferer)))
+            .awaitSuccess().body.string()
         val m3u8Start = body.indexOf("#EXTM3U")
         if (m3u8Start == -1) return emptyList()
-        val m3u8Content = body.substring(m3u8Start)
 
-        val subPlaylists = mutableListOf<Pair<String, String>>()
-        val lines = m3u8Content.lines()
-        for (i in lines.indices) {
-            if (lines[i].startsWith("#EXT-X-STREAM-INF:")) {
-                val resolution = Regex("RESOLUTION=(\\d+x\\d+)").find(lines[i])?.groupValues?.get(1)
-                val bandwidth = Regex("BANDWIDTH=(\\d+)").find(lines[i])?.groupValues?.get(1)
-                val name = Regex("NAME=\"(.*?)\"").find(lines[i])?.groupValues?.get(1)
-                val qualityStr = name ?: buildString {
-                    if (resolution != null) {
-                        append(resolution.substringAfter("x"))
-                        append("p")
-                    }
-                    if (bandwidth != null) {
-                        if (isNotEmpty()) append(" ")
-                        append(bandwidth)
-                    }
-                    if (isEmpty()) append("Unknown")
-                }
-                if (i + 1 < lines.size && lines[i + 1].isNotBlank() && !lines[i + 1].startsWith("#")) {
-                    val subUrl = lines[i + 1].trim()
-                    val absoluteSubUrl = when {
-                        subUrl.startsWith("http") -> subUrl
-                        subUrl.startsWith("//") -> "${fullUrl.toHttpUrl().scheme}:$subUrl"
-                        subUrl.startsWith("/") -> {
-                            val httpUrl = fullUrl.toHttpUrl()
-                            "${httpUrl.scheme}://${httpUrl.host}$subUrl"
-                        }
-                        else -> fullUrl.substringBeforeLast("/") + "/" + subUrl
-                    }
-                    subPlaylists.add(qualityStr to absoluteSubUrl)
-                }
-            }
-        }
+        val m3u8Content = body.substring(m3u8Start)
+        val headers = videoHeaders(watchReferer)
+        val subPlaylists = parseDioSubPlaylists(m3u8Content, fullUrl)
 
         val dioVideos = if (subPlaylists.isEmpty()) {
-            listOf(
-                Video(
-                    fullUrl,
-                    "${serverId.uppercase()}: Unknown ($audioLabel)$subLabel",
-                    fullUrl,
-                    videoHeaders(watchReferer),
-                    subtitleTracks,
-                ),
-            )
+            listOf(Video(fullUrl, videoNameGen("Unknown"), fullUrl, headers, subtitleTracks))
         } else {
-            subPlaylists.map { (qualityStr, url) ->
-                val cleanQuality = qualityStr.substringBefore(" ").let { q ->
-                    if (q.endsWith("P")) q.lowercase() else q
-                }
-                Video(
-                    url,
-                    "${serverId.uppercase()}: $cleanQuality ($audioLabel)$subLabel",
-                    url,
-                    videoHeaders(watchReferer),
-                    subtitleTracks,
-                )
+            subPlaylists.map { (quality, url) ->
+                Video(url, videoNameGen(quality), url, headers, subtitleTracks)
             }
         }
 
-        // ENFORCE M3U8 SERVER FOR DIO: Force process and drop if it fails
-        val result = mutableListOf<Video>()
-        for (video in dioVideos) {
-            val processedUrl = getProcessedM3u8Url(video.url)
-            if (processedUrl != null) {
-                result.add(
-                    Video(
-                        url = processedUrl,
-                        quality = video.quality,
-                        videoUrl = processedUrl,
-                        headers = video.headers,
-                        subtitleTracks = video.subtitleTracks,
-                        audioTracks = video.audioTracks,
-                    ),
-                )
-            } else {
-                // If the server fails to proxy the URL, we MUST NOT add the raw URL.
-                Log.e("Animetsu", "Dropping Dio video due to M3U8 server failure.")
+        // ENFORCE M3U8 SERVER FOR DIO: proxy through local server, drop if it fails
+        return dioVideos.mapNotNull { video ->
+            val processedUrl = getProcessedM3u8Url(video.url) ?: return@mapNotNull null
+            Video(
+                url = processedUrl,
+                quality = video.quality,
+                videoUrl = processedUrl,
+                headers = video.headers,
+                subtitleTracks = video.subtitleTracks,
+                audioTracks = video.audioTracks,
+            )
+        }
+    }
+
+    /**
+     * Parses sub-playlists from a Dio M3U8 master playlist.
+     */
+    private fun parseDioSubPlaylists(m3u8Content: String, baseUrl: String): List<Pair<String, String>> {
+        val lines = m3u8Content.lines()
+        val result = mutableListOf<Pair<String, String>>()
+
+        for (i in lines.indices) {
+            if (!lines[i].startsWith("#EXT-X-STREAM-INF:")) continue
+
+            val line = lines[i]
+            val name = DIO_NAME_REGEX.find(line)?.groupValues?.get(1)
+            val resolution = DIO_RESOLUTION_REGEX.find(line)?.groupValues?.get(1)
+            val bandwidth = DIO_BANDWIDTH_REGEX.find(line)?.groupValues?.get(1)
+
+            val qualityStr = name ?: buildString {
+                resolution?.let { append(it.substringAfter("x")).append("p") }
+                bandwidth?.let {
+                    if (isNotEmpty()) append(" ")
+                    append(it)
+                }
+                if (isEmpty()) append("Unknown")
+            }
+
+            if (i + 1 < lines.size) {
+                val subUrl = lines[i + 1].trim()
+                if (subUrl.isNotBlank() && !subUrl.startsWith("#")) {
+                    val absoluteUrl = UrlUtils.fixUrl(subUrl, baseUrl) ?: continue
+                    result.add(qualityStr to absoluteUrl)
+                }
             }
         }
+
         return result
     }
 
     /**
-     * Helper to enforce M3u8 Server with a robust retry mechanism.
-     * If the server fails to start or process, it restarts the server and tries again up to 3 times.
-     * If it still fails, returns null so the video gets strictly dropped.
+     * Enforces M3u8 Server with retry mechanism.
+     * If the server fails to start or process, it restarts and tries again up to 3 times.
+     * Returns null so the video gets strictly dropped.
      */
     private suspend fun getProcessedM3u8Url(originalUrl: String): String? {
         repeat(3) { attempt ->
             try {
                 if (!m3u8ServerManager.isRunning()) {
                     m3u8ServerManager.startServer()
-                    // Give NanoHTTPD a fraction of a second to properly bind the port
                     delay(200L)
                 }
 
                 val processedUrl = m3u8ServerManager.processM3u8Url(originalUrl)
                 if (processedUrl != null) return processedUrl
 
-                // If it returned null despite running, the server instance might be corrupted. Restart it.
                 Log.w("Animetsu", "M3U8 server process returned null on attempt ${attempt + 1}, restarting...")
                 m3u8ServerManager.stopServer()
                 delay(500L)
             } catch (e: Exception) {
                 Log.e("Animetsu", "M3U8 server start failed on attempt ${attempt + 1}: ${e.message}")
-                m3u8ServerManager.stopServer() // Ensure clean state
+                m3u8ServerManager.stopServer()
                 delay(500L)
             }
         }
@@ -651,7 +626,7 @@ class Animetsu :
         if (invalidHosters || invalidServer || oldAudioTypes != null) {
             edit().also { editor ->
                 if (invalidHosters) editor.putStringSet(PREF_HOSTER_EXCLUDE_KEY, hostExclusion.filter { it in SERVER_VALUES }.toSet())
-                if (invalidServer) editor.putString(PREF_PREFERRED_SERVER_KEY, PREF_PREFERRED_SERVER_DEFAULT)
+                if (invalidServer) editor.putStringSet(PREF_PREFERRED_SERVER_KEY, PREF_HOSTER_EXCLUDE_DEFAULT)
                 if (oldAudioTypes != null) {
                     val newExclusion = AUDIO_TYPE_VALUES.toSet() - oldAudioTypes
                     editor.putStringSet(PREF_AUDIO_TYPE_EXCLUDE_KEY, newExclusion)
@@ -723,6 +698,10 @@ class Animetsu :
             "NOT_YET_RELEASED" -> SAnime.UNKNOWN
             else -> SAnime.UNKNOWN
         }
+
+        private val DIO_NAME_REGEX by lazy { Regex("""NAME="(.*?)"""") }
+        private val DIO_RESOLUTION_REGEX by lazy { Regex("""RESOLUTION=(\d+x\d+)""") }
+        private val DIO_BANDWIDTH_REGEX by lazy { Regex("""BANDWIDTH=(\d+)""") }
 
         val newLineRegex by lazy { Regex("""<br\s*/?>""", RegexOption.IGNORE_CASE) }
         val textStyleRegex by lazy { Regex("""</?(i|b|em)>""", RegexOption.IGNORE_CASE) }

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -151,7 +151,7 @@ class Animetsu :
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val dto = response.parseAs<AnimetsuRecentDto>()
         val filteredResults = if (hideAdult) dto.results.filter { !it.isAdult } else dto.results
-        val animes = filteredResults.mapNotNull { it.toSAnime(titleLanguage, showTags) }
+        val animes = filteredResults.mapNotNull { it.toSAnime(titleLanguage, showTags, baseUrl = baseUrl) }
 
         return AnimesPage(animes, dto.currentPage < dto.lastPage)
     }
@@ -192,7 +192,7 @@ class Animetsu :
     override fun searchAnimeParse(response: Response): AnimesPage {
         val dto = response.parseAs<AnimetsuSearchDto>()
         val filteredResults = if (hideAdult) dto.results.filter { !it.isAdult } else dto.results
-        val animes = filteredResults.mapNotNull { it.toSAnime(titleLanguage, showTags) }
+        val animes = filteredResults.mapNotNull { it.toSAnime(titleLanguage, showTags, baseUrl = baseUrl) }
 
         return AnimesPage(animes, dto.page < dto.lastPage)
     }
@@ -215,6 +215,7 @@ class Animetsu :
             showTrailer = showTrailer,
             showBanner = showBanner,
         ),
+        baseUrl = baseUrl,
     )!!
 
     // ============================== Related ===============================

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -109,7 +109,6 @@ class Animetsu :
     private fun videoHeaders(referer: String = "$baseUrl/"): Headers = Headers.Builder()
         .add("Accept", "*/*")
         .add("Accept-Language", "en-US,en;q=0.9")
-        .add("Accept-Encoding", "gzip, deflate, br, zstd")
         .add("Origin", baseUrl)
         .add("Referer", referer)
         .add("Sec-Fetch-Dest", "empty")

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -313,8 +313,8 @@ class Animetsu :
                 }.orEmpty()
 
                 val subLabel = when (server.id.lowercase()) {
-                    "baku", "dio", "meg" -> " [Hard Subs]"
-                    "kite" -> " [Soft Subs]"
+                    "baku", "dio", "meg" -> "[Hard Subs]"
+                    "kite" -> "[Soft Subs]"
                     else -> ""
                 }
 
@@ -322,7 +322,7 @@ class Animetsu :
                     val cleanQuality = quality.substringBefore(" ").let { q ->
                         if (q.endsWith("P")) q.lowercase() else q
                     }
-                    "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel"
+                    "${server.id.uppercase()}: $cleanQuality ($audioLabel) $subLabel"
                 }
 
                 dto.sources.parallelCatchingFlatMap { source ->

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -106,6 +106,18 @@ class Animetsu :
         .add("Sec-Fetch-Site", "same-origin")
         .build()
 
+    private fun videoHeaders(referer: String = "$baseUrl/"): Headers = Headers.Builder()
+        .add("Accept", "*/*")
+        .add("Accept-Language", "en-US,en;q=0.9")
+        .add("Accept-Encoding", "gzip, deflate, br, zstd")
+        .add("Origin", baseUrl)
+        .add("Referer", referer)
+        .add("Sec-Fetch-Dest", "empty")
+        .add("Sec-Fetch-Mode", "cors")
+        .add("Sec-Fetch-Site", "cross-site")
+        .add("User-Agent", "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36")
+        .build()
+
     private val rateLimit = 5
 
     override val client by lazy {
@@ -270,7 +282,7 @@ class Animetsu :
         val sortedAudioTypes = enabledAudioTypes
             .sortedByDescending { type -> type == preferredAudioType }
 
-        val playlistUtils = PlaylistUtils(client, apiHeaders(watchReferer))
+        val playlistUtils = PlaylistUtils(client, videoHeaders()) // ← changed
 
         return servers.parallelFlatMap { server ->
             sortedAudioTypes.parallelCatchingFlatMap { sourceType ->
@@ -303,7 +315,7 @@ class Animetsu :
                                 fullUrl,
                                 "${server.id.uppercase()}: ${source.quality} ($audioLabel)$subLabel",
                                 fullUrl,
-                                apiHeaders(watchReferer),
+                                videoHeaders(),
                                 subtitleTracks,
                             ).let(::listOf)
                         source.type?.contains("mpegurl") == true ->

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.preference.PreferenceScreen
 import aniyomi.lib.m3u8server.M3u8ServerManager
+import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -15,7 +16,6 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
-import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.addSwitchPreference
@@ -62,6 +62,9 @@ class Animetsu :
 
     // M3u8ServerManager uses the m3u8Client to ensure the local server also fetches segments via HTTP/1.1
     private val m3u8ServerManager by lazy { M3u8ServerManager(m3u8Client) }
+
+    // PlaylistUtils uses m3u8Client for HTTP/1.1 and to handle potential garbage prefix in responses
+    private val playlistUtils by lazy { PlaylistUtils(m3u8Client) }
 
     private val titleLanguage: String
         get() = preferences.getString(PREF_TITLE_LANG_KEY, PREF_TITLE_LANG_DEFAULT) ?: PREF_TITLE_LANG_DEFAULT
@@ -290,8 +293,8 @@ class Animetsu :
         val allServers = serverResponse.parseAs<List<AnimetsuServerDto>>()
 
         val servers = allServers
-            .filter { server -> server.id !in excludedHosts }
-            .sortedByDescending { server -> server.id == preferredServer }
+            .filter { server -> server.id.lowercase() !in excludedHosts }
+            .sortedByDescending { server -> server.id.equals(preferredServer, ignoreCase = true) }
 
         val sortedAudioTypes = enabledAudioTypes
             .sortedByDescending { type -> type == preferredAudioType }
@@ -310,8 +313,8 @@ class Animetsu :
                 }.orEmpty()
 
                 val subLabel = when (server.id.lowercase()) {
-                    "baku", "dio", "meg" -> "[Hard Subs]"
-                    "kite" -> "[Soft Subs]"
+                    "baku", "dio", "meg" -> " [Hard Subs]"
+                    "kite" -> " [Soft Subs]"
                     else -> ""
                 }
 
@@ -319,7 +322,7 @@ class Animetsu :
                     val cleanQuality = quality.substringBefore(" ").let { q ->
                         if (q.endsWith("P")) q.lowercase() else q
                     }
-                    "${server.id.uppercase()}: $cleanQuality ($audioLabel) $subLabel"
+                    "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel"
                 }
 
                 dto.sources.parallelCatchingFlatMap { source ->
@@ -506,11 +509,11 @@ class Animetsu :
     // ============================= Utilities ==============================
 
     /**
-     * Dedicated helper for fetching, parsing, and enforcing the local M3U8 server for all HLS sources.
+     * Fetches and parses HLS playlists using PlaylistUtils with m3u8Client (HTTP/1.1),
+     * then enforces local M3U8 server proxying for all extracted videos.
      *
-     * Some server responses may have non-M3U8 content before the actual playlist (garbage prefix),
-     * which standard extractors cannot handle since they fetch URLs internally.
-     * This method pre-fetches with m3u8Client, strips any garbage, then parses manually.
+     * PlaylistUtils' parsing naturally handles any garbage prefix before the actual M3U8
+     * content since it uses `substringAfter("#EXT-X-STREAM-INF:")` internally.
      */
     private suspend fun processHls(
         fullUrl: String,
@@ -518,22 +521,16 @@ class Animetsu :
         watchReferer: String,
         subtitleTracks: List<Track>,
     ): List<Video> {
-        val body = m3u8Client.newCall(GET(fullUrl, videoHeaders(watchReferer)))
-            .awaitSuccess().body.string()
-        val m3u8Start = body.indexOf("#EXTM3U")
-        if (m3u8Start == -1) return emptyList()
+        val vidHeaders = videoHeaders(watchReferer)
 
-        val m3u8Content = body.substring(m3u8Start)
-        val headers = videoHeaders(watchReferer)
-        val subPlaylists = parseSubPlaylists(m3u8Content, fullUrl)
-
-        val videos = if (subPlaylists.isEmpty()) {
-            listOf(Video(fullUrl, videoNameGen("Unknown"), fullUrl, headers, subtitleTracks))
-        } else {
-            subPlaylists.map { (quality, url) ->
-                Video(url, videoNameGen(quality), url, headers, subtitleTracks)
-            }
-        }
+        val videos = playlistUtils.extractFromHls(
+            playlistUrl = fullUrl,
+            referer = watchReferer,
+            masterHeaders = vidHeaders,
+            videoHeaders = vidHeaders,
+            videoNameGen = videoNameGen,
+            subtitleList = subtitleTracks,
+        )
 
         // ENFORCE M3U8 SERVER: proxy through local server, drop if it fails
         return videos.mapNotNull { video ->
@@ -547,42 +544,6 @@ class Animetsu :
                 audioTracks = video.audioTracks,
             )
         }
-    }
-
-    /**
-     * Parses sub-playlists from an M3U8 master playlist.
-     */
-    private fun parseSubPlaylists(m3u8Content: String, baseUrl: String): List<Pair<String, String>> {
-        val lines = m3u8Content.lines()
-        val result = mutableListOf<Pair<String, String>>()
-
-        for (i in lines.indices) {
-            if (!lines[i].startsWith("#EXT-X-STREAM-INF:")) continue
-
-            val line = lines[i]
-            val name = M3U8_NAME_REGEX.find(line)?.groupValues?.get(1)
-            val resolution = M3U8_RESOLUTION_REGEX.find(line)?.groupValues?.get(1)
-            val bandwidth = M3U8_BANDWIDTH_REGEX.find(line)?.groupValues?.get(1)
-
-            val qualityStr = name ?: buildString {
-                resolution?.let { append(it.substringAfter("x")).append("p") }
-                bandwidth?.let {
-                    if (isNotEmpty()) append(" ")
-                    append(it)
-                }
-                if (isEmpty()) append("Unknown")
-            }
-
-            if (i + 1 < lines.size) {
-                val subUrl = lines[i + 1].trim()
-                if (subUrl.isNotBlank() && !subUrl.startsWith("#")) {
-                    val absoluteUrl = UrlUtils.fixUrl(subUrl, baseUrl) ?: continue
-                    result.add(qualityStr to absoluteUrl)
-                }
-            }
-        }
-
-        return result
     }
 
     /**
@@ -698,10 +659,6 @@ class Animetsu :
             "NOT_YET_RELEASED" -> SAnime.UNKNOWN
             else -> SAnime.UNKNOWN
         }
-
-        private val M3U8_NAME_REGEX by lazy { Regex("""NAME="(.*?)"""") }
-        private val M3U8_RESOLUTION_REGEX by lazy { Regex("""RESOLUTION=(\d+x\d+)""") }
-        private val M3U8_BANDWIDTH_REGEX by lazy { Regex("""BANDWIDTH=(\d+)""") }
 
         val newLineRegex by lazy { Regex("""<br\s*/?>""", RegexOption.IGNORE_CASE) }
         val textStyleRegex by lazy { Regex("""</?(i|b|em)>""", RegexOption.IGNORE_CASE) }

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -550,7 +550,7 @@ class Animetsu :
                     val subUrl = lines[i + 1].trim()
                     val absoluteSubUrl = when {
                         subUrl.startsWith("http") -> subUrl
-                        subUrl.startsWith("//") -> "${fullUrl.toHttpUrl().scheme}:$subUrl" // Prevents https:////
+                        subUrl.startsWith("//") -> "${fullUrl.toHttpUrl().scheme}:$subUrl"
                         subUrl.startsWith("/") -> {
                             val httpUrl = fullUrl.toHttpUrl()
                             "${httpUrl.scheme}://${httpUrl.host}$subUrl"
@@ -604,7 +604,6 @@ class Animetsu :
                 )
             } else {
                 // If the server fails to proxy the URL, we MUST NOT add the raw URL.
-                // Adding the raw URL causes "cubes" / macroblocking.
                 Log.e("Animetsu", "Dropping Dio video due to M3U8 server failure.")
             }
         }

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -120,14 +120,11 @@ class Animetsu :
         .add("Sec-Fetch-Site", "same-origin")
         .build()
 
-    private fun videoHeaders(referer: String = "$baseUrl/"): Headers = Headers.Builder()
-        .add("Accept", "*/*")
-        .add("Accept-Language", "en-US,en;q=0.9")
+    // Builds video headers from API headers, overriding only the specific fields needed for video streams
+    private fun videoHeaders(referer: String = "$baseUrl/"): Headers = apiHeaders(referer).newBuilder()
+        .set("Accept", "*/*")
+        .set("Sec-Fetch-Site", "cross-site")
         .add("Origin", baseUrl)
-        .add("Referer", referer)
-        .add("Sec-Fetch-Dest", "empty")
-        .add("Sec-Fetch-Mode", "cors")
-        .add("Sec-Fetch-Site", "cross-site")
         .add("User-Agent", "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36")
         .build()
 
@@ -328,90 +325,9 @@ class Animetsu :
 
                     try {
                         if (isDio && source.type?.contains("mpegurl") == true) {
-                            val body = dioClient.newCall(GET(fullUrl, videoHeaders(watchReferer))).awaitSuccess().body.string()
-                            val m3u8Start = body.indexOf("#EXTM3U")
-                            if (m3u8Start == -1) return@forEach
-                            val m3u8Content = body.substring(m3u8Start)
-
-                            val subPlaylists = mutableListOf<Pair<String, String>>()
-                            val lines = m3u8Content.lines()
-                            for (i in lines.indices) {
-                                if (lines[i].startsWith("#EXT-X-STREAM-INF:")) {
-                                    val resolution = Regex("RESOLUTION=(\\d+x\\d+)").find(lines[i])?.groupValues?.get(1)
-                                    val bandwidth = Regex("BANDWIDTH=(\\d+)").find(lines[i])?.groupValues?.get(1)
-                                    val name = Regex("NAME=\"(.*?)\"").find(lines[i])?.groupValues?.get(1)
-                                    val qualityStr = name ?: buildString {
-                                        if (resolution != null) {
-                                            append(resolution.substringAfter("x"))
-                                            append("p")
-                                        }
-                                        if (bandwidth != null) {
-                                            if (isNotEmpty()) append(" ")
-                                            append(bandwidth)
-                                        }
-                                        if (isEmpty()) append("Unknown")
-                                    }
-                                    if (i + 1 < lines.size && lines[i + 1].isNotBlank() && !lines[i + 1].startsWith("#")) {
-                                        val subUrl = lines[i + 1].trim()
-                                        val absoluteSubUrl = when {
-                                            subUrl.startsWith("http") -> subUrl
-                                            subUrl.startsWith("//") -> {
-                                                val httpUrl = fullUrl.toHttpUrl()
-                                                "${httpUrl.scheme}://$subUrl"
-                                            }
-                                            subUrl.startsWith("/") -> {
-                                                val httpUrl = fullUrl.toHttpUrl()
-                                                "${httpUrl.scheme}://${httpUrl.host}$subUrl"
-                                            }
-                                            else -> fullUrl.substringBeforeLast("/") + "/" + subUrl
-                                        }
-                                        subPlaylists.add(qualityStr to absoluteSubUrl)
-                                    }
-                                }
-                            }
-
-                            val dioVideos = if (subPlaylists.isEmpty()) {
-                                listOf(
-                                    Video(
-                                        fullUrl,
-                                        "${server.id.uppercase()}: Unknown ($audioLabel)$subLabel",
-                                        fullUrl,
-                                        videoHeaders(watchReferer),
-                                        subtitleTracks,
-                                    ),
-                                )
-                            } else {
-                                subPlaylists.map { (qualityStr, url) ->
-                                    val cleanQuality = qualityStr.substringBefore(" ").let { q ->
-                                        if (q.endsWith("P")) q.lowercase() else q
-                                    }
-                                    Video(
-                                        url,
-                                        "${server.id.uppercase()}: $cleanQuality ($audioLabel)$subLabel",
-                                        url,
-                                        videoHeaders(watchReferer),
-                                        subtitleTracks,
-                                    )
-                                }
-                            }
-                            for (video in dioVideos) {
-                                val processedUrl = getProcessedM3u8Url(video.url)
-                                if (processedUrl != null) {
-                                    videos.add(
-                                        Video(
-                                            url = processedUrl,
-                                            quality = video.quality,
-                                            videoUrl = processedUrl,
-                                            headers = video.headers,
-                                            subtitleTracks = video.subtitleTracks,
-                                            audioTracks = video.audioTracks,
-                                        ),
-                                    )
-                                } else {
-                                    // If the server fails to proxy the URL, we MUST NOT add the raw URL.
-                                    Log.e("Animetsu", "Dropping Dio video due to M3U8 server failure.")
-                                }
-                            }
+                            videos.addAll(
+                                parseDioM3u8Playlists(fullUrl, server.id, audioLabel, subLabel, watchReferer, subtitleTracks),
+                            )
                         } else if (source.type?.contains("mp4") == true) {
                             videos.add(
                                 Video(
@@ -437,7 +353,8 @@ class Animetsu :
                                 ),
                             )
                         }
-                    } catch (_: Exception) {
+                    } catch (e: Exception) {
+                        Log.w("Animetsu", "Failed to fetch or parse sources", e)
                     }
                 }
 
@@ -594,6 +511,106 @@ class Animetsu :
     }
 
     // ============================= Utilities ==============================
+
+    /**
+     * Dedicated helper for fetching, parsing, and enforcing the local M3U8 server for Dio.
+     * Extracts the complex logic out of the main video list flow.
+     */
+    private suspend fun parseDioM3u8Playlists(
+        fullUrl: String,
+        serverId: String,
+        audioLabel: String,
+        subLabel: String,
+        watchReferer: String,
+        subtitleTracks: List<Track>,
+    ): List<Video> {
+        val body = dioClient.newCall(GET(fullUrl, videoHeaders(watchReferer))).awaitSuccess().body.string()
+        val m3u8Start = body.indexOf("#EXTM3U")
+        if (m3u8Start == -1) return emptyList()
+        val m3u8Content = body.substring(m3u8Start)
+
+        val subPlaylists = mutableListOf<Pair<String, String>>()
+        val lines = m3u8Content.lines()
+        for (i in lines.indices) {
+            if (lines[i].startsWith("#EXT-X-STREAM-INF:")) {
+                val resolution = Regex("RESOLUTION=(\\d+x\\d+)").find(lines[i])?.groupValues?.get(1)
+                val bandwidth = Regex("BANDWIDTH=(\\d+)").find(lines[i])?.groupValues?.get(1)
+                val name = Regex("NAME=\"(.*?)\"").find(lines[i])?.groupValues?.get(1)
+                val qualityStr = name ?: buildString {
+                    if (resolution != null) {
+                        append(resolution.substringAfter("x"))
+                        append("p")
+                    }
+                    if (bandwidth != null) {
+                        if (isNotEmpty()) append(" ")
+                        append(bandwidth)
+                    }
+                    if (isEmpty()) append("Unknown")
+                }
+                if (i + 1 < lines.size && lines[i + 1].isNotBlank() && !lines[i + 1].startsWith("#")) {
+                    val subUrl = lines[i + 1].trim()
+                    val absoluteSubUrl = when {
+                        subUrl.startsWith("http") -> subUrl
+                        subUrl.startsWith("//") -> "${fullUrl.toHttpUrl().scheme}:$subUrl" // Prevents https:////
+                        subUrl.startsWith("/") -> {
+                            val httpUrl = fullUrl.toHttpUrl()
+                            "${httpUrl.scheme}://${httpUrl.host}$subUrl"
+                        }
+                        else -> fullUrl.substringBeforeLast("/") + "/" + subUrl
+                    }
+                    subPlaylists.add(qualityStr to absoluteSubUrl)
+                }
+            }
+        }
+
+        val dioVideos = if (subPlaylists.isEmpty()) {
+            listOf(
+                Video(
+                    fullUrl,
+                    "${serverId.uppercase()}: Unknown ($audioLabel)$subLabel",
+                    fullUrl,
+                    videoHeaders(watchReferer),
+                    subtitleTracks,
+                ),
+            )
+        } else {
+            subPlaylists.map { (qualityStr, url) ->
+                val cleanQuality = qualityStr.substringBefore(" ").let { q ->
+                    if (q.endsWith("P")) q.lowercase() else q
+                }
+                Video(
+                    url,
+                    "${serverId.uppercase()}: $cleanQuality ($audioLabel)$subLabel",
+                    url,
+                    videoHeaders(watchReferer),
+                    subtitleTracks,
+                )
+            }
+        }
+
+        // ENFORCE M3U8 SERVER FOR DIO: Force process and drop if it fails
+        val result = mutableListOf<Video>()
+        for (video in dioVideos) {
+            val processedUrl = getProcessedM3u8Url(video.url)
+            if (processedUrl != null) {
+                result.add(
+                    Video(
+                        url = processedUrl,
+                        quality = video.quality,
+                        videoUrl = processedUrl,
+                        headers = video.headers,
+                        subtitleTracks = video.subtitleTracks,
+                        audioTracks = video.audioTracks,
+                    ),
+                )
+            } else {
+                // If the server fails to proxy the URL, we MUST NOT add the raw URL.
+                // Adding the raw URL causes "cubes" / macroblocking.
+                Log.e("Animetsu", "Dropping Dio video due to M3U8 server failure.")
+            }
+        }
+        return result
+    }
 
     /**
      * Helper to enforce M3u8 Server with a robust retry mechanism.

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -313,7 +313,7 @@ class Animetsu :
                 }.orEmpty()
 
                 val subLabel = when (server.id.lowercase()) {
-                    "baku", "dio", "meg" -> "[Hard Subs]"
+                    "sage", "dio", "meg" -> "[Hard Subs]"
                     "kite" -> "[Soft Subs]"
                     else -> ""
                 }
@@ -337,7 +337,7 @@ class Animetsu :
                             listOf(
                                 Video(
                                     fullUrl,
-                                    "${server.id.uppercase()}: ${source.quality} ($audioLabel)$subLabel",
+                                    "${server.id.uppercase()}: ${source.quality} ($audioLabel) $subLabel",
                                     fullUrl,
                                     videoHeaders(watchReferer),
                                     subtitleTracks,
@@ -607,13 +607,13 @@ class Animetsu :
 
         private const val PREF_PREFERRED_SERVER_KEY = "preferred_server"
         private const val PREF_PREFERRED_SERVER_DEFAULT = "none"
-        private val PREF_PREFERRED_SERVER_ENTRIES = listOf("None", "Baku - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kite - Multi Quality")
-        private val PREF_PREFERRED_SERVER_VALUES = listOf("none", "baku", "dio", "meg", "kite")
+        private val PREF_PREFERRED_SERVER_ENTRIES = listOf("None", "Sage - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kite - Multi Quality")
+        private val PREF_PREFERRED_SERVER_VALUES = listOf("none", "sage", "dio", "meg", "kite")
 
         private const val PREF_HOSTER_EXCLUDE_KEY = "hoster_exclusion"
         private val PREF_HOSTER_EXCLUDE_DEFAULT = emptySet<String>()
-        private val SERVER_ENTRIES = listOf("Baku - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kite - Multi Quality")
-        private val SERVER_VALUES = listOf("baku", "dio", "meg", "kite")
+        private val SERVER_ENTRIES = listOf("Sage - Multi Quality", "Dio - Multi Quality", "Meg - Multi Quality", "Kite - Multi Quality")
+        private val SERVER_VALUES = listOf("sage", "dio", "meg", "kite")
 
         private const val PREF_PREFERRED_AUDIO_TYPE_KEY = "preferred_audio_type"
         private const val PREF_PREFERRED_AUDIO_TYPE_DEFAULT = "none"

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -24,6 +24,7 @@ import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parallelFlatMap
 import keiyoushi.utils.parseAs
+import kotlinx.coroutines.delay
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Protocol
@@ -393,17 +394,10 @@ class Animetsu :
                                     )
                                 }
                             }
-                            if (!m3u8ServerManager.isRunning()) {
-                                try {
-                                    m3u8ServerManager.startServer()
-                                } catch (e: Exception) {
-                                    Log.e("Animetsu", "Failed to start M3U8 server: ${e.message}")
-                                }
-                            }
-                            videos.addAll(
-                                dioVideos.map { video ->
-                                    val processedUrl = m3u8ServerManager.processM3u8Url(video.url)
-                                    if (processedUrl != null) {
+                            for (video in dioVideos) {
+                                val processedUrl = getProcessedM3u8Url(video.url)
+                                if (processedUrl != null) {
+                                    videos.add(
                                         Video(
                                             url = processedUrl,
                                             quality = video.quality,
@@ -411,12 +405,13 @@ class Animetsu :
                                             headers = video.headers,
                                             subtitleTracks = video.subtitleTracks,
                                             audioTracks = video.audioTracks,
-                                        )
-                                    } else {
-                                        video
-                                    }
-                                },
-                            )
+                                        ),
+                                    )
+                                } else {
+                                    // If the server fails to proxy the URL, we MUST NOT add the raw URL.
+                                    Log.e("Animetsu", "Dropping Dio video due to M3U8 server failure.")
+                                }
+                            }
                         } else if (source.type?.contains("mp4") == true) {
                             videos.add(
                                 Video(
@@ -599,6 +594,38 @@ class Animetsu :
     }
 
     // ============================= Utilities ==============================
+
+    /**
+     * Helper to enforce M3u8 Server with a robust retry mechanism.
+     * If the server fails to start or process, it restarts the server and tries again up to 3 times.
+     * If it still fails, returns null so the video gets strictly dropped.
+     */
+    private suspend fun getProcessedM3u8Url(originalUrl: String): String? {
+        repeat(3) { attempt ->
+            try {
+                if (!m3u8ServerManager.isRunning()) {
+                    m3u8ServerManager.startServer()
+                    // Give NanoHTTPD a fraction of a second to properly bind the port
+                    delay(200L)
+                }
+
+                val processedUrl = m3u8ServerManager.processM3u8Url(originalUrl)
+                if (processedUrl != null) return processedUrl
+
+                // If it returned null despite running, the server instance might be corrupted. Restart it.
+                Log.w("Animetsu", "M3U8 server process returned null on attempt ${attempt + 1}, restarting...")
+                m3u8ServerManager.stopServer()
+                delay(500L)
+            } catch (e: Exception) {
+                Log.e("Animetsu", "M3U8 server start failed on attempt ${attempt + 1}: ${e.message}")
+                m3u8ServerManager.stopServer() // Ensure clean state
+                delay(500L)
+            }
+        }
+
+        Log.e("Animetsu", "M3U8 server failed to process URL after 3 attempts. Dropping video to prevent cubes.")
+        return null
+    }
 
     private fun SharedPreferences.clearOldPrefs() {
         val hostExclusion = getStringSet(PREF_HOSTER_EXCLUDE_KEY, PREF_HOSTER_EXCLUDE_DEFAULT)!!

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -375,8 +375,7 @@ class Animetsu :
         return sortedWith(
             compareByDescending<Video> { it.quality.contains(quality) }
                 .thenByDescending { video -> qualitiesList.indexOfLast { video.quality.contains(it) } }
-                .thenByDescending { it.quality.contains(server, true) }
-                .thenByDescending { it.quality.contains(type, true) },
+                .thenByDescending { it.quality.contains(server, true) },
         )
     }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/AnimetsuDto.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/AnimetsuDto.kt
@@ -20,6 +20,7 @@ class TagField(
     val showRelations: Boolean = true,
     val showTrackers: Boolean = true,
     val showTrailer: Boolean = true,
+    val showBanner: Boolean = true,
 )
 
 @Serializable
@@ -38,6 +39,13 @@ data class AnimetsuRecentDto(
 )
 
 @Serializable
+data class AnimetsuNextAiringEpisodeDto(
+    @SerialName("airing_at") val airingAt: Long? = null,
+    @SerialName("ep_num") val epNum: Int? = null,
+    @SerialName("time_left") val timeLeft: Long? = null,
+)
+
+@Serializable
 data class AnimetsuAnimeDto(
     val id: String,
     val type: String? = null,
@@ -50,6 +58,8 @@ data class AnimetsuAnimeDto(
     @SerialName("total_eps") val totalEps: Int? = null,
     @SerialName("start_date") val startDate: String? = null,
     @SerialName("end_date") val endDate: String? = null,
+    @SerialName("next_airing_ep") val nextAiringEp: AnimetsuNextAiringEpisodeDto? = null,
+    val rank: Int? = null,
     val year: Int? = null,
     val format: String? = null,
     val duration: Int? = null,
@@ -112,6 +122,18 @@ data class AnimetsuAnimeDto(
         return "${"★".repeat(stars)}${"☆".repeat(5 - stars)} $score"
     }
 
+    private fun formatTimeLeft(seconds: Long): String {
+        val days = seconds / 86400
+        val hours = (seconds % 86400) / 3600
+        val minutes = (seconds % 3600) / 60
+
+        return buildString {
+            if (days > 0) append("${days}d ")
+            if (hours > 0) append("${hours}h ")
+            if (minutes > 0 && days == 0L) append("${minutes}m")
+        }.trim()
+    }
+
     fun buildDescription(tagField: TagField): String {
         val desc = StringBuilder()
 
@@ -121,6 +143,8 @@ data class AnimetsuAnimeDto(
                 desc.append(fancyScore)
             }
         }
+        rank?.let { desc.append(" #$it") }
+        trending?.takeIf { it > 0 }?.let { desc.append(" Trending") }
 
         description?.cleanHtml()?.let {
             if (desc.isNotBlank()) desc.append("\n\n")
@@ -154,12 +178,24 @@ data class AnimetsuAnimeDto(
                 desc.append(meta.joinToString(" | "))
             }
 
-            val dates = mutableListOf<String>()
-            startDate?.let { dates.add("**Start**: $it") }
-            endDate?.let { dates.add("**End**: $it") }
-            if (dates.isNotEmpty()) {
+            val scheduleInfo = buildString {
+                val dates = mutableListOf<String>()
+                startDate?.let { dates.add("**Start**: $it") }
+                endDate?.let { dates.add("**End**: $it") }
+                if (dates.isNotEmpty()) append(dates.joinToString(" | ")).append("\n")
+
+                nextAiringEp?.let { next ->
+                    next.epNum?.let { epNum ->
+                        val timeStr = next.timeLeft?.let { formatTimeLeft(it) } ?: ""
+                        val nextText = if (timeStr.isNotEmpty()) "Ep. $epNum in $timeStr" else "Ep. $epNum"
+                        append("**Next Episode**: $nextText")
+                    }
+                }
+            }.trimEnd()
+
+            if (scheduleInfo.isNotBlank()) {
                 if (desc.isNotBlank()) desc.append("\n\n")
-                desc.append(dates.joinToString(" | "))
+                desc.append(scheduleInfo)
             }
 
             synonyms?.takeIf { it.isNotEmpty() }?.let {
@@ -180,7 +216,6 @@ data class AnimetsuAnimeDto(
             val stats = mutableListOf<String>()
             popularity?.let { stats.add("**Popularity**: $it") }
             favourites?.let { stats.add("**Favourites**: $it") }
-            trending?.let { if (it > 0) stats.add("**Trending**: $it") }
             users?.let { stats.add("**Bookmarked**: $it") }
             if (stats.isNotEmpty()) {
                 if (desc.isNotBlank()) desc.append("\n")
@@ -255,6 +290,18 @@ data class AnimetsuAnimeDto(
             trailer?.takeIf { it.isNotBlank() && it != "-" }?.let {
                 if (desc.isNotBlank()) desc.append("\n\n")
                 desc.append("[Trailer](https://www.youtube.com/watch?v=$it)")
+            }
+        }
+
+        if (tagField.showBanner) {
+            banner?.takeIf { it.isNotBlank() }?.let {
+                val bannerUrl = when {
+                    it.startsWith("http") -> it
+                    it.startsWith("/") -> "https://animetsu.net$it"
+                    else -> "https://animetsu.net/$it"
+                }
+                if (desc.isNotBlank()) desc.append("\n\n")
+                desc.append("![Banner]($bannerUrl)")
             }
         }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/AnimetsuDto.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/AnimetsuDto.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.animeextension.all.animetsu.Animetsu.Companion.parseS
 import eu.kanade.tachiyomi.animeextension.all.animetsu.Animetsu.Companion.textStyleRegex
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
+import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -93,7 +94,7 @@ data class AnimetsuAnimeDto(
         titleLanguage: String,
         showTags: Boolean,
         tagField: TagField = TagField(),
-        baseUrl: String = "",
+        baseUrl: String,
     ): SAnime? = SAnime.create().apply {
         val dto = this@AnimetsuAnimeDto
         url = dto.id
@@ -135,7 +136,7 @@ data class AnimetsuAnimeDto(
         }.trim()
     }
 
-    fun buildDescription(tagField: TagField, baseUrl: String = ""): String {
+    fun buildDescription(tagField: TagField, baseUrl: String): String {
         val desc = StringBuilder()
 
         averageScore?.let { score ->
@@ -296,11 +297,7 @@ data class AnimetsuAnimeDto(
 
         if (tagField.showBanner) {
             banner?.takeIf { it.isNotBlank() }?.let {
-                val bannerUrl = when {
-                    it.startsWith("http") -> it
-                    it.startsWith("/") -> "$baseUrl$it"
-                    else -> "$baseUrl/$it"
-                }
+                val bannerUrl = UrlUtils.fixUrl(it, baseUrl) ?: return@let
                 if (desc.isNotBlank()) desc.append("\n\n")
                 desc.append("![Banner]($bannerUrl)")
             }

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/AnimetsuDto.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/AnimetsuDto.kt
@@ -93,6 +93,7 @@ data class AnimetsuAnimeDto(
         titleLanguage: String,
         showTags: Boolean,
         tagField: TagField = TagField(),
+        baseUrl: String = "",
     ): SAnime? = SAnime.create().apply {
         val dto = this@AnimetsuAnimeDto
         url = dto.id
@@ -104,7 +105,7 @@ data class AnimetsuAnimeDto(
         genre = (genreList + tagList).joinToString().takeIf { it.isNotBlank() }
 
         status = parseStatus(dto.status)
-        description = dto.buildDescription(tagField).takeIf { it.isNotBlank() }
+        description = dto.buildDescription(tagField, baseUrl).takeIf { it.isNotBlank() }
         artist = dto.staff?.filter {
             it.role in listOf("Original Story", "Original Creator", "Original Character Design")
         }?.mapNotNull { it.name }?.joinToString()
@@ -134,7 +135,7 @@ data class AnimetsuAnimeDto(
         }.trim()
     }
 
-    fun buildDescription(tagField: TagField): String {
+    fun buildDescription(tagField: TagField, baseUrl: String = ""): String {
         val desc = StringBuilder()
 
         averageScore?.let { score ->
@@ -297,8 +298,8 @@ data class AnimetsuAnimeDto(
             banner?.takeIf { it.isNotBlank() }?.let {
                 val bannerUrl = when {
                     it.startsWith("http") -> it
-                    it.startsWith("/") -> "https://animetsu.net$it"
-                    else -> "https://animetsu.net/$it"
+                    it.startsWith("/") -> "$baseUrl$it"
+                    else -> "$baseUrl/$it"
                 }
                 if (desc.isNotBlank()) desc.append("\n\n")
                 desc.append("![Banner]($bannerUrl)")


### PR DESCRIPTION
Closes #516.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] This PR is Secozzi-assisted, thanks for the help :)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the Animetsu extension to use dedicated video request headers and bump its version code.

Bug Fixes:
- Adjust video request headers, including a mobile User-Agent and CORS-related fields, to resolve 403 errors when fetching streams.

Enhancements:
- Introduce a reusable video-specific headers builder to unify video streaming requests.

Build:
- Bump Animetsu extension version code from 5 to 6.

## Summary by Sourcery

Update the Animetsu extension’s video streaming pipeline to use dedicated headers and a local M3U8 proxy for more reliable Dio playback, and bump its version code.

New Features:
- Introduce a dedicated video headers builder for all video and playlist requests.
- Add an M3U8 server manager backed by a custom HTTP/1.1 client with extended read timeouts to proxy Dio HLS streams.

Bug Fixes:
- Adjust video request headers, including a mobile User-Agent, to prevent 403 errors when fetching video streams.
- Handle Dio HLS playlists via a local M3U8 proxy with retries, dropping invalid URLs to avoid broken playback.

Enhancements:
- Refine HLS extraction flow to reuse video headers and support processed M3U8 URLs for Dio sources.

Build:
- Bump Animetsu extension version code from 5 to 6 and add the m3u8server library dependency.