### PR TITLE
Xfani [ZH]: Update URL & fix search using suggest API

### DIFF
--- a/src/zh/xfani/build.gradle
+++ b/src/zh/xfani/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Xfani'
     extClass = '.Xfani'
-    extVersionCode = 7
+    extVersionCode = 8
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
+++ b/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
@@ -316,10 +316,6 @@ class Xfani :
             MultipartBody.Builder().setType(MultipartBody.FORM).addFormDataPart("page", "$page")
                 .addFormDataPart("time", "$time").addFormDataPart("key", generateKey(time))
 
-        if (query.isNotBlank()) {
-            formBody.addFormDataPart("wd", query)
-        }
-
         filters.forEach { filter ->
             when (filter) {
                 is TypeFilter -> formBody.addFormDataPart("type", filter.selected)

--- a/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
+++ b/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
@@ -88,16 +88,10 @@ class Xfani :
     }
 
     override val client: OkHttpClient by lazy {
-        val builder = if (preferences.getBoolean(PREF_KEY_IGNORE_SSL_ERROR, false)) {
+        if (preferences.getBoolean(PREF_KEY_IGNORE_SSL_ERROR, false)) {
             network.client.newBuilder().ignoreAllSSLErrors()
         } else {
             network.client.newBuilder().addInterceptor(::checkSSLErrorInterceptor)
-        }
-        builder.addInterceptor { chain ->
-            val request = chain.request().newBuilder()
-                .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
-                .build()
-            chain.proceed(request)
         }.addInterceptor(::updateFiltersInterceptor).build()
     }
 

--- a/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
+++ b/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/Xfani.kt
@@ -54,7 +54,7 @@ class Xfani :
     AnimeHttpSource(),
     ConfigurableAnimeSource {
     override val baseUrl: String
-        get() = "https://dm.xifanacg.com"
+        get() = "https://anime.xifanacg.com"
     override val lang: String
         get() = "zh"
     override val name: String
@@ -88,10 +88,16 @@ class Xfani :
     }
 
     override val client: OkHttpClient by lazy {
-        if (preferences.getBoolean(PREF_KEY_IGNORE_SSL_ERROR, false)) {
+        val builder = if (preferences.getBoolean(PREF_KEY_IGNORE_SSL_ERROR, false)) {
             network.client.newBuilder().ignoreAllSSLErrors()
         } else {
             network.client.newBuilder().addInterceptor(::checkSSLErrorInterceptor)
+        }
+        builder.addInterceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                .build()
+            chain.proceed(request)
         }.addInterceptor(::updateFiltersInterceptor).build()
     }
 
@@ -205,7 +211,23 @@ class Xfani :
     override fun popularAnimeRequest(page: Int): Request = searchAnimeRequest(page, "", AnimeFilterList(SortFilter().apply { state = 1 }))
 
     private fun vodListToAnimePageList(response: Response): AnimesPage {
-        val vodResponse = json.decodeFromString<VodResponse>(response.body.string())
+        val responseBody = response.body.string()
+        if (response.request.url.encodedPath.endsWith("suggest")) {
+            val suggestResponse = json.decodeFromString<SuggestResponse>(responseBody)
+            val animeList = suggestResponse.list.map {
+                SAnime.create().apply {
+                    url = "/bangumi/${it.id}.html"
+                    thumbnail_url = it.pic
+                    title = it.name
+                }
+            }
+            return AnimesPage(
+                animeList,
+                suggestResponse.page < suggestResponse.pageCount,
+            )
+        }
+
+        val vodResponse = json.decodeFromString<VodResponse>(responseBody)
         val animeList = vodResponse.list.map {
             SAnime.create().apply {
                 url = "/bangumi/${it.vodId}.html"
@@ -222,31 +244,7 @@ class Xfani :
         )
     }
 
-    override fun searchAnimeParse(response: Response): AnimesPage {
-        if (response.request.url.toString().contains("api/vod")) {
-            return vodListToAnimePageList(response)
-        }
-        val jsoup = response.asJsoup()
-        val items = jsoup.select("div.search-list")
-        val animeList = items.map { item ->
-            SAnime.create().apply {
-                item.selectFirst("div.detail-info > a")!!.let {
-                    url = it.attr("href")
-                    title = it.text()
-                }
-                thumbnail_url =
-                    item.select("div.detail-pic img[data-src]").attr("data-src")
-            }
-        }
-        val tip = jsoup.select("div.pages div.page-tip").text()
-        return AnimesPage(animeList, tip.isNotEmpty() && hasMorePage(tip))
-    }
-
-    private fun hasMorePage(tip: String): Boolean {
-        val pageIndicator = tip.substringAfter("当前").substringBefore("页")
-        val numbers = pageIndicator.split("/")
-        return numbers.size == 2 && numbers[0] != numbers[1]
-    }
+    override fun searchAnimeParse(response: Response): AnimesPage = vodListToAnimePageList(response)
 
     private val scope by lazy { CoroutineScope(SupervisorJob() + Dispatchers.IO) }
 
@@ -307,26 +305,27 @@ class Xfani :
         ),
     )
 
-    private fun doSearch(page: Int, query: String): Request {
-        val url = baseUrl.toHttpUrl().newBuilder()
-        if (page <= 1) {
-            url.addPathSegment("search.html").addQueryParameter("wd", query)
-        } else {
-            url.addPathSegments("search/wd/").addPathSegment(query)
-                .addPathSegments("page/$page.html")
-        }
-        return GET(url.build())
-    }
-
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         if (query.isNotBlank()) {
-            return doSearch(page, query)
+            val url = "$baseUrl/index.php/ajax/suggest".toHttpUrl().newBuilder()
+                .addQueryParameter("mid", "1")
+                .addQueryParameter("wd", query)
+                .addQueryParameter("page", "$page")
+                .addQueryParameter("limit", "40")
+                .build()
+            return GET(url.toString(), headers)
         }
+
         val url = baseUrl.toHttpUrl().newBuilder().addPathSegments("index.php/api/vod").build()
         val time = System.currentTimeMillis() / 1000
         val formBody =
             MultipartBody.Builder().setType(MultipartBody.FORM).addFormDataPart("page", "$page")
                 .addFormDataPart("time", "$time").addFormDataPart("key", generateKey(time))
+
+        if (query.isNotBlank()) {
+            formBody.addFormDataPart("wd", query)
+        }
+
         filters.forEach { filter ->
             when (filter) {
                 is TypeFilter -> formBody.addFormDataPart("type", filter.selected)

--- a/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/XfaniDTO.kt
+++ b/src/zh/xfani/src/eu/kanade/tachiyomi/animeextension/zh/xfani/XfaniDTO.kt
@@ -40,3 +40,20 @@ data class VodResponse(
     val total: Int,
     val list: List<VodInfo>,
 )
+
+@Serializable
+data class SuggestInfo(
+    val id: Int,
+    val name: String,
+    val pic: String,
+)
+
+@Serializable
+data class SuggestResponse(
+    val page: Int,
+    @SerialName("pagecount")
+    val pageCount: Int,
+    val limit: Int,
+    val total: Int,
+    val list: List<SuggestInfo>,
+)


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the Xfani Chinese extension to use the new site endpoint and JSON suggest API for searching while bumping the extension version.

New Features:
- Add support for the JSON-based suggest search API to return anime results.

Bug Fixes:
- Fix broken search functionality by switching from HTML search parsing to the suggest API response.

Enhancements:
- Update the Xfani base URL to the new anime subdomain.
- Attach a desktop browser User-Agent header to all Xfani requests to improve compatibility.

Build:
- Bump the Xfani extension version code to 8.