### PR TITLE
Anime-Sama [Fr]: Anime Parse Logic Change

### DIFF
--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime-Sama'
     extClass = '.AnimeSama'
-    extVersionCode = 28
+    extVersionCode = 29
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -84,11 +84,6 @@ class AnimeSama :
             response
         }.build()
 
-    private val planning: String by lazy {
-        client.newCall(GET("$baseUrl/planning/", headers))
-            .execute().bodyString()
-    }
-
     // ============================== Popular ===============================
     override fun popularAnimeParse(response: Response): AnimesPage {
         val doc = response.useAsJsoup()
@@ -236,24 +231,35 @@ class AnimeSama :
     private val seasonRegex by lazy { Regex("^\\s*panneauAnime\\(\"(.*)\", \"(.*)\"\\)", RegexOption.MULTILINE) }
     private val movieNameRegex by lazy { Regex("^\\s*newSPF\\(\"(.*)\"\\);", RegexOption.MULTILINE) }
 
-    private suspend fun fetchAnimeSeasons(response: Response, season: String): List<SAnime> {
-        val animeDoc = response.useAsJsoup()
+    private fun fetchAnimeSeasons(response: Response, Season: String): List<SAnime> {
+        val animeDoc = response.asJsoup()
+
         val animeUrl = response.request.url
-        val animeName = animeDoc.getElementById("titreOeuvre")?.text() ?: ""
+        val animeName = animeDoc.selectFirst("h1")?.text() ?: ""
 
-        val scripts = animeDoc.select("h2 + p + div > script, h2 + div > script").toString()
+        val statusText = animeDoc.select(".info-lbl:contains(État) + .info-val")
+            .firstOrNull()?.text()?.trim() ?: ""
+
+        val animeStatus = when {
+            statusText.contains("En cours", true) -> SAnime.ONGOING
+            statusText.contains("Terminé", true) -> SAnime.COMPLETED
+            else -> SAnime.UNKNOWN
+        }
+
+        val thumbnailUrl = animeDoc.getElementById("coverOeuvre")?.attr("src")
+            ?: animeDoc.selectFirst("meta[property=og:image]")?.attr("content")
+            ?: animeDoc.selectFirst("meta[itemprop=image]")?.attr("content")
+
+        val scripts = animeDoc.select("script").joinToString("\n") { it.data() }
         val uncommented = commentRegex.replace(scripts, "")
-        val animes = seasonRegex.findAll(uncommented).withIndex().asIterable().parallelCatchingFlatMapBlocking { (animeIndex, seasonMatch) ->
+        val animes = seasonRegex.findAll(uncommented).flatMapIndexed { animeIndex, seasonMatch ->
             val (seasonName, seasonStem) = seasonMatch.destructured
-
-            if (season.isNotEmpty() && seasonStem.replace("/vostfr", "") != season) {
-                return@parallelCatchingFlatMapBlocking emptyList()
-            }
 
             if (seasonStem.contains("film", true)) {
                 val moviesUrl = "$animeUrl/$seasonStem"
-                val movies = fetchPlayers(moviesUrl).ifEmpty { return@parallelCatchingFlatMapBlocking emptyList() }
-                val moviesDoc = client.newCall(GET(moviesUrl)).awaitSuccess().bodyString()
+                val movies = fetchPlayers(moviesUrl).ifEmpty { return@flatMapIndexed emptyList() }
+                val movieNameRegex = Regex("^\\s*newSPF\\(\"(.*)\"\\);", RegexOption.MULTILINE)
+                val moviesDoc = client.newCall(GET(moviesUrl)).execute().body.string()
                 val matches = movieNameRegex.findAll(moviesDoc).toList()
                 List(movies.size) { i ->
                     val title = when {
@@ -272,29 +278,15 @@ class AnimeSama :
         return animes.map {
             SAnime.create().apply {
                 title = it.first
-                thumbnail_url = animeDoc.getElementById("coverOeuvre")?.attr("src")
-                description = animeDoc.select("h2:contains(synopsis) + p").text()
-                genre = animeDoc.select("h2:contains(genres) + a").text().replace(" - ", ", ")
+                thumbnail_url = thumbnailUrl
+                description = animeDoc.selectFirst("#synopsisText")?.text() ?: ""
+                genre = animeDoc.select(".genre-pill").joinToString(", ") { g -> g.text() }
                 setUrlWithoutDomain(it.second)
-                status = parseStatus(it.second.substringBefore('#')) ?: SAnime.UNKNOWN
+                status = animeStatus
                 initialized = true
             }
         }.toList()
     }
-
-    private val cleanUrlRegex by lazy { "(?<!:)/{2,}".toRegex() }
-    private val statusRegex by lazy { ".*/(catalogue/[^/]+/[^/]+)".toRegex() }
-    private fun parseStatus(animeUrl: String): Int? = runCatching {
-        val cleanedUrl = animeUrl.replace(cleanUrlRegex, "/")
-        val match = statusRegex.find(cleanedUrl)
-        val searchTarget = match?.groupValues?.get(1) ?: cleanedUrl
-
-        return if (planning.contains(searchTarget)) {
-            SAnime.ONGOING
-        } else {
-            SAnime.COMPLETED
-        }
-    }.getOrNull()
 
     private fun playersToEpisodes(list: List<List<List<String>>>): List<SEpisode> = List(list.fold(0) { acc, it -> maxOf(acc, it.size) }) { episodeNumber ->
         val players = list.map { it.getOrElse(episodeNumber) { emptyList() } }

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -231,35 +231,37 @@ class AnimeSama :
     private val seasonRegex by lazy { Regex("^\\s*panneauAnime\\(\"(.*)\", \"(.*)\"\\)", RegexOption.MULTILINE) }
     private val movieNameRegex by lazy { Regex("^\\s*newSPF\\(\"(.*)\"\\);", RegexOption.MULTILINE) }
 
-    private fun fetchAnimeSeasons(response: Response, Season: String): List<SAnime> {
-        val animeDoc = response.asJsoup()
-
+    private suspend fun fetchAnimeSeasons(response: Response, season: String): List<SAnime> {
+        val animeDoc = response.useAsJsoup()
         val animeUrl = response.request.url
         val animeName = animeDoc.selectFirst("h1")?.text() ?: ""
-
+    
         val statusText = animeDoc.select(".info-lbl:contains(État) + .info-val")
             .firstOrNull()?.text()?.trim() ?: ""
-
+    
         val animeStatus = when {
             statusText.contains("En cours", true) -> SAnime.ONGOING
             statusText.contains("Terminé", true) -> SAnime.COMPLETED
             else -> SAnime.UNKNOWN
         }
-
+    
         val thumbnailUrl = animeDoc.getElementById("coverOeuvre")?.attr("src")
             ?: animeDoc.selectFirst("meta[property=og:image]")?.attr("content")
             ?: animeDoc.selectFirst("meta[itemprop=image]")?.attr("content")
-
+    
         val scripts = animeDoc.select("script").joinToString("\n") { it.data() }
         val uncommented = commentRegex.replace(scripts, "")
-        val animes = seasonRegex.findAll(uncommented).flatMapIndexed { animeIndex, seasonMatch ->
+        val animes = seasonRegex.findAll(uncommented).withIndex().asIterable().parallelCatchingFlatMapBlocking { (animeIndex, seasonMatch) ->
             val (seasonName, seasonStem) = seasonMatch.destructured
-
+    
+            if (season.isNotEmpty() && seasonStem.replace("/vostfr", "") != season) {
+                return@parallelCatchingFlatMapBlocking emptyList()
+            }
+    
             if (seasonStem.contains("film", true)) {
                 val moviesUrl = "$animeUrl/$seasonStem"
-                val movies = fetchPlayers(moviesUrl).ifEmpty { return@flatMapIndexed emptyList() }
-                val movieNameRegex = Regex("^\\s*newSPF\\(\"(.*)\"\\);", RegexOption.MULTILINE)
-                val moviesDoc = client.newCall(GET(moviesUrl)).execute().body.string()
+                val movies = fetchPlayers(moviesUrl).ifEmpty { return@parallelCatchingFlatMapBlocking emptyList() }
+                val moviesDoc = client.newCall(GET(moviesUrl)).awaitSuccess().bodyString()
                 val matches = movieNameRegex.findAll(moviesDoc).toList()
                 List(movies.size) { i ->
                     val title = when {
@@ -274,7 +276,7 @@ class AnimeSama :
                 listOf(Pair("$animeName $seasonName", "$animeUrl/$seasonStem"))
             }
         }
-
+    
         return animes.map {
             SAnime.create().apply {
                 title = it.first

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -27,6 +27,7 @@ import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parallelFlatMapBlocking
+import keiyoushi.utils.parallelMapBlocking
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
 import keiyoushi.utils.useAsJsoup
@@ -148,10 +149,11 @@ class AnimeSama :
     override fun searchAnimeParse(response: Response): AnimesPage {
         val document = response.useAsJsoup()
         val anime = document.select("#list_catalog > div a").parallelFlatMapBlocking {
-            fetchAnimeSeasons(it.attr("href"), "")
+            fetchAnimeSeasons(it.attr("abs:href"), "")
         }
-        val page = response.request.url.queryParameterValues("page").firstOrNull()
-        val hasNextPage = document.select("#list_pagination a:last-child").text() != page
+        val page = response.request.url.queryParameterValues("page").firstOrNull() ?: "1"
+        val lastPage = document.select("#list_pagination a:last-child").text()
+        val hasNextPage = lastPage.isNotEmpty() && lastPage != page
         return AnimesPage(anime, hasNextPage)
     }
 
@@ -169,10 +171,20 @@ class AnimeSama :
 
     // ============================== Episodes ==============================
     override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
-        val animeUrl = "$baseUrl${anime.url.substringBeforeLast("/")}"
-        val movie = anime.url.split("#").getOrElse(1) { "" }.toIntOrNull()
-        val players = VOICES_VALUES.asIterable().parallelCatchingFlatMapBlocking { fetchPlayers("$animeUrl/$it").let(::listOf) }
-        val episodes = playersToEpisodes(players)
+        val url = anime.url.removeSuffix("/")
+        val movie = url.split("#").getOrElse(1) { "" }.toIntOrNull()
+        val cleanUrl = url.substringBefore("#")
+        val currentFolder = cleanUrl.substringAfterLast("/")
+        val isVoiceFolder = VOICES_VALUES.contains(currentFolder)
+        val parentUrl = if (isVoiceFolder) {
+            "$baseUrl${cleanUrl.substringBeforeLast("/")}"
+        } else {
+            "$baseUrl$cleanUrl"
+        }
+
+        val paths = (listOf(currentFolder) + VOICES_VALUES).distinct()
+        val players = paths.parallelMapBlocking { fetchPlayers("$parentUrl/$it") }
+        val episodes = playersToEpisodes(players, paths)
         return if (movie == null) episodes.reversed() else listOf(episodes[movie])
     }
 
@@ -186,8 +198,9 @@ class AnimeSama :
 
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
         val playerUrls = episode.url.parseAs<List<List<String>>>()
-        val videos = playerUrls.flatMapIndexed { i, it ->
-            val prefix = "(${VOICES_VALUES[i].uppercase()}) "
+        val voiceNames = episode.scanlator?.split(", ") ?: emptyList()
+        val videos = playerUrls.filter { it.isNotEmpty() }.flatMapIndexed { i, it ->
+            val prefix = "(${voiceNames.getOrElse(i) { "" }}) "
             it.parallelCatchingFlatMap { playerUrl ->
                 with(playerUrl) {
                     when {
@@ -233,11 +246,11 @@ class AnimeSama :
 
     private suspend fun fetchAnimeSeasons(response: Response, season: String): List<SAnime> {
         val animeDoc = response.useAsJsoup()
-        val animeUrl = response.request.url
+        val animeUrl = response.request.url.toString().removeSuffix("/")
         val animeName = animeDoc.selectFirst("h1")?.text() ?: ""
 
         val statusText = animeDoc.select(".info-lbl:contains(État) + .info-val")
-            .firstOrNull()?.text()?.trim() ?: ""
+            .firstOrNull()?.text() ?: ""
 
         val animeStatus = when {
             statusText.contains("En cours", true) -> SAnime.ONGOING
@@ -245,16 +258,17 @@ class AnimeSama :
             else -> SAnime.UNKNOWN
         }
 
-        val thumbnailUrl = animeDoc.getElementById("coverOeuvre")?.attr("src")
-            ?: animeDoc.selectFirst("meta[property=og:image]")?.attr("content")
-            ?: animeDoc.selectFirst("meta[itemprop=image]")?.attr("content")
+        val thumbnailUrl = animeDoc.getElementById("coverOeuvre")?.attr("abs:src")
+            ?: animeDoc.selectFirst("meta[property=og:image]")?.attr("abs:content")
+            ?: animeDoc.selectFirst("meta[itemprop=image]")?.attr("abs:content")
 
         val scripts = animeDoc.select("script").joinToString("\n") { it.data() }
         val uncommented = commentRegex.replace(scripts, "")
         val animes = seasonRegex.findAll(uncommented).withIndex().asIterable().parallelCatchingFlatMapBlocking { (animeIndex, seasonMatch) ->
             val (seasonName, seasonStem) = seasonMatch.destructured
 
-            if (season.isNotEmpty() && seasonStem.replace("/vostfr", "") != season) {
+            val stemSeason = seasonStem.substringBefore("/")
+            if (season.isNotEmpty() && stemSeason != season) {
                 return@parallelCatchingFlatMapBlocking emptyList()
             }
 
@@ -273,46 +287,65 @@ class AnimeSama :
                     Pair(title, "$moviesUrl#$i")
                 }
             } else {
-                listOf(Pair("$animeName $seasonName", "$animeUrl/$seasonStem"))
+                val displaySeason = if (stemSeason.startsWith("saison")) {
+                    "Saison " + stemSeason.substringAfter("saison").substringBefore("/")
+                } else {
+                    seasonName.substringBefore(" (")
+                }
+                listOf(Pair("$animeName $displaySeason", "$animeUrl/$seasonStem"))
             }
         }
+
+        val descriptionText = animeDoc.selectFirst("#synopsisText")?.text() ?: ""
+        val genresText = animeDoc.select(".genre-pill").joinToString(", ") { g -> g.text() }
 
         return animes.map {
             SAnime.create().apply {
                 title = it.first
                 thumbnail_url = thumbnailUrl
-                description = animeDoc.selectFirst("#synopsisText")?.text() ?: ""
-                genre = animeDoc.select(".genre-pill").joinToString(", ") { g -> g.text() }
-                setUrlWithoutDomain(it.second)
+                description = descriptionText
+                genre = genresText
+                setUrlWithoutDomain(it.second.removeSuffix("/"))
                 status = animeStatus
                 initialized = true
             }
-        }.toList()
+        }
     }
 
-    private fun playersToEpisodes(list: List<List<List<String>>>): List<SEpisode> = List(list.fold(0) { acc, it -> maxOf(acc, it.size) }) { episodeNumber ->
-        val players = list.map { it.getOrElse(episodeNumber) { emptyList() } }
-        SEpisode.create().apply {
-            name = "Episode ${episodeNumber + 1}"
-            url = players.toJsonString()
-            episode_number = (episodeNumber + 1).toFloat()
-            scanlator = players.mapIndexedNotNull { i, it -> if (it.isNotEmpty()) VOICES_VALUES[i] else null }.joinToString().uppercase()
+    private fun playersToEpisodes(list: List<List<List<String>>>, voiceNames: List<String>): List<SEpisode> {
+        val episodeCount = list.maxOfOrNull { voice ->
+            voice.maxOfOrNull { player -> player.size } ?: 0
+        } ?: 0
+
+        return List(episodeCount) { epIdx ->
+            val episodeVoices = list.map { voicePlayers ->
+                voicePlayers.mapNotNull { it.getOrNull(epIdx) }
+            }
+            SEpisode.create().apply {
+                name = "Episode ${epIdx + 1}"
+                url = episodeVoices.toJsonString()
+                episode_number = (epIdx + 1).toFloat()
+                scanlator = episodeVoices.mapIndexedNotNull { i, players ->
+                    if (players.isNotEmpty()) voiceNames[i] else null
+                }.joinToString().uppercase()
+            }
         }
     }
 
     private suspend fun fetchPlayers(url: String): List<List<String>> {
-        val docUrl = "$url/episodes.js"
-        val doc = client.newCall(GET(docUrl))
-            .awaitSuccess()
-            .bodyString()
-        val urls = QuickJs.create().use { qjs ->
-            qjs.evaluate(doc)
-            val res = qjs.evaluate($$"JSON.stringify(Array.from({length: 10}, (e,i) => this[`eps${i}`]).filter(e => e))")
-            (res as String).parseAs<List<List<String>>>()
+        val docUrl = "${url.removeSuffix("/")}/episodes.js"
+        return try {
+            val doc = client.newCall(GET(docUrl))
+                .awaitSuccess()
+                .bodyString()
+            QuickJs.create().use { qjs ->
+                qjs.evaluate(doc)
+                val res = qjs.evaluate($$"JSON.stringify(Object.keys(this).filter(k => /^eps[0-9]+$/.test(k)).sort((a, b) => parseInt(a.slice(3)) - parseInt(b.slice(3))).map(k => this[k]))")
+                (res as String).parseAs<List<List<String>>>()
+            }
+        } catch (_: Exception) {
+            emptyList()
         }
-
-        if (urls.isEmpty() || urls[0].isEmpty()) return emptyList()
-        return List(urls[0].size) { i -> urls.mapNotNull { it.getOrNull(i) }.distinct() }
     }
 
     private fun String.sanitizeDomain() = trim().removeSuffix("/").ifBlank { PREF_URL_DEFAULT }
@@ -387,6 +420,7 @@ class AnimeSama :
             "Préférer VF1" to "vf1",
             "Préférer VF2" to "vf2",
             "Préférer VA" to "va",
+            "Préférer VAR" to "var",
             "Préférer VCN" to "vcn",
             "Préférer VJ" to "vj",
             "Préférer VKR" to "vkr",

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -235,29 +235,29 @@ class AnimeSama :
         val animeDoc = response.useAsJsoup()
         val animeUrl = response.request.url
         val animeName = animeDoc.selectFirst("h1")?.text() ?: ""
-    
+
         val statusText = animeDoc.select(".info-lbl:contains(État) + .info-val")
             .firstOrNull()?.text()?.trim() ?: ""
-    
+
         val animeStatus = when {
             statusText.contains("En cours", true) -> SAnime.ONGOING
             statusText.contains("Terminé", true) -> SAnime.COMPLETED
             else -> SAnime.UNKNOWN
         }
-    
+
         val thumbnailUrl = animeDoc.getElementById("coverOeuvre")?.attr("src")
             ?: animeDoc.selectFirst("meta[property=og:image]")?.attr("content")
             ?: animeDoc.selectFirst("meta[itemprop=image]")?.attr("content")
-    
+
         val scripts = animeDoc.select("script").joinToString("\n") { it.data() }
         val uncommented = commentRegex.replace(scripts, "")
         val animes = seasonRegex.findAll(uncommented).withIndex().asIterable().parallelCatchingFlatMapBlocking { (animeIndex, seasonMatch) ->
             val (seasonName, seasonStem) = seasonMatch.destructured
-    
+
             if (season.isNotEmpty() && seasonStem.replace("/vostfr", "") != season) {
                 return@parallelCatchingFlatMapBlocking emptyList()
             }
-    
+
             if (seasonStem.contains("film", true)) {
                 val moviesUrl = "$animeUrl/$seasonStem"
                 val movies = fetchPlayers(moviesUrl).ifEmpty { return@parallelCatchingFlatMapBlocking emptyList() }
@@ -276,7 +276,7 @@ class AnimeSama :
                 listOf(Pair("$animeName $seasonName", "$animeUrl/$seasonStem"))
             }
         }
-    
+
         return animes.map {
             SAnime.create().apply {
                 title = it.first


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---



Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update Anime-Sama French extension to change how anime seasons and metadata are parsed from the site.

New Features:
- Derive anime status from the detail page state field instead of the separate planning endpoint.
- Populate anime synopsis and genres from updated DOM selectors on the anime detail page.

Bug Fixes:
- Fix season and movie parsing by reading all inline scripts and extracting season and movie names from current script structure.
- Avoid reliance on the removed planning page for determining anime status, preventing incorrect status values.

Enhancements:
- Reuse a single thumbnail URL and shared status for all seasons derived from an anime detail page.
- Simplify season parsing logic by removing parallel processing and unused status helper methods.

Build:
- Bump Anime-Sama extension version code to 29.