### PR TITLE
chore(workflow): Fix building workflow won't remove extensions if it's the only change

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -144,7 +144,7 @@ jobs:
   publish:
     name: Publish extension repo
     needs: [prepare, build]
-    if: github.repository == 'yuzono/anime-extensions'
+    if: always() && github.repository == 'yuzono/anime-extensions'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the build_push workflow so the publish job is guarded by an always() condition alongside the repository check.