### PR TITLE
Fix AnimeID extension: Change to a new domain and fix video servers 

### DIFF
--- a/src/es/animeid/build.gradle
+++ b/src/es/animeid/build.gradle
@@ -1,13 +1,15 @@
 ext {
     extName = 'AnimeID'
     extClass = '.AnimeID'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
-    implementation(project(':lib:streamtapeextractor'))
+    implementation(project(':lib:voeextractor'))
+    implementation(project(':lib:mp4uploadextractor'))
     implementation(project(':lib:streamwishextractor'))
+    implementation(project(':lib:uqloadextractor'))
     implementation(project(':lib:universalextractor'))
 }

--- a/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
+++ b/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
@@ -29,7 +29,9 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.util.concurrent.TimeUnit
 
-class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
+class AnimeID :
+    ParsedAnimeHttpSource(),
+    ConfigurableAnimeSource {
 
     override val name = "AnimeID"
     override val baseUrl = "https://wwv.animeid2.com"
@@ -55,7 +57,7 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
                 val newReq = original.newBuilder()
                     .header(
                         "User-Agent",
-                        "Mozilla/5.0 (Linux; Android 13; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Mobile Safari/537.36"
+                        "Mozilla/5.0 (Linux; Android 13; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Mobile Safari/537.36",
                     )
                     .header("Accept-Language", "es-ES,es;q=0.9")
                     .build()
@@ -177,61 +179,64 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
         GenreFilter(),
         YearFilter(),
         StatusFilter(),
-        OrderFilter()
+        OrderFilter(),
     )
 
-    private class GenreFilter : UriPartFilter(
-        "Género",
-        arrayOf(
-            Pair("Todos", ""),
-            Pair("Acción", "accion"),
-            Pair("Aventura", "aventura"),
-            Pair("Comedia", "comedia"),
-            Pair("Drama", "drama"),
-            Pair("Fantasía", "fantasia"),
-            Pair("Romance", "romance"),
-            Pair("Sci-Fi", "ciencia-ficcion"),
-            Pair("Seinen", "seinen"),
-            Pair("Shounen", "shounen"),
-            Pair("Suspenso", "suspenso"),
-            Pair("Terror", "terror")
+    private class GenreFilter :
+        UriPartFilter(
+            "Género",
+            arrayOf(
+                Pair("Todos", ""),
+                Pair("Acción", "accion"),
+                Pair("Aventura", "aventura"),
+                Pair("Comedia", "comedia"),
+                Pair("Drama", "drama"),
+                Pair("Fantasía", "fantasia"),
+                Pair("Romance", "romance"),
+                Pair("Sci-Fi", "ciencia-ficcion"),
+                Pair("Seinen", "seinen"),
+                Pair("Shounen", "shounen"),
+                Pair("Suspenso", "suspenso"),
+                Pair("Terror", "terror"),
+            ),
         )
-    )
 
-    private class YearFilter : UriPartFilter(
-        "Año",
-        arrayOf(
-            Pair("Todos", ""),
-            Pair("2026", "2026"),
-            Pair("2025", "2025"),
-            Pair("2024", "2024"),
-            Pair("2023", "2023"),
-            Pair("2022", "2022"),
-            Pair("2021", "2021"),
-            Pair("2020", "2020")
+    private class YearFilter :
+        UriPartFilter(
+            "Año",
+            arrayOf(
+                Pair("Todos", ""),
+                Pair("2026", "2026"),
+                Pair("2025", "2025"),
+                Pair("2024", "2024"),
+                Pair("2023", "2023"),
+                Pair("2022", "2022"),
+                Pair("2021", "2021"),
+                Pair("2020", "2020"),
+            ),
         )
-    )
 
-    private class StatusFilter : UriPartFilter(
-        "Estado",
-        arrayOf(
-            Pair("Todos", ""),
-            Pair("En emisión", "en-emision"),
-            Pair("Finalizado", "finalizado")
+    private class StatusFilter :
+        UriPartFilter(
+            "Estado",
+            arrayOf(
+                Pair("Todos", ""),
+                Pair("En emisión", "en-emision"),
+                Pair("Finalizado", "finalizado"),
+            ),
         )
-    )
 
-    private class OrderFilter : UriPartFilter(
-        "Ordenar por",
-        arrayOf(
-            Pair("Recientes", "newest"),
-            Pair("Popularidad", "views"),
-            Pair("A-Z", "asc")
+    private class OrderFilter :
+        UriPartFilter(
+            "Ordenar por",
+            arrayOf(
+                Pair("Recientes", "newest"),
+                Pair("Popularidad", "views"),
+                Pair("A-Z", "asc"),
+            ),
         )
-    )
 
-    private open class UriPartFilter(displayName: String, val vals: Array<Pair<String, String>>) :
-        AnimeFilter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
+    private open class UriPartFilter(displayName: String, val vals: Array<Pair<String, String>>) : AnimeFilter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
         fun toUriPart() = if (state > 0) vals[state].second else ""
     }
 
@@ -298,27 +303,25 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
         return allEpisodes.distinctBy { it.url }.sortedByDescending { it.episode_number }
     }
 
-    private fun fetchEpisodesPage(animeId: String, animeSlug: String, page: Int): String {
-        return try {
-            val request = Request.Builder()
-                .url("$baseUrl/id")
-                .post(
-                    FormBody.Builder()
-                        .add("acc", "episodes")
-                        .add("i", animeId)
-                        .add("u", animeSlug)
-                        .add("p", page.toString())
-                        .build()
-                )
-                .addHeader("X-Requested-With", "XMLHttpRequest")
-                .addHeader("Referer", baseUrl)
-                .build()
-            customClient.newCall(request).execute().use { response ->
-                response.body?.string() ?: ""
-            }
-        } catch (e: Exception) {
-            ""
+    private fun fetchEpisodesPage(animeId: String, animeSlug: String, page: Int): String = try {
+        val request = Request.Builder()
+            .url("$baseUrl/id")
+            .post(
+                FormBody.Builder()
+                    .add("acc", "episodes")
+                    .add("i", animeId)
+                    .add("u", animeSlug)
+                    .add("p", page.toString())
+                    .build(),
+            )
+            .addHeader("X-Requested-With", "XMLHttpRequest")
+            .addHeader("Referer", baseUrl)
+            .build()
+        customClient.newCall(request).execute().use { response ->
+            response.body?.string() ?: ""
         }
+    } catch (e: Exception) {
+        ""
     }
 
     // ============================== Videos ===============================
@@ -386,25 +389,23 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
         return orderVideosByPreferences(videos)
     }
 
-    private fun fetchServerList(encryptId: String): String {
-        return try {
-            val request = Request.Builder()
-                .url("$baseUrl/id")
-                .post(
-                    FormBody.Builder()
-                        .add("acc", "opt")
-                        .add("i", encryptId)
-                        .build()
-                )
-                .addHeader("X-Requested-With", "XMLHttpRequest")
-                .addHeader("Referer", baseUrl)
-                .build()
-            customClient.newCall(request).execute().use { response ->
-                response.body?.string() ?: ""
-            }
-        } catch (e: Exception) {
-            ""
+    private fun fetchServerList(encryptId: String): String = try {
+        val request = Request.Builder()
+            .url("$baseUrl/id")
+            .post(
+                FormBody.Builder()
+                    .add("acc", "opt")
+                    .add("i", encryptId)
+                    .build(),
+            )
+            .addHeader("X-Requested-With", "XMLHttpRequest")
+            .addHeader("Referer", baseUrl)
+            .build()
+        customClient.newCall(request).execute().use { response ->
+            response.body?.string() ?: ""
         }
+    } catch (e: Exception) {
+        ""
     }
 
     private fun parseServerUrls(html: String): List<Pair<String, String>> {
@@ -424,19 +425,17 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
         return result
     }
 
-    private fun hexToString(hex: String): String {
-        return try {
-            val output = StringBuilder()
-            var i = 0
-            while (i < hex.length) {
-                val str = hex.substring(i, minOf(i + 2, hex.length))
-                output.append(str.toInt(16).toChar())
-                i += 2
-            }
-            output.toString()
-        } catch (e: Exception) {
-            ""
+    private fun hexToString(hex: String): String = try {
+        val output = StringBuilder()
+        var i = 0
+        while (i < hex.length) {
+            val str = hex.substring(i, minOf(i + 2, hex.length))
+            output.append(str.toInt(16).toChar())
+            i += 2
         }
+        output.toString()
+    } catch (e: Exception) {
+        ""
     }
 
     private fun orderVideosByPreferences(videos: List<Video>): List<Video> {

--- a/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
+++ b/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
@@ -290,7 +290,7 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
             allEpisodes.addAll(episodesOnPage)
             currentPage++
             try {
-                Thread.sleep(500)
+                Thread.sleep(100)
             } catch (_: InterruptedException) {
                 // ignore
             }
@@ -499,7 +499,7 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         ListPreference(screen.context).apply {
             key = "animeid_preferred_server"
-            title = "Servidor preferido"
+            title = "Preferred server"
             entries = arrayOf("Voe", "Mp4upload", "Uqload", "StreamWish")
             entryValues = arrayOf("Voe", "Mp4upload", "Uqload", "StreamWish")
             setDefaultValue("Voe")
@@ -508,8 +508,8 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
 
         ListPreference(screen.context).apply {
             key = "animeid_preferred_quality"
-            title = "Calidad preferida"
-            entries = arrayOf("Automático", "480p", "720p", "1080p")
+            title = "Preferred quality"
+            entries = arrayOf("Automatic", "480p", "720p", "1080p")
             entryValues = arrayOf("automatic", "480", "720", "1080")
             setDefaultValue("automatic")
             summary = "%s"

--- a/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
+++ b/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
@@ -1,8 +1,13 @@
 package eu.kanade.tachiyomi.animeextension.es.animeid
 
-import aniyomi.lib.streamtapeextractor.StreamTapeExtractor
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceScreen
+import aniyomi.lib.mp4uploadextractor.Mp4uploadExtractor
 import aniyomi.lib.streamwishextractor.StreamWishExtractor
 import aniyomi.lib.universalextractor.UniversalExtractor
+import aniyomi.lib.uqloadextractor.UqloadExtractor
+import aniyomi.lib.voeextractor.VoeExtractor
+import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.SAnime
@@ -10,346 +15,527 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import keiyoushi.utils.bodyString
-import keiyoushi.utils.parallelCatchingFlatMapBlocking
-import keiyoushi.utils.parseAs
-import keiyoushi.utils.tryParse
-import keiyoushi.utils.useAsJsoup
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import keiyoushi.utils.getPreferencesLazy
+import kotlinx.coroutines.runBlocking
+import okhttp3.ConnectionPool
+import okhttp3.ConnectionSpec
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Locale
+import java.util.concurrent.TimeUnit
 
-class AnimeID : ParsedAnimeHttpSource() {
+class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
 
     override val name = "AnimeID"
-
-    override val baseUrl = "https://www.animeid.tv/"
-
+    override val baseUrl = "https://wwv.animeid2.com"
     override val lang = "es"
-
     override val supportsLatest = true
 
-    override fun popularAnimeSelector(): String = "#result article.item"
+    private val preferences by getPreferencesLazy()
 
-    override fun popularAnimeRequest(page: Int) = GET("$baseUrl/series?sort=views&pag=$page")
+    /**
+     * Custom OkHttpClient independent from the global `client`.
+     * - Mobile Chrome User-Agent
+     * - Own ConnectionPool and ConnectionSpec to avoid sharing TLS sessions
+     */
+    private val customClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .connectionPool(ConnectionPool(5, 5, TimeUnit.MINUTES))
+            .connectionSpecs(listOf(ConnectionSpec.MODERN_TLS, ConnectionSpec.CLEARTEXT))
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val newReq = original.newBuilder()
+                    .header(
+                        "User-Agent",
+                        "Mozilla/5.0 (Linux; Android 13; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Mobile Safari/537.36"
+                    )
+                    .header("Accept-Language", "es-ES,es;q=0.9")
+                    .build()
+                chain.proceed(newReq)
+            }
+            .build()
+    }
+
+    // Use the same customClient for all extractors to keep behavior consistent
+    private val voeExtractor by lazy { VoeExtractor(customClient, headers) }
+    private val mp4uploadExtractor by lazy { Mp4uploadExtractor(customClient) }
+    private val uqloadExtractor by lazy { UqloadExtractor(customClient) }
+    private val streamWishExtractor by lazy { StreamWishExtractor(customClient, headers) }
+    private val universalExtractor by lazy { UniversalExtractor(customClient) }
+
+    // Track last host used to evict connection pool when switching servers
+    private var lastServerHost: String? = null
+
+    // ============================== Popular ===============================
+    override fun popularAnimeSelector(): String = "div.ul.x5 article.li, div.ul article.li"
+
+    override fun popularAnimeRequest(page: Int): Request {
+        val url = if (page == 1) "$baseUrl/series" else "$baseUrl/series?pag=$page"
+        return GET(url, headers)
+    }
 
     override fun popularAnimeFromElement(element: Element): SAnime {
         val anime = SAnime.create()
-        anime.setUrlWithoutDomain(baseUrl + element.select("a").attr("href"))
-        anime.title = element.select("a header").text()
-        anime.thumbnail_url = element.select("a figure img").attr("src")
-        anime.description = element.select("p div").text().removeSurrounding("\"")
+        val linkElement = element.select("a").first()
+        val href = linkElement?.attr("href") ?: ""
+        anime.setUrlWithoutDomain(href)
+        anime.title = linkElement?.select("span")?.text()?.trim() ?: ""
+
+        val imgElement = element.select("figure.i img").first()
+        var imgUrl = imgElement?.attr("data-src")
+        if (imgUrl.isNullOrEmpty()) imgUrl = imgElement?.attr("src")
+        if (!imgUrl.isNullOrEmpty()) {
+            anime.thumbnail_url = if (imgUrl.startsWith("http")) imgUrl else baseUrl + imgUrl
+        }
         return anime
     }
 
-    override fun popularAnimeNextPageSelector(): String = "#paginas ul li:nth-last-child(2) a"
+    override fun popularAnimeNextPageSelector(): String = "ul.pag li a:contains(Siguiente)"
 
-    override fun episodeListSelector() = throw UnsupportedOperationException()
+    // ============================== Latest ===============================
+    override fun latestUpdatesSelector(): String = "div.ul.hm article.li"
 
-    override fun episodeListParse(response: Response): List<SEpisode> {
-        val document = response.useAsJsoup()
-        val animeId = document.select("#ord").attr("data-id")
-        return episodeJsonParse(response.request.url.toString(), animeId)
+    override fun latestUpdatesRequest(page: Int): Request {
+        val url = if (page == 1) baseUrl else "$baseUrl?pag=$page"
+        return GET(url, headers)
     }
 
-    private fun episodeJsonParse(url: String, animeId: String): MutableList<SEpisode> {
-        val capList = mutableListOf<SEpisode>()
-        var nextPage = 1
-        do {
-            val headers = headers.newBuilder()
-                .set("Referer", url)
-                .set("sec-fetch-site", "same-origin")
-                .set("x-requested-with", "XMLHttpRequest")
-                .set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0")
-                .set("Accept-Language", "es-MX,es-419;q=0.9,es;q=0.8,en;q=0.7")
-                .build()
+    override fun latestUpdatesFromElement(element: Element): SAnime {
+        val anime = SAnime.create()
+        val linkElement = element.select("a").first()
+        val href = linkElement?.attr("href") ?: ""
+        val animeSlug = href.substringAfter("/ver/").substringBeforeLast("-")
+        anime.setUrlWithoutDomain("/$animeSlug")
+        anime.title = linkElement?.select("span")?.text()?.trim() ?: ""
 
-            val responseString = client.newCall(GET("https://www.animeid.tv/ajax/caps?id=$animeId&ord=DESC&pag=$nextPage", headers))
-                .execute().bodyString().substringAfter("<body>").substringBefore("</body>")
-            val jObject = responseString.parseAs<JsonObject>()
-            val listCaps = jObject["list"]!!.jsonArray
-            listCaps.forEach { cap ->
-                val capParsed = cap.jsonObject
-                val epNum = capParsed["numero"]!!.jsonPrimitive.content
-                val episode = SEpisode.create()
-                val dateUpload = manualDateParse(capParsed["date"]!!.jsonPrimitive.content)
-                episode.episode_number = epNum.toFloat()
-                episode.name = "Episodio $epNum"
-                dateUpload!!.also { episode.date_upload = it }
-                episode.setUrlWithoutDomain(baseUrl + capParsed["href"]!!.jsonPrimitive.content)
-                capList.add(episode)
+        val imgElement = element.select("figure.i img").first()
+        var imgUrl = imgElement?.attr("data-src")
+        if (imgUrl.isNullOrEmpty()) imgUrl = imgElement?.attr("src")
+        if (!imgUrl.isNullOrEmpty()) {
+            anime.thumbnail_url = if (imgUrl.startsWith("http")) imgUrl else baseUrl + imgUrl
+        }
+        return anime
+    }
+
+    override fun latestUpdatesNextPageSelector(): String? = "ul.pag li a:contains(Siguiente)"
+
+    // ============================== Search ===============================
+    override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
+        val filterList = if (filters.isEmpty()) getFilterList() else filters
+        val genreFilter = filterList.find { it is GenreFilter } as? GenreFilter
+        val yearFilter = filterList.find { it is YearFilter } as? YearFilter
+        val statusFilter = filterList.find { it is StatusFilter } as? StatusFilter
+        val orderFilter = filterList.find { it is OrderFilter } as? OrderFilter
+
+        val params = mutableListOf<String>()
+
+        if (query.isNotBlank()) {
+            params.add("buscar=$query")
+        } else {
+            genreFilter?.takeIf { it.state != 0 }?.let {
+                params.add("genero=${it.toUriPart()}")
             }
-            if (listCaps.any()) nextPage += 1 else nextPage = -1
-        } while (nextPage != -1)
-        return capList
-    }
-
-    private fun manualDateParse(stringDate: String): Long? = try {
-        val format = SimpleDateFormat("dd MMM yyyy", Locale.ENGLISH)
-        format.tryParse(stringDate)
-    } catch (_: Exception) {
-        val dateParsed = stringDate.split(" ")
-        val arrMonths = arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
-        val day = dateParsed[0].trim().toInt()
-        val month = arrMonths.indexOf(dateParsed[1].trim()) + 1
-        val year = dateParsed[2].trim().toInt()
-        Calendar.getInstance().apply { set(year, month - 1, day) }.time.time
-    }
-
-    override fun episodeFromElement(element: Element) = throw UnsupportedOperationException()
-
-    // ============================ Video Links =============================
-    private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
-    private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
-    private val universalExtractor by lazy { UniversalExtractor(client) }
-
-    override fun videoListParse(response: Response): List<Video> {
-        val document = response.useAsJsoup()
-        return document.select("#partes div.container li.subtab div.parte").parallelCatchingFlatMapBlocking { script ->
-            val jsonString = script.attr("data")
-            val titleServer = script.closest(".subtab")?.attr("data-tab-id")?.let {
-                document.selectFirst("#mirrors [data-tab-id=\"$it\"]")?.ownText()?.trim()
-            } ?: ""
-            val jsonUnescape = unescapeJava(jsonString).replace("\\", "")
-            val url = fetchUrls(jsonUnescape).firstOrNull()?.replace("\\\\", "\\") ?: ""
-            val matched = conventions.firstOrNull { (_, names) -> names.any { it.lowercase() in url.lowercase() || it.lowercase() in titleServer.lowercase() } }?.first
-            when (matched) {
-                "streamtape" -> streamtapeExtractor.videosFromUrl(url)
-                "streamwish" -> streamwishExtractor.videosFromUrl(url, videoNameGen = { "StreamWish:$it" })
-                else -> universalExtractor.videosFromUrl(url, headers)
+            yearFilter?.takeIf { it.state != 0 }?.let {
+                params.add("anio=${it.toUriPart()}")
+            }
+            statusFilter?.takeIf { it.state != 0 }?.let {
+                params.add("estado=${it.toUriPart()}")
             }
         }
+
+        orderFilter?.takeIf { it.state != 0 && query.isBlank() }?.let {
+            params.add("sort=${it.toUriPart()}")
+        }
+
+        if (page > 1) {
+            params.add("pag=$page")
+        }
+
+        val url = if (params.isEmpty()) {
+            "$baseUrl/series"
+        } else {
+            "$baseUrl/series?${params.joinToString("&")}"
+        }
+        return GET(url, headers)
     }
 
-    private val conventions = listOf(
-        "streamwish" to listOf("wishembed", "streamwish", "strwish", "wish", "Kswplayer", "Swhoi", "Multimovies", "Uqloads", "neko-stream", "swdyu", "fviplions", "streamgg"),
-        "streamtape" to listOf("streamtape", "stp", "stape", "shavetape", "shg"),
+    override fun searchAnimeSelector(): String = popularAnimeSelector()
+    override fun searchAnimeFromElement(element: Element): SAnime = popularAnimeFromElement(element)
+    override fun searchAnimeNextPageSelector(): String = popularAnimeNextPageSelector()
+
+    // ============================== Filters ===============================
+    override fun getFilterList(): AnimeFilterList = AnimeFilterList(
+        AnimeFilter.Header("La búsqueda por texto ignora los filtros"),
+        GenreFilter(),
+        YearFilter(),
+        StatusFilter(),
+        OrderFilter()
     )
 
-    private fun unescapeJava(escaped: String): String {
-        var escaped = escaped
-        if (escaped.indexOf("\\u") == -1) return escaped
-        var processed = ""
-        var position = escaped.indexOf("\\u")
-        while (position != -1) {
-            if (position != 0) processed += escaped.substring(0, position)
-            val token = escaped.substring(position + 2, position + 6)
-            escaped = escaped.substring(position + 6)
-            processed += token.toInt(16).toChar()
-            position = escaped.indexOf("\\u")
+    private class GenreFilter : UriPartFilter(
+        "Género",
+        arrayOf(
+            Pair("Todos", ""),
+            Pair("Acción", "accion"),
+            Pair("Aventura", "aventura"),
+            Pair("Comedia", "comedia"),
+            Pair("Drama", "drama"),
+            Pair("Fantasía", "fantasia"),
+            Pair("Romance", "romance"),
+            Pair("Sci-Fi", "ciencia-ficcion"),
+            Pair("Seinen", "seinen"),
+            Pair("Shounen", "shounen"),
+            Pair("Suspenso", "suspenso"),
+            Pair("Terror", "terror")
+        )
+    )
+
+    private class YearFilter : UriPartFilter(
+        "Año",
+        arrayOf(
+            Pair("Todos", ""),
+            Pair("2026", "2026"),
+            Pair("2025", "2025"),
+            Pair("2024", "2024"),
+            Pair("2023", "2023"),
+            Pair("2022", "2022"),
+            Pair("2021", "2021"),
+            Pair("2020", "2020")
+        )
+    )
+
+    private class StatusFilter : UriPartFilter(
+        "Estado",
+        arrayOf(
+            Pair("Todos", ""),
+            Pair("En emisión", "en-emision"),
+            Pair("Finalizado", "finalizado")
+        )
+    )
+
+    private class OrderFilter : UriPartFilter(
+        "Ordenar por",
+        arrayOf(
+            Pair("Recientes", "newest"),
+            Pair("Popularidad", "views"),
+            Pair("A-Z", "asc")
+        )
+    )
+
+    private open class UriPartFilter(displayName: String, val vals: Array<Pair<String, String>>) :
+        AnimeFilter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
+        fun toUriPart() = if (state > 0) vals[state].second else ""
+    }
+
+    // ============================== Anime Details ===============================
+    override fun animeDetailsParse(document: Document): SAnime {
+        val anime = SAnime.create()
+        anime.title = document.selectFirst("div.info-a .c h1")?.text()?.trim() ?: ""
+        anime.thumbnail_url = document.selectFirst("div.info-a .i img")?.attr("data-src")
+            ?: document.selectFirst("div.info-a .i img")?.attr("src")
+        anime.description = document.selectFirst("div.info-a .c .tx p")?.text()?.trim()
+        anime.genre = document.select("div.info-a .c .gn li a").joinToString { it.text() }
+        val statusText = document.selectFirst("div.info-b .dv ul li strong.ee, div.info-b .dv ul li strong.ef")?.text()?.trim()
+        anime.status = when {
+            statusText?.contains("emision", ignoreCase = true) == true -> SAnime.ONGOING
+            statusText?.contains("finalizada", ignoreCase = true) == true -> SAnime.COMPLETED
+            else -> SAnime.UNKNOWN
         }
-        processed += escaped
+        return anime
+    }
+
+    // ============================== Episodes ===============================
+    override fun episodeListSelector(): String = "ul.epis li"
+
+    override fun episodeFromElement(element: Element): SEpisode {
+        val episode = SEpisode.create()
+        val linkElement = element.select("a").first()
+        val href = linkElement?.attr("href") ?: ""
+        val episodeNumber = href.substringAfterLast("-").toFloatOrNull() ?: 1f
+        episode.setUrlWithoutDomain(href)
+        val episodeDisplay = if (episodeNumber == episodeNumber.toInt().toFloat()) {
+            episodeNumber.toInt().toString()
+        } else {
+            episodeNumber.toString()
+        }
+        episode.name = "Episodio $episodeDisplay"
+        episode.episode_number = episodeNumber
+        return episode
+    }
+
+    override fun episodeListParse(response: Response): List<SEpisode> {
+        val initialHtml = response.body?.string() ?: return emptyList()
+        val doc = Jsoup.parse(initialHtml, baseUrl)
+        val animeId = doc.selectFirst("#dt")?.attr("data-i") ?: return emptyList()
+        val animeSlug = doc.selectFirst("#dt")?.attr("data-u") ?: return emptyList()
+
+        val allEpisodes = mutableListOf<SEpisode>()
+        var currentPage = 1
+        while (true) {
+            val pageHtml = fetchEpisodesPage(animeId, animeSlug, currentPage)
+            if (pageHtml.isBlank()) break
+            val pageDoc = Jsoup.parse(pageHtml)
+            val episodesOnPage = pageDoc.select(episodeListSelector()).map { episodeFromElement(it) }
+            if (episodesOnPage.isEmpty()) break
+            allEpisodes.addAll(episodesOnPage)
+            currentPage++
+            try {
+                Thread.sleep(500)
+            } catch (_: InterruptedException) {
+                // ignore
+            }
+        }
+        return allEpisodes.distinctBy { it.url }.sortedByDescending { it.episode_number }
+    }
+
+    private fun fetchEpisodesPage(animeId: String, animeSlug: String, page: Int): String {
+        return try {
+            val request = Request.Builder()
+                .url("$baseUrl/id")
+                .post(
+                    FormBody.Builder()
+                        .add("acc", "episodes")
+                        .add("i", animeId)
+                        .add("u", animeSlug)
+                        .add("p", page.toString())
+                        .build()
+                )
+                .addHeader("X-Requested-With", "XMLHttpRequest")
+                .addHeader("Referer", baseUrl)
+                .build()
+            val response = customClient.newCall(request).execute()
+            response.body?.string() ?: ""
+        } catch (e: Exception) {
+            ""
+        }
+    }
+
+    // ============================== Videos ===============================
+    private fun serverVideoResolverBlocking(url: String): List<Video> {
+        // Determine host to detect server switch
+        val host = runCatching { url.toHttpUrlOrNull()?.host }.getOrNull()
+            ?: url.substringAfter("://").substringBefore("/")
+        if (lastServerHost == null || lastServerHost != host) {
+            try {
+                customClient.connectionPool.evictAll()
+            } catch (_: Exception) {
+                // ignore
+            }
+            lastServerHost = host
+        }
+        return runBlocking {
+            serverVideoResolver(url)
+        }
+    }
+
+    private suspend fun serverVideoResolver(url: String): List<Video> {
+        val embedUrl = url.lowercase()
+        return try {
+            when {
+                embedUrl.contains("voe") -> voeExtractor.videosFromUrl(url, prefix = "Voe")
+                embedUrl.contains("mp4upload") -> mp4uploadExtractor.videosFromUrl(url, headers, prefix = "Mp4upload")
+                embedUrl.contains("uqload") -> uqloadExtractor.videosFromUrl(url, prefix = "Uqload")
+                embedUrl.contains("streamwish") -> streamWishExtractor.videosFromUrl(url, prefix = "StreamWish")
+                else -> universalExtractor.videosFromUrl(url, headers)
+            }
+        } catch (e: Exception) {
+            universalExtractor.videosFromUrl(url, headers)
+        }
+    }
+
+    override fun videoListParse(response: Response): List<Video> {
+        val body = response.body?.string() ?: return emptyList()
+        val document = Jsoup.parse(body, baseUrl)
+        val videos = mutableListOf<Video>()
+
+        val optElement = document.selectFirst("ul.opt[data-encrypt]")
+        if (optElement != null) {
+            val encryptedId = optElement.attr("data-encrypt")
+            val serversHtml = fetchServerList(encryptedId)
+            if (serversHtml.isNotBlank()) {
+                val videoUrls = parseServerUrls(serversHtml)
+                for ((_, pageUrl) in videoUrls) {
+                    videos.addAll(serverVideoResolverBlocking(pageUrl))
+                }
+                if (videos.isNotEmpty()) return orderVideosByPreferences(videos)
+            }
+        }
+
+        if (videos.isEmpty()) {
+            document.select("#partes div.container li.subtab div.parte").forEach { script ->
+                val jsonString = script.attr("data")
+                val jsonUnescape = unescapeJava(jsonString).replace("\\", "")
+                val url = fetchUrls(jsonUnescape).firstOrNull()?.replace("\\\\", "\\") ?: ""
+                if (url.isNotBlank()) {
+                    videos.addAll(serverVideoResolverBlocking(url))
+                }
+            }
+        }
+
+        return orderVideosByPreferences(videos)
+    }
+
+    private fun orderVideosByPreferences(videos: List<Video>): List<Video> {
+        val preferredServer = preferences.getString("animeid_preferred_server", "Voe")?.lowercase()
+        val preferredQuality = preferences.getString("animeid_preferred_quality", "any")?.lowercase()
+
+        fun detectServer(video: Video): String {
+            val urlHost = runCatching { video.url.toHttpUrlOrNull()?.host }.getOrNull() ?: ""
+            return when {
+                urlHost.contains("voe", ignoreCase = true) -> "voe"
+                urlHost.contains("mp4upload", ignoreCase = true) -> "mp4upload"
+                urlHost.contains("uqload", ignoreCase = true) -> "uqload"
+                urlHost.contains("streamwish", ignoreCase = true) -> "streamwish"
+                video.quality.contains("voe", ignoreCase = true) -> "voe"
+                video.quality.contains("mp4upload", ignoreCase = true) -> "mp4upload"
+                video.quality.contains("uqload", ignoreCase = true) -> "uqload"
+                video.quality.contains("streamwish", ignoreCase = true) -> "streamwish"
+                else -> "other"
+            }
+        }
+
+        fun qualityScore(video: Video): Int {
+            if (preferredQuality == null || preferredQuality == "any") return 0
+            val qToken = "${preferredQuality}p"
+            return when {
+                video.quality.contains(qToken, ignoreCase = true) -> 3
+                video.quality.contains(preferredQuality, ignoreCase = true) -> 2
+                video.url.contains("/$qToken", ignoreCase = true) -> 3
+                else -> 0
+            }
+        }
+
+        val grouped = videos.groupBy { detectServer(it) }
+
+        val order = mutableListOf<Video>()
+
+        if (!preferredServer.isNullOrBlank()) {
+            grouped[preferredServer]?.let { list ->
+                order.addAll(list.sortedByDescending { qualityScore(it) })
+            }
+        }
+
+        val serversOrder = listOf("voe", "mp4upload", "uqload", "streamwish", "other")
+        for (srv in serversOrder) {
+            if (srv == preferredServer) continue
+            grouped[srv]?.let { list ->
+                order.addAll(list.sortedByDescending { qualityScore(it) })
+            }
+        }
+
+        val addedUrls = order.map { it.url }.toSet()
+        videos.filter { it.url !in addedUrls }.let { leftovers ->
+            order.addAll(leftovers.sortedByDescending { qualityScore(it) })
+        }
+
+        return order
+    }
+
+    // ============================== Preferences ===============================
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        ListPreference(screen.context).apply {
+            key = "animeid_preferred_server"
+            title = "Servidor preferido"
+            entries = arrayOf("Voe", "Mp4upload", "Uqload", "StreamWish")
+            entryValues = arrayOf("Voe", "Mp4upload", "Uqload", "StreamWish")
+            setDefaultValue("Voe")
+            summary = "%s"
+        }.also(screen::addPreference)
+
+        ListPreference(screen.context).apply {
+            key = "animeid_preferred_quality"
+            title = "Calidad preferida"
+            entries = arrayOf("Automático", "480p", "720p", "1080p")
+            entryValues = arrayOf("automatic", "480", "720", "1080")
+            setDefaultValue("automatic")
+            summary = "%s"
+        }.also(screen::addPreference)
+    }
+
+    // ============================== Utilidades ===============================
+    private fun fetchServerList(encryptId: String): String {
+        return try {
+            val request = Request.Builder()
+                .url("$baseUrl/id")
+                .post(
+                    FormBody.Builder()
+                        .add("acc", "opt")
+                        .add("i", encryptId)
+                        .build()
+                )
+                .addHeader("X-Requested-With", "XMLHttpRequest")
+                .addHeader("Referer", baseUrl)
+                .build()
+            val response = customClient.newCall(request).execute()
+            response.body?.string() ?: ""
+        } catch (e: Exception) {
+            ""
+        }
+    }
+
+    private fun parseServerUrls(html: String): List<Pair<String, String>> {
+        val result = mutableListOf<Pair<String, String>>()
+        val document = Jsoup.parse(html)
+        val serverItems = document.select("li")
+        for (item in serverItems) {
+            val encryptedUrl = item.attr("encrypt")
+            if (encryptedUrl.isNotEmpty()) {
+                val decodedUrl = hexToString(encryptedUrl)
+                val serverName = item.select("span").first()?.text()?.trim() ?: "Servidor"
+                if (decodedUrl.isNotEmpty()) {
+                    result.add(Pair(serverName, decodedUrl))
+                }
+            }
+        }
+        return result
+    }
+
+    private fun hexToString(hex: String): String {
+        return try {
+            val output = StringBuilder()
+            var i = 0
+            while (i < hex.length) {
+                val str = hex.substring(i, minOf(i + 2, hex.length))
+                output.append(str.toInt(16).toChar())
+                i += 2
+            }
+            output.toString()
+        } catch (e: Exception) {
+            ""
+        }
+    }
+
+    private fun unescapeJava(escaped: String): String {
+        var escapedVar = escaped
+        if (escapedVar.indexOf("\\u") == -1) return escapedVar
+        var processed = ""
+        var position = escapedVar.indexOf("\\u")
+        while (position != -1) {
+            if (position != 0) processed += escapedVar.substring(0, position)
+            val token = escapedVar.substring(position + 2, position + 6)
+            escapedVar = escapedVar.substring(position + 6)
+            processed += token.toInt(16).toChar()
+            position = escapedVar.indexOf("\\u")
+        }
+        processed += escapedVar
         return processed
     }
 
     private fun fetchUrls(text: String?): List<String> {
         if (text.isNullOrEmpty()) return listOf()
-        val linkRegex = "(http|ftp|https)://([\\w_-]+(?:\\.[\\w_-]+)+)([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])".toRegex()
+        val linkRegex = "(http|ftp|https):\\/\\/([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:\\/~+#-]*[\\w@?^=%&\\/~+#-])".toRegex()
         return linkRegex.findAll(text).map { it.value.trim().removeSurrounding("\"") }.toList()
     }
 
-    override fun animeDetailsParse(document: Document): SAnime {
-        val anime = SAnime.create()
-        anime.thumbnail_url = document.selectFirst("#anime figure img.cover")!!.attr("abs:src")
-        anime.title = document.selectFirst("#anime section hgroup h1")!!.text()
-        anime.description = document.selectFirst("#anime section p.sinopsis")!!.text().removeSurrounding("\"")
-        anime.genre = document.select("#anime section ul.tags li a").joinToString { it.text() }
-        anime.status = parseStatus(document.select("div.main div section div.status-left div.cuerpo div:nth-child(2) span").text().trim())
-        return anime
-    }
-
-    override fun videoListSelector() = throw UnsupportedOperationException()
-
-    override fun videoUrlParse(document: Document) = throw UnsupportedOperationException()
-
-    override fun videoFromElement(element: Element) = throw UnsupportedOperationException()
-
-    override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
-        val filterList = if (filters.isEmpty()) getFilterList() else filters
-        val genreFilter = filterList.find { it is GenreFilter } as GenreFilter
-        val orderByFilter = filters.find { it is OrderByFilter } as OrderByFilter
-
-        return when {
-            query.isNotBlank() -> GET("$baseUrl/buscar?q=$query&pag=$page&sort=${orderByFilter.toUriPart()}")
-            genreFilter.state != 0 -> GET("$baseUrl/genero/${genreFilter.toUriPart()}?pag=$page&sort=${orderByFilter.toUriPart()}")
-            orderByFilter.state != 0 -> GET("$baseUrl/series?sort=${orderByFilter.toUriPart()}&pag=$page")
-            else -> popularAnimeRequest(page)
-        }
-    }
-
-    override fun searchAnimeFromElement(element: Element): SAnime = popularAnimeFromElement(element)
-
-    override fun searchAnimeNextPageSelector(): String = popularAnimeNextPageSelector()
-
-    override fun searchAnimeSelector(): String = popularAnimeSelector()
-
-    override fun getFilterList(): AnimeFilterList = AnimeFilterList(
-        AnimeFilter.Header("La busqueda por texto ignora el filtro"),
-        GenreFilter(),
-        OrderByFilter(),
-    )
-
-    private class GenreFilter :
-        UriPartFilter(
-            "Géneros",
-            arrayOf(
-                Pair("<Selecionar>", ""),
-                Pair("+18", "18"),
-                Pair("Acción", "accion"),
-                Pair("Animación", "animacion"),
-                Pair("Arte", "arte"),
-                Pair("Artes Marciales", "artes-marciales"),
-                Pair("Aventura", "aventura"),
-                Pair("Bizarro", "bizarro"),
-                Pair("Carreras", "carreras"),
-                Pair("Ciencia Ficción", "ciencia-ficcion"),
-                Pair("Colegialas", "colegialas"),
-                Pair("Comedia", "comedia"),
-                Pair("Concert", "concert"),
-                Pair("Cyberpunk", "cyberpunk"),
-                Pair("Demonios", "demonios"),
-                Pair("Deportes", "deportes"),
-                Pair("Drama", "drama"),
-                Pair("Ecchi", "ecchi"),
-                Pair("Escolares", "escolares"),
-                Pair("Fantasía", "fantasia"),
-                Pair("Fútbol", "futbol"),
-                Pair("Game", "game"),
-                Pair("Gore", "gore"),
-                Pair("Guerra", "guerra"),
-                Pair("Harem", "harem"),
-                Pair("Histórico", "historico"),
-                Pair("Horror", "horror"),
-                Pair("Idol", "idol"),
-                Pair("Infantil", "infantil"),
-                Pair("invier", "invier"),
-                Pair("Invierno 2013", "invierno-2013"),
-                Pair("Invierno 2014", "invierno-2014"),
-                Pair("Invierno 2015", "invierno-2015"),
-                Pair("Invierno 2016", "invierno-2016"),
-                Pair("Invierno 2017", "invierno-2017"),
-                Pair("Invierno 2019", "invierno-2019"),
-                Pair("Invierno 2020", "invierno-2020"),
-                Pair("Invierno 2021", "invierno-2021"),
-                Pair("Invierno 2022", "invierno-2022"),
-                Pair("Invierno-2018", "invierno-2018"),
-                Pair("Josei", "josei"),
-                Pair("Juegos", "juegos"),
-                Pair("Juegos De Mesa", "juegos-de-mesa"),
-                Pair("Kids", "kids"),
-                Pair("Loli", "loli"),
-                Pair("Lucha", "lucha"),
-                Pair("Mafia", "mafia"),
-                Pair("Magia", "magia"),
-                Pair("Mahou Shōjo", "mahou-shojo"),
-                Pair("Mecha", "mecha"),
-                Pair("Militar", "militar"),
-                Pair("Misterio", "misterio"),
-                Pair("Música", "musica"),
-                Pair("Otoño 2012", "otono-2012"),
-                Pair("Otoño 2013", "otono-2013"),
-                Pair("Otoño 2014", "otono-2014"),
-                Pair("Otoño 2015", "otono-2015"),
-                Pair("Otoño 2016", "otono-2016"),
-                Pair("Otoño 2018", "otono-2018"),
-                Pair("Otoño 2019", "otono-2019"),
-                Pair("Otoño 2020", "otono-2020"),
-                Pair("Otoño 2021", "otono-2021"),
-                Pair("otono-2017", "otono-2017"),
-                Pair("Pantsu", "pantsu"),
-                Pair("Parodia", "parodia"),
-                Pair("Policía", "policia"),
-                Pair("Post Apocalitico", "post-apocalitico"),
-                Pair("prima", "prima"),
-                Pair("Primavera 2013", "primavera-2013"),
-                Pair("Primavera 2014", "primavera-2014"),
-                Pair("Primavera 2015", "primavera-2015"),
-                Pair("Primavera 2016", "primavera-2016"),
-                Pair("Primavera 2017", "primavera-2017"),
-                Pair("primavera 2018", "primavera-2018"),
-                Pair("Primavera 2019", "primavera-2019"),
-                Pair("Primavera 2020", "primavera-2020"),
-                Pair("Primavera 2021", "primavera-2021"),
-                Pair("Primavera 2022", "primavera-2022"),
-                Pair("Primvera 2018", "primvera-2018"),
-                Pair("Psicológico", "psicologico"),
-                Pair("Recuentos De La Vida", "recuentos-de-la-vida"),
-                Pair("Romance", "romance"),
-                Pair("Samurai", "samurai"),
-                Pair("Sci-Fi", "sci-fi"),
-                Pair("Seinen", "seinen"),
-                Pair("Shōjo", "shojo"),
-                Pair("Shōjo-ai", "shojo-ai"),
-                Pair("Shōnen", "shonen"),
-                Pair("Shōnen-ai", "shonen-ai"),
-                Pair("Shooter", "shooter"),
-                Pair("Shoujo", "shoujo"),
-                Pair("Shoujo Ai", "shoujo-ai"),
-                Pair("Shounen", "shounen"),
-                Pair("shounen ai", "shounen-ai"),
-                Pair("Slice Of Life", "slice-of-life"),
-                Pair("Sobrenatural", "sobrenatural"),
-                Pair("Super poder", "super-poder"),
-                Pair("Supernatural", "supernatural"),
-                Pair("Suspenso", "suspenso"),
-                Pair("Terror", "terror"),
-                Pair("Thriller", "thriller"),
-                Pair("Torneo", "torneo"),
-                Pair("Tragedia", "tragedia"),
-                Pair("Vampiros", "vampiros"),
-                Pair("ver", "ver"),
-                Pair("vera", "vera"),
-                Pair("Verano 2013", "verano-2013"),
-                Pair("Verano 2014", "verano-2014"),
-                Pair("Verano 2015", "verano-2015"),
-                Pair("Verano 2016", "verano-2016"),
-                Pair("Verano 2017", "verano-2017"),
-                Pair("Verano 2018", "verano-2018"),
-                Pair("Verano 2019", "verano-2019"),
-                Pair("Verano 2020", "verano-2020"),
-                Pair("Verano 2021", "verano-2021"),
-                Pair("Verano 2022", "verano-2022"),
-                Pair("Violencia", "violencia"),
-                Pair("Vocaloid", "vocaloid"),
-                Pair("Yaoi", "yaoi"),
-                Pair("Yuri", "yuri"),
-            ),
-        )
-
-    private open class UriPartFilter(displayName: String, val vals: Array<Pair<String, String>>) : AnimeFilter.Select<String>(displayName, vals.map { it.first }.toTypedArray()) {
-        fun toUriPart() = vals[state].second
-    }
-
-    private class OrderByFilter :
-        UriPartFilter(
-            "Ordenar Por",
-            arrayOf(
-                Pair("<Seleccionar>", ""),
-                Pair("Recientes", "newest"),
-                Pair("A-Z", "asc"),
-                Pair("Más vistos", "views"),
-            ),
-        )
-
-    private fun parseStatus(statusString: String): Int = when {
-        statusString.contains("En emisión") -> SAnime.ONGOING
-        statusString.contains("Finalizada") -> SAnime.COMPLETED
-        else -> SAnime.UNKNOWN
-    }
-
-    override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
-
-    override fun latestUpdatesFromElement(element: Element) = popularAnimeFromElement(element)
-
-    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/series?sort=newest&pag=$page")
-
-    override fun latestUpdatesSelector() = popularAnimeSelector()
+    override fun videoListSelector(): String = throw UnsupportedOperationException()
+    override fun videoFromElement(element: Element): Video = throw UnsupportedOperationException()
+    override fun videoUrlParse(document: Document): String = throw UnsupportedOperationException()
 }

--- a/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
+++ b/src/es/animeid/src/eu/kanade/tachiyomi/animeextension/es/animeid/AnimeID.kt
@@ -39,12 +39,12 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
     private val preferences by getPreferencesLazy()
 
     /**
-     * Custom OkHttpClient independent from the global `client`.
-     * - Mobile Chrome User-Agent
-     * - Own ConnectionPool and ConnectionSpec to avoid sharing TLS sessions
+     * Custom OkHttpClient based on the app's global client.
+     * - Inherits cookies, cache, and default interceptors.
+     * - Adds custom timeout, connection pool, and mobile Chrome User-Agent.
      */
     private val customClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
+        client.newBuilder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
@@ -64,14 +64,14 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
             .build()
     }
 
-    // Use the same customClient for all extractors to keep behavior consistent
+    // Extractors using the custom client for consistency
     private val voeExtractor by lazy { VoeExtractor(customClient, headers) }
     private val mp4uploadExtractor by lazy { Mp4uploadExtractor(customClient) }
     private val uqloadExtractor by lazy { UqloadExtractor(customClient) }
     private val streamWishExtractor by lazy { StreamWishExtractor(customClient, headers) }
     private val universalExtractor by lazy { UniversalExtractor(customClient) }
 
-    // Track last host used to evict connection pool when switching servers
+    // Track last host to evict connection pool when switching servers
     private var lastServerHost: String? = null
 
     // ============================== Popular ===============================
@@ -279,7 +279,9 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
 
         val allEpisodes = mutableListOf<SEpisode>()
         var currentPage = 1
-        while (true) {
+        val maxPages = 200 // Safety limit to avoid infinite loops
+
+        while (currentPage <= maxPages) {
             val pageHtml = fetchEpisodesPage(animeId, animeSlug, currentPage)
             if (pageHtml.isBlank()) break
             val pageDoc = Jsoup.parse(pageHtml)
@@ -311,8 +313,9 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
                 .addHeader("X-Requested-With", "XMLHttpRequest")
                 .addHeader("Referer", baseUrl)
                 .build()
-            val response = customClient.newCall(request).execute()
-            response.body?.string() ?: ""
+            customClient.newCall(request).execute().use { response ->
+                response.body?.string() ?: ""
+            }
         } catch (e: Exception) {
             ""
         }
@@ -381,6 +384,59 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
         }
 
         return orderVideosByPreferences(videos)
+    }
+
+    private fun fetchServerList(encryptId: String): String {
+        return try {
+            val request = Request.Builder()
+                .url("$baseUrl/id")
+                .post(
+                    FormBody.Builder()
+                        .add("acc", "opt")
+                        .add("i", encryptId)
+                        .build()
+                )
+                .addHeader("X-Requested-With", "XMLHttpRequest")
+                .addHeader("Referer", baseUrl)
+                .build()
+            customClient.newCall(request).execute().use { response ->
+                response.body?.string() ?: ""
+            }
+        } catch (e: Exception) {
+            ""
+        }
+    }
+
+    private fun parseServerUrls(html: String): List<Pair<String, String>> {
+        val result = mutableListOf<Pair<String, String>>()
+        val document = Jsoup.parse(html)
+        val serverItems = document.select("li")
+        for (item in serverItems) {
+            val encryptedUrl = item.attr("encrypt")
+            if (encryptedUrl.isNotEmpty()) {
+                val decodedUrl = hexToString(encryptedUrl)
+                val serverName = item.select("span").first()?.text()?.trim() ?: "Servidor"
+                if (decodedUrl.isNotEmpty()) {
+                    result.add(Pair(serverName, decodedUrl))
+                }
+            }
+        }
+        return result
+    }
+
+    private fun hexToString(hex: String): String {
+        return try {
+            val output = StringBuilder()
+            var i = 0
+            while (i < hex.length) {
+                val str = hex.substring(i, minOf(i + 2, hex.length))
+                output.append(str.toInt(16).toChar())
+                i += 2
+            }
+            output.toString()
+        } catch (e: Exception) {
+            ""
+        }
     }
 
     private fun orderVideosByPreferences(videos: List<Video>): List<Video> {
@@ -460,59 +516,7 @@ class AnimeID : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
         }.also(screen::addPreference)
     }
 
-    // ============================== Utilidades ===============================
-    private fun fetchServerList(encryptId: String): String {
-        return try {
-            val request = Request.Builder()
-                .url("$baseUrl/id")
-                .post(
-                    FormBody.Builder()
-                        .add("acc", "opt")
-                        .add("i", encryptId)
-                        .build()
-                )
-                .addHeader("X-Requested-With", "XMLHttpRequest")
-                .addHeader("Referer", baseUrl)
-                .build()
-            val response = customClient.newCall(request).execute()
-            response.body?.string() ?: ""
-        } catch (e: Exception) {
-            ""
-        }
-    }
-
-    private fun parseServerUrls(html: String): List<Pair<String, String>> {
-        val result = mutableListOf<Pair<String, String>>()
-        val document = Jsoup.parse(html)
-        val serverItems = document.select("li")
-        for (item in serverItems) {
-            val encryptedUrl = item.attr("encrypt")
-            if (encryptedUrl.isNotEmpty()) {
-                val decodedUrl = hexToString(encryptedUrl)
-                val serverName = item.select("span").first()?.text()?.trim() ?: "Servidor"
-                if (decodedUrl.isNotEmpty()) {
-                    result.add(Pair(serverName, decodedUrl))
-                }
-            }
-        }
-        return result
-    }
-
-    private fun hexToString(hex: String): String {
-        return try {
-            val output = StringBuilder()
-            var i = 0
-            while (i < hex.length) {
-                val str = hex.substring(i, minOf(i + 2, hex.length))
-                output.append(str.toInt(16).toChar())
-                i += 2
-            }
-            output.toString()
-        } catch (e: Exception) {
-            ""
-        }
-    }
-
+    // ============================== Utilities ===============================
     private fun unescapeJava(escaped: String): String {
         var escapedVar = escaped
         if (escapedVar.indexOf("\\u") == -1) return escapedVar


### PR DESCRIPTION
## 📌 Changes made to the AnimeID extension

### 🌐 Domain change
- Updated base domain from `https://www.animeid.com/` → `https://wwv.animeid2.com/`
- Adapted all selectors and requests to the new domain.

### 📦 New video extractors
- **VoeExtractor** (working correctly)
- **Mp4uploadExtractor** (with custom SSL client to avoid protocol errors)
- **UqloadExtractor**
- **StreamWishExtractor**
- **UniversalExtractor** (fallback for unrecognized servers)

### ⚙️ Episode fetching improvements
- Full pagination via AJAX (`POST /id` with `acc=episodes`).
- Support for decimal episode numbers (e.g., `1.5`, `11.5`) – displayed correctly without errors.
- Sorted in descending order by episode number.

### 🎨 User preferences
- **Preferred server**: Voe, Mp4upload, Uqload, StreamWish.
- **Preferred quality**: 480p, 720p, 1080p (plus automatic mode).
- Results ordered according to the chosen server and quality.

### 🔧 Custom HTTP client
- Independent OkHttpClient with 30-second timeouts.
- Mobile Chrome User‑Agent
- Support for modern TLS and connection pool eviction when switching servers.

### 📄 Updated selectors
- **Popular**: `div.ul.x5 article.li, div.ul article.li`
- **Latest episodes**: `div.ul.hm article.li`
- **Next page**: `ul.pag li a:contains(Siguiente)`
- **Episode list**: `ul.epis li`
- **Anime details**: selectors based on new HTML classes.

### 🐛 Bug fixes
- Solved SSL error for `Mp4uploadExtractor` using a custom client with `TrustManager` that trusts all certificates (only for that domain).
- Evict stale connections when switching servers to avoid network failures.
- Safe handling of episode pagination (500ms delay between requests).

### ✅ Testing performed
- [x] Browse Popular, Latest, Search sections.
- [x] Load all episodes for long-running anime (One Piece, Naruto).
- [x] Play videos from Voe, Mp4upload, Uqload and StreamWish.
- [x] Respect preferred server and quality filters.

## Notes
This PR fixes the issues reported in issues #411

## extension working 
<img width="1520" height="720" alt="Screenshot_20260610-163304_Animetail" src="https://github.com/user-attachments/assets/2b7bdd43-163e-4e06-9d09-4b8d1e89ee1d" />
<img width="720" height="1520" alt="Screenshot_20260610-163323_Animetail" src="https://github.com/user-attachments/assets/65a15c9a-2f57-4d40-8b26-13b061ccdae2" />
<img width="720" height="1520" alt="Screenshot_20260610-163335_Animetail" src="https://github.com/user-attachments/assets/edbca928-94f2-41a3-904f-31c47fa74010" />
<img width="720" height="1520" alt="Screenshot_20260610-163454_Animetail" src="https://github.com/user-attachments/assets/c31be3b3-45d2-494c-8c54-855a5d173682" />


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc