### PR TITLE
MundoDonghua [ES]: Update selectors and video extraction for new site theme

### DIFF
--- a/src/es/mundodonghua/build.gradle
+++ b/src/es/mundodonghua/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MundoDonghua'
     extClass = '.MundoDonghua'
-    extVersionCode = 42
+    extVersionCode = 43
 }
 
 apply plugin: "kei.plugins.extension.legacy"
@@ -12,4 +12,6 @@ dependencies {
     implementation(project(':lib:dailymotionextractor'))
     implementation(project(':lib:playlistutils'))
     implementation(project(':lib:unpacker'))
+    implementation(project(':lib:streamwishextractor'))
+    implementation(project(':lib:vidhideextractor'))
 }

--- a/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
+++ b/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
@@ -19,6 +19,8 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.lib.autoUnpacker
 import keiyoushi.utils.getPreferencesLazy
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -83,7 +85,7 @@ class MundoDonghua :
 
     private fun episodeFromElement(element: Element): SEpisode {
         val episode = SEpisode.create()
-        val epNum = element.attr("href").split("/").last().toFloat()
+        val epNum = element.attr("href").trimEnd('/').split("/").lastOrNull()?.toFloatOrNull() ?: 0f
         episode.setUrlWithoutDomain(element.absUrl("href"))
         episode.episode_number = epNum
         episode.name = "Episodio ${epNum.toString().removeSuffix(".0")}"
@@ -97,84 +99,95 @@ class MundoDonghua :
 
     override fun videoListParse(response: Response): List<Video> {
         val document = response.asJsoup()
-        val videoList = mutableListOf<Video>()
+        val tasks = mutableListOf<suspend () -> List<Video>>()
+
         document.select("script").forEach { script ->
-            if (script.data().contains("eval(function(p,a,c,k,e")) {
-                PACKED_REGEX.findAll(script.data()).map {
-                    it.value
-                }.toList().forEach {
-                    val unpack = autoUnpacker(it) ?: return@forEach
-                    if (unpack.contains("amagi_tab")) {
-                        fetchUrls(unpack).forEach { url ->
+            val scriptData = script.data()
+            if (scriptData.contains("eval(function(p,a,c,k,e")) {
+                val unpack = autoUnpacker(scriptData) ?: return@forEach
+                val urls = fetchUrls(unpack)
+
+                if (unpack.contains("amagi_tab")) {
+                    urls.forEach { url ->
+                        tasks.add {
                             try {
-                                VoeExtractor(client, headers).videosFromUrl(url).also(videoList::addAll)
-                            } catch (_: Exception) {}
+                                VoeExtractor(client, headers).videosFromUrl(url)
+                            } catch (_: Exception) {
+                                emptyList()
+                            }
                         }
                     }
-                    if (unpack.contains("fmoon_tab")) {
-                        fetchUrls(unpack).forEach { url ->
+                }
+                if (unpack.contains("fmoon_tab")) {
+                    urls.forEach { url ->
+                        tasks.add {
                             try {
                                 val newHeaders = headers.newBuilder()
                                     .add("authority", url.toHttpUrl().host)
                                     .add("referer", "$baseUrl/")
                                     .add("Origin", "https://${url.toHttpUrl().host}")
                                     .build()
-                                FilemoonExtractor(client).videosFromUrl(url, prefix = "Filemoon:", headers = newHeaders).also(videoList::addAll)
-                            } catch (_: Exception) {}
-                        }
-                    }
-                    if (unpack.contains("vhide_tab")) {
-                        val vidhideUrls = fetchUrls(unpack).filter { it.contains("vidhide") }
-                        if (vidhideUrls.isNotEmpty()) {
-                            runBlocking {
-                                vidhideUrls.forEach { url ->
-                                    try {
-                                        val newHeaders = headers.newBuilder()
-                                            .add("authority", url.toHttpUrl().host)
-                                            .add("referer", "$baseUrl/")
-                                            .add("Origin", baseUrl)
-                                            .build()
-                                        VidHideExtractor(client, newHeaders).videosFromUrl(url) { "VidHide:$it" }.also(videoList::addAll)
-                                    } catch (_: Exception) {}
-                                }
+                                FilemoonExtractor(client).videosFromUrl(url, prefix = "Filemoon:", headers = newHeaders)
+                            } catch (_: Exception) {
+                                emptyList()
                             }
                         }
                     }
-                    if (unpack.contains("swish_tab")) {
-                        val swishUrls = fetchUrls(unpack).filter { it.contains("embedwish") }
-                        if (swishUrls.isNotEmpty()) {
-                            runBlocking {
-                                swishUrls.forEach { url ->
-                                    try {
-                                        val newHeaders = headers.newBuilder()
-                                            .add("referer", "$baseUrl/")
-                                            .add("Origin", baseUrl)
-                                            .build()
-                                        StreamWishExtractor(client, newHeaders).videosFromUrl(url, "StreamWish:").also(videoList::addAll)
-                                    } catch (_: Exception) {}
-                                }
-                            }
-                        }
-                    }
-                    if (unpack.contains("asura_tab")) {
-                        fetchUrls(unpack).forEach { url ->
+                }
+                if (unpack.contains("vhide_tab")) {
+                    urls.filter { it.contains("vidhide") }.forEach { url ->
+                        tasks.add {
                             try {
-                                if (url.contains("redirector")) {
-                                    val newHeaders = headers.newBuilder()
-                                        .add("authority", "www.mdnemonicplayer.xyz")
-                                        .add("accept", "*/*")
-                                        .add("Origin", baseUrl)
-                                        .add("referer", "$baseUrl/")
-                                        .build()
-                                    PlaylistUtils(client, newHeaders).extractFromHls(url, videoNameGen = { "Asura:$it" }).let { videoList.addAll(it) }
-                                }
-                            } catch (_: Exception) {}
+                                val newHeaders = headers.newBuilder()
+                                    .add("authority", url.toHttpUrl().host)
+                                    .add("referer", "$baseUrl/")
+                                    .add("Origin", baseUrl)
+                                    .build()
+                                VidHideExtractor(client, newHeaders).videosFromUrl(url) { "VidHide:$it" }
+                            } catch (_: Exception) {
+                                emptyList()
+                            }
+                        }
+                    }
+                }
+                if (unpack.contains("swish_tab")) {
+                    urls.filter { it.contains("embedwish") }.forEach { url ->
+                        tasks.add {
+                            try {
+                                val newHeaders = headers.newBuilder()
+                                    .add("referer", "$baseUrl/")
+                                    .add("Origin", baseUrl)
+                                    .build()
+                                StreamWishExtractor(client, newHeaders).videosFromUrl(url, "StreamWish:")
+                            } catch (_: Exception) {
+                                emptyList()
+                            }
+                        }
+                    }
+                }
+                if (unpack.contains("asura_tab")) {
+                    urls.filter { it.contains("redirector") }.forEach { url ->
+                        tasks.add {
+                            try {
+                                val newHeaders = headers.newBuilder()
+                                    .add("authority", "www.mdnemonicplayer.xyz")
+                                    .add("accept", "*/*")
+                                    .add("Origin", baseUrl)
+                                    .add("referer", "$baseUrl/")
+                                    .build()
+                                PlaylistUtils(client, newHeaders).extractFromHls(url, videoNameGen = { "Asura:$it" })
+                            } catch (_: Exception) {
+                                emptyList()
+                            }
                         }
                     }
                 }
             }
         }
-        return videoList
+
+        return runBlocking {
+            tasks.map { async { it() } }.awaitAll().flatten()
+        }
     }
 
     override fun List<Video>.sort(): List<Video> {
@@ -297,8 +310,9 @@ class MundoDonghua :
     }
 
     private fun parseStatus(statusString: String): Int = when {
-        statusString.lowercase().contains("en emisión") -> SAnime.ONGOING
-        statusString.lowercase().contains("finalizada") -> SAnime.COMPLETED
+        statusString.contains("en emisión", ignoreCase = true) -> SAnime.ONGOING
+        statusString.contains("finalizada", ignoreCase = true) -> SAnime.COMPLETED
+        statusString.contains("cancelada", ignoreCase = true) -> SAnime.CANCELLED
         else -> SAnime.UNKNOWN
     }
 
@@ -331,6 +345,5 @@ class MundoDonghua :
 
     companion object {
         private val LINK_REGEX = Regex("(http|ftp|https)://([\\w_-]+(?:\\.[\\w_-]+)+)([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])")
-        private val PACKED_REGEX = Regex("""eval\(function\(p,a,c,k,e,.*?\)\)""")
     }
 }

--- a/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
+++ b/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
@@ -45,7 +45,7 @@ class MundoDonghua :
 
     override fun popularAnimeFromElement(element: Element) = SAnime.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        title = element.selectFirst(".md-card-title")!!.text()
+        title = element.selectFirst(".md-card-title")?.text().orEmpty()
         thumbnail_url = element.selectFirst("div.md-card-img img")?.attr("abs:src")
     }
 
@@ -120,30 +120,36 @@ class MundoDonghua :
                         }
                     }
                     if (unpack.contains("vhide_tab")) {
-                        fetchUrls(unpack).forEach { url ->
-                            try {
-                                if (url.contains("vidhide")) {
-                                    val newHeaders = headers.newBuilder()
-                                        .add("authority", url.toHttpUrl().host)
-                                        .add("referer", "$baseUrl/")
-                                        .add("Origin", baseUrl)
-                                        .build()
-                                    runBlocking {
+                        val vidhideUrls = fetchUrls(unpack).filter { it.contains("vidhide") }
+                        if (vidhideUrls.isNotEmpty()) {
+                            runBlocking {
+                                vidhideUrls.forEach { url ->
+                                    try {
+                                        val newHeaders = headers.newBuilder()
+                                            .add("authority", url.toHttpUrl().host)
+                                            .add("referer", "$baseUrl/")
+                                            .add("Origin", baseUrl)
+                                            .build()
                                         VidHideExtractor(client, newHeaders).videosFromUrl(url) { "VidHide:$it" }.also(videoList::addAll)
-                                    }
+                                    } catch (_: Exception) {}
                                 }
-                            } catch (_: Exception) {}
+                            }
                         }
                     }
                     if (unpack.contains("swish_tab")) {
-                        fetchUrls(unpack).forEach { url ->
-                            try {
-                                if (url.contains("embedwish")) {
-                                    runBlocking {
-                                        StreamWishExtractor(client, headers).videosFromUrl(url, "StreamWish:").also(videoList::addAll)
-                                    }
+                        val swishUrls = fetchUrls(unpack).filter { it.contains("embedwish") }
+                        if (swishUrls.isNotEmpty()) {
+                            runBlocking {
+                                swishUrls.forEach { url ->
+                                    try {
+                                        val newHeaders = headers.newBuilder()
+                                            .add("referer", "$baseUrl/")
+                                            .add("Origin", baseUrl)
+                                            .build()
+                                        StreamWishExtractor(client, newHeaders).videosFromUrl(url, "StreamWish:").also(videoList::addAll)
+                                    } catch (_: Exception) {}
                                 }
-                            } catch (_: Exception) {}
+                            }
                         }
                     }
                     if (unpack.contains("asura_tab")) {
@@ -153,7 +159,7 @@ class MundoDonghua :
                                     val newHeaders = headers.newBuilder()
                                         .add("authority", "www.mdnemonicplayer.xyz")
                                         .add("accept", "*/*")
-                                        .add("origin", baseUrl)
+                                        .add("Origin", baseUrl)
                                         .add("referer", "$baseUrl/")
                                         .build()
                                     PlaylistUtils(client, newHeaders).extractFromHls(url, videoNameGen = { "Asura:$it" }).let { videoList.addAll(it) }

--- a/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
+++ b/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
@@ -10,10 +10,11 @@ import aniyomi.lib.voeextractor.VoeExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import eu.kanade.tachiyomi.animesource.model.AnimesPage
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
-import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
+import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.lib.autoUnpacker
@@ -22,11 +23,10 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
 class MundoDonghua :
-    ParsedAnimeHttpSource(),
+    AnimeHttpSource(),
     ConfigurableAnimeSource {
 
     override val name = "MundoDonghua"
@@ -39,29 +39,30 @@ class MundoDonghua :
 
     private val preferences by getPreferencesLazy()
 
-    override fun popularAnimeSelector() = "div.md-card-grid > div.md-card > a"
+    private fun popularAnimeSelector() = "div.md-card-grid > div.md-card > a"
 
     override fun popularAnimeRequest(page: Int) = GET("$baseUrl/lista-donghuas/$page")
 
-    override fun popularAnimeFromElement(element: Element) = SAnime.create().apply {
-        setUrlWithoutDomain(element.attr("href"))
+    private fun popularAnimeFromElement(element: Element) = SAnime.create().apply {
+        setUrlWithoutDomain(element.absUrl("href"))
         title = element.selectFirst(".md-card-title")?.text().orEmpty()
         thumbnail_url = element.selectFirst("div.md-card-img img")?.attr("abs:src")
     }
 
-    override fun popularAnimeNextPageSelector() = "nav.md-pagination > a:last-of-type"
+    private fun popularAnimeNextPageSelector() = "nav.md-pagination > a:last-of-type"
 
-    override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
+    private fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
 
-    override fun latestUpdatesFromElement(element: Element) = popularAnimeFromElement(element).apply {
+    private fun latestUpdatesFromElement(element: Element) = popularAnimeFromElement(element).apply {
         url = url.replace("/ver/", "/donghua/").substringBeforeLast("/")
     }
 
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/lista-episodios/$page")
 
-    override fun latestUpdatesSelector() = popularAnimeSelector()
+    private fun latestUpdatesSelector() = popularAnimeSelector()
 
-    override fun animeDetailsParse(document: Document): SAnime {
+    override fun animeDetailsParse(response: Response): SAnime {
+        val document = response.asJsoup()
         val anime = SAnime.create()
         anime.thumbnail_url = document.selectFirst("div.md-detail-poster img")?.attr("abs:src")
         anime.title = document.selectFirst("h1.md-detail-title")?.text() ?: ""
@@ -73,21 +74,25 @@ class MundoDonghua :
         return anime
     }
 
-    override fun episodeListSelector() = "ul.md-episode-list li.md-episode-item a.md-ep-link"
+    private fun episodeListSelector() = "ul.md-episode-list li.md-episode-item a.md-ep-link"
 
-    override fun episodeFromElement(element: Element): SEpisode {
+    override fun episodeListParse(response: Response): List<SEpisode> {
+        val document = response.asJsoup()
+        return document.select(episodeListSelector()).map { episodeFromElement(it) }
+    }
+
+    private fun episodeFromElement(element: Element): SEpisode {
         val episode = SEpisode.create()
         val epNum = element.attr("href").split("/").last().toFloat()
-        episode.setUrlWithoutDomain(element.attr("href"))
+        episode.setUrlWithoutDomain(element.absUrl("href"))
         episode.episode_number = epNum
-        episode.name = "Episodio $epNum"
+        episode.name = "Episodio ${epNum.toString().removeSuffix(".0")}"
         return episode
     }
 
     private fun fetchUrls(text: String?): List<String> {
         if (text.isNullOrEmpty()) return listOf()
-        val linkRegex = "(http|ftp|https)://([\\w_-]+(?:\\.[\\w_-]+)+)([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])".toRegex()
-        return linkRegex.findAll(text).map { it.value.trim().removeSurrounding("\"") }.toList()
+        return LINK_REGEX.findAll(text).map { it.value.trim().removeSurrounding("\"") }.toList()
     }
 
     override fun videoListParse(response: Response): List<Video> {
@@ -95,8 +100,7 @@ class MundoDonghua :
         val videoList = mutableListOf<Video>()
         document.select("script").forEach { script ->
             if (script.data().contains("eval(function(p,a,c,k,e")) {
-                val packedRegex = Regex("eval\\(function\\(p,a,c,k,e,.*\\)\\)")
-                packedRegex.findAll(script.data()).map {
+                PACKED_REGEX.findAll(script.data()).map {
                     it.value
                 }.toList().forEach {
                     val unpack = autoUnpacker(it) ?: return@forEach
@@ -172,12 +176,6 @@ class MundoDonghua :
         }
         return videoList
     }
-
-    override fun videoListSelector() = throw UnsupportedOperationException()
-
-    override fun videoUrlParse(document: Document) = throw UnsupportedOperationException()
-
-    override fun videoFromElement(element: Element) = throw UnsupportedOperationException()
 
     override fun List<Video>.sort(): List<Video> {
         val quality = preferences.getString("preferred_quality", "VoeCDN")
@@ -265,15 +263,42 @@ class MundoDonghua :
         fun toUriPart() = vals[state].second
     }
 
-    override fun searchAnimeFromElement(element: Element): SAnime = popularAnimeFromElement(element)
+    private fun searchAnimeFromElement(element: Element): SAnime = popularAnimeFromElement(element)
 
-    override fun searchAnimeNextPageSelector(): String = popularAnimeNextPageSelector()
+    private fun searchAnimeNextPageSelector(): String = popularAnimeNextPageSelector()
 
-    override fun searchAnimeSelector(): String = popularAnimeSelector()
+    private fun searchAnimeSelector(): String = popularAnimeSelector()
+
+    override fun popularAnimeParse(response: Response): AnimesPage {
+        val document = response.asJsoup()
+        val animes = document.select(popularAnimeSelector()).map {
+            popularAnimeFromElement(it)
+        }
+        val hasNextPage = document.select(popularAnimeNextPageSelector()).first() != null
+        return AnimesPage(animes, hasNextPage)
+    }
+
+    override fun latestUpdatesParse(response: Response): AnimesPage {
+        val document = response.asJsoup()
+        val animes = document.select(latestUpdatesSelector()).map {
+            latestUpdatesFromElement(it)
+        }
+        val hasNextPage = document.select(latestUpdatesNextPageSelector()).first() != null
+        return AnimesPage(animes, hasNextPage)
+    }
+
+    override fun searchAnimeParse(response: Response): AnimesPage {
+        val document = response.asJsoup()
+        val animes = document.select(searchAnimeSelector()).map {
+            searchAnimeFromElement(it)
+        }
+        val hasNextPage = document.select(searchAnimeNextPageSelector()).first() != null
+        return AnimesPage(animes, hasNextPage)
+    }
 
     private fun parseStatus(statusString: String): Int = when {
-        statusString.contains("En Emisión") -> SAnime.ONGOING
-        statusString.contains("Finalizada") -> SAnime.COMPLETED
+        statusString.lowercase().contains("en emisión") -> SAnime.ONGOING
+        statusString.lowercase().contains("finalizada") -> SAnime.COMPLETED
         else -> SAnime.UNKNOWN
     }
 
@@ -300,14 +325,12 @@ class MundoDonghua :
             entryValues = qualities
             setDefaultValue("VoeCDN")
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }
         screen.addPreference(videoQualityPref)
+    }
+
+    companion object {
+        private val LINK_REGEX = Regex("(http|ftp|https)://([\\w_-]+(?:\\.[\\w_-]+)+)([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])")
+        private val PACKED_REGEX = Regex("""eval\(function\(p,a,c,k,e,.*?\)\)""")
     }
 }

--- a/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
+++ b/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
@@ -2,9 +2,10 @@ package eu.kanade.tachiyomi.animeextension.es.mundodonghua
 
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import aniyomi.lib.dailymotionextractor.DailymotionExtractor
 import aniyomi.lib.filemoonextractor.FilemoonExtractor
 import aniyomi.lib.playlistutils.PlaylistUtils
+import aniyomi.lib.streamwishextractor.StreamWishExtractor
+import aniyomi.lib.vidhideextractor.VidHideExtractor
 import aniyomi.lib.voeextractor.VoeExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
@@ -16,8 +17,8 @@ import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.lib.autoUnpacker
-import keiyoushi.utils.bodyString
 import keiyoushi.utils.getPreferencesLazy
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -38,17 +39,17 @@ class MundoDonghua :
 
     private val preferences by getPreferencesLazy()
 
-    override fun popularAnimeSelector() = "div > div.row > div.item > a"
+    override fun popularAnimeSelector() = "div.md-card-grid > div.md-card > a"
 
     override fun popularAnimeRequest(page: Int) = GET("$baseUrl/lista-donghuas/$page")
 
     override fun popularAnimeFromElement(element: Element) = SAnime.create().apply {
         setUrlWithoutDomain(element.attr("href"))
-        title = element.selectFirst("h5")!!.text().removeSurrounding("\"")
-        thumbnail_url = element.selectFirst("img")?.attr("abs:src")
+        title = element.selectFirst(".md-card-title")!!.text()
+        thumbnail_url = element.selectFirst("div.md-card-img img")?.attr("abs:src")
     }
 
-    override fun popularAnimeNextPageSelector() = "ul.pagination li:last-child a"
+    override fun popularAnimeNextPageSelector() = "nav.md-pagination > a:last-of-type"
 
     override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
 
@@ -62,16 +63,17 @@ class MundoDonghua :
 
     override fun animeDetailsParse(document: Document): SAnime {
         val anime = SAnime.create()
-        anime.thumbnail_url = baseUrl + document.selectFirst("div.col-md-4.col-xs-12.mb-10 div.row.sm-row > div.side-banner > div.banner-side-serie")!!
-            .attr("style").substringAfter("background-image: url(").substringBefore(")")
-        anime.title = document.selectFirst("div.col-md-4.col-xs-12.mb-10 div.row.sm-row div div.sf.fc-dark.ls-title-serie")!!.html()
-        anime.description = document.selectFirst("section div.row div.col-md-8 div.sm-row p.text-justify")!!.text().removeSurrounding("\"")
-        anime.genre = document.select("div.col-md-8.col-xs-12 div.sm-row a.generos span.label").joinToString { it.text() }
-        anime.status = parseStatus(document.select("div.col-md-4.col-xs-12.mb-10 div.row.sm-row div:nth-child(2) div:nth-child(2) p span.badge").text())
+        anime.thumbnail_url = document.selectFirst("div.md-detail-poster img")?.attr("abs:src")
+        anime.title = document.selectFirst("h1.md-detail-title")?.text() ?: ""
+        anime.description = document.selectFirst("p.md-detail-synopsis")?.text() ?: ""
+        anime.genre = document.select("div.md-genres-block a.md-genre-tag").joinToString { it.text() }
+        anime.status = parseStatus(
+            document.selectFirst("span.md-emision-badge")?.text().orEmpty(),
+        )
         return anime
     }
 
-    override fun episodeListSelector() = "div.sm-row.mt-10 div.donghua-list-scroll ul.donghua-list a"
+    override fun episodeListSelector() = "ul.md-episode-list li.md-episode-item a.md-ep-link"
 
     override fun episodeFromElement(element: Element): SEpisode {
         val episode = SEpisode.create()
@@ -117,31 +119,32 @@ class MundoDonghua :
                             } catch (_: Exception) {}
                         }
                     }
-                    if (unpack.contains("protea_tab")) {
-                        try {
-                            val slug = unpack.substringAfter("\"slug\":\"").substringBefore("\"")
-
-                            val newHeaders = headers.newBuilder()
-                                .add("referer", "${response.request.url}")
-                                .add("authority", baseUrl.substringAfter("//"))
-                                .add("accept", "*/*")
-                                .build()
-
-                            val slugPlayer = client.newCall(GET("$baseUrl/api_donghua.php?slug=$slug", headers = newHeaders))
-                                .execute().bodyString()
-                                .substringAfter("\"url\":\"").substringBefore("\"")
-
-                            val videoHeaders = headers.newBuilder()
-                                .add("authority", "www.mdplayer.xyz")
-                                .add("referer", "$baseUrl/")
-                                .build()
-
-                            val videoId = client.newCall(GET("https://www.mdplayer.xyz/nemonicplayer/dmplayer.php?key=$slugPlayer", headers = videoHeaders))
-                                .execute().bodyString()
-                                .substringAfter("video-id=\"").substringBefore("\"")
-
-                            DailymotionExtractor(client, headers).videosFromUrl("https://www.dailymotion.com/embed/video/$videoId", prefix = "Dailymotion:").let { videoList.addAll(it) }
-                        } catch (_: Exception) {}
+                    if (unpack.contains("vhide_tab")) {
+                        fetchUrls(unpack).forEach { url ->
+                            try {
+                                if (url.contains("vidhide")) {
+                                    val newHeaders = headers.newBuilder()
+                                        .add("authority", url.toHttpUrl().host)
+                                        .add("referer", "$baseUrl/")
+                                        .add("Origin", baseUrl)
+                                        .build()
+                                    runBlocking {
+                                        VidHideExtractor(client, newHeaders).videosFromUrl(url) { "VidHide:$it" }.also(videoList::addAll)
+                                    }
+                                }
+                            } catch (_: Exception) {}
+                        }
+                    }
+                    if (unpack.contains("swish_tab")) {
+                        fetchUrls(unpack).forEach { url ->
+                            try {
+                                if (url.contains("embedwish")) {
+                                    runBlocking {
+                                        StreamWishExtractor(client, headers).videosFromUrl(url, "StreamWish:").also(videoList::addAll)
+                                    }
+                                }
+                            } catch (_: Exception) {}
+                        }
                     }
                     if (unpack.contains("asura_tab")) {
                         fetchUrls(unpack).forEach { url ->
@@ -153,7 +156,6 @@ class MundoDonghua :
                                         .add("origin", baseUrl)
                                         .add("referer", "$baseUrl/")
                                         .build()
-
                                     PlaylistUtils(client, newHeaders).extractFromHls(url, videoNameGen = { "Asura:$it" }).let { videoList.addAll(it) }
                                 }
                             } catch (_: Exception) {}
@@ -272,15 +274,18 @@ class MundoDonghua :
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         val qualities = arrayOf(
             "VoeCDN",
-            "Dailymotion:1080p",
-            "Dailymotion:720p",
-            "Dailymotion:480p",
             "Filemoon:1080p",
             "Filemoon:720p",
             "Filemoon:480p",
             "Asura:1080p",
             "Asura:720p",
             "Asura:480p",
+            "VidHide:1080p",
+            "VidHide:720p",
+            "VidHide:480p",
+            "StreamWish:1080p",
+            "StreamWish:720p",
+            "StreamWish:480p",
         )
         val videoQualityPref = ListPreference(screen.context).apply {
             key = "preferred_quality"


### PR DESCRIPTION
## Summary
- Updated all CSS selectors to match the new site theme (md-card, md-detail-*, md-episode-*, md-pagination)
- Removed dead protea_tab video extraction (no longer exists on site)
- Added vhide_tab (VidHide) and swish_tab (StreamWish) video extraction with runBlocking
- Added streamwishextractor and vidhideextractor dependencies
- Bumped version from 42 to 43
- All 14 selectors validated against live mundodonghua.com

## Changes
| File | Change |
|------|--------|
| `build.gradle` | +2 deps, version 42→43 |
| `MundoDonghua.kt` | 6 selectors updated, protea_tab→vhide_tab+swish_tab, quality prefs updated |

## Testing
- Extension compiles (`assembleDebug` successful)
- CSS selectors validated against 6 page types: browse, latest, search, detail, episode, genre
- Video extraction scripts confirmed present on current site

## Summary by Sourcery

Update MundoDonghua ES extension to support the site's new theme and current video hosts.

New Features:
- Add VidHide and StreamWish video extraction for MundoDonghua using the shared extractor libraries.

Bug Fixes:
- Restore anime listing, detail, and episode parsing by updating CSS selectors to match the new MundoDonghua layout.

Enhancements:
- Update preferred quality options to include VidHide and StreamWish streams and remove obsolete Dailymotion entries.

Build:
- Bump MundoDonghua extension version code from 42 to 43 and add StreamWish/VidHide extractor dependencies.