### PR TITLE
Cineby [EN]: Remove movieOnly Requirement For Yoru

### DIFF
--- a/src/en/cineby/build.gradle
+++ b/src/en/cineby/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cineby'
     extClass = '.Cineby'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -394,7 +394,6 @@ class CinebyExtractor(
                 "Yoru",
                 "https://api.videasy.to",
                 "cdn",
-                movieOnly = true,
                 mayHave4K = true,
                 audioLabel = "Original",
             ),


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Allow the Cineby Yoru provider to handle non-movie content by removing the movie-only restriction and bumping the extension version code.

Enhancements:
- Relax the Cineby Yoru provider content type restriction by removing the movie-only flag.

Build:
- Increment the Cineby extension version code to 6.