### PR TITLE
AnimeiTo [PT]: Fix extractor

### DIFF
--- a/src/pt/animeito/build.gradle
+++ b/src/pt/animeito/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeIto'
     themePkg = 'animestream'
     baseUrl = 'https://animesonline.io'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
@@ -17,15 +17,14 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
     suspend fun videosFromUrl(url: String): List<Video> {
         val playerDoc = client.newCall(GET(url, headers)).awaitSuccess().useAsJsoup()
 
-        val script = try {
-            val encodedScript = playerDoc.selectFirst("script:containsData(TextDecoder)")
-                ?.data() ?: error("")
+        val encodedScript = playerDoc.selectFirst("script:containsData(TextDecoder)")?.data()
+        val script = if (encodedScript != null) {
             Log.d(tag, "TextDecoder script found, length=${encodedScript.length}")
-            decodeTextDecoderScript(encodedScript).ifEmpty {
-                error("decodeTextDecoderScript returned empty")
-            }
-        } catch (e: Exception) {
-            Log.w(tag, "TextDecoder path failed: ${e.message}")
+            decodeTextDecoderScript(encodedScript).takeIf { it.isNotEmpty() }
+        } else {
+            null
+        } ?: run {
+            Log.w(tag, "TextDecoder script not found, falling back to const player")
             playerDoc.selectFirst("script:containsData(const player)")?.data()
                 ?: return emptyList<Video>().also { Log.e(tag, "No const player script found") }
         }
@@ -63,7 +62,6 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         }
 
         val params = mainContent.substring(funcCallStart + 2, funcCallEnd + 1)
-        Log.d(tag, "Params preview: ${params.take(200)}...${params.takeLast(100)}")
 
         val array1End = Regex("""\],\s*\[""").find(params)?.range?.first ?: -1
         if (array1End < 0) {
@@ -97,19 +95,40 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
             .map { it.groupValues[1] }
             .toList()
 
-        val indices = secondArrayStr
+        val rawIndexTokens = secondArrayStr
             .removeSurrounding("[", "]")
             .split(",")
-            .map { it.trim().toInt() }
+        val indices = rawIndexTokens.mapNotNull { token ->
+            val trimmed = token.trim()
+            if (trimmed.isEmpty()) {
+                Log.w(tag, "Skipping empty index token while decoding")
+                return@mapNotNull null
+            }
+            val value = trimmed.toIntOrNull()
+            if (value == null) {
+                Log.w(tag, "Skipping non-numeric index token while decoding: '$trimmed'")
+            }
+            value
+        }
 
-        Log.d(tag, "Decode: ${strings.size} strings, ${indices.size} indices, keyLen=${keyStr.length}")
+        if (indices.isEmpty()) {
+            Log.w(tag, "No valid indices found")
+            return ""
+        }
 
-        val joined = indices.joinToString("") { strings[it] }
-        Log.d(tag, "Joined base64 length=${joined.length}")
+        val joined = indices.joinToString("") { strings.getOrNull(it) ?: "" }
+        if (joined.isEmpty()) {
+            Log.w(tag, "Joined base64 is empty")
+            return ""
+        }
 
         val decodedData = Base64.decode(joined, Base64.DEFAULT)
         val key = Base64.decode(keyStr, Base64.DEFAULT)
-        Log.d(tag, "Decoded data size=${decodedData.size}, key size=${key.size}")
+
+        if (decodedData.isEmpty() || key.isEmpty()) {
+            Log.w(tag, "Decoded data or key is empty")
+            return ""
+        }
 
         val result = ByteArray(decodedData.size) { i ->
             (decodedData[i].toInt() xor key[i % key.size].toInt()).toByte()

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
@@ -13,6 +13,9 @@ import okhttp3.OkHttpClient
 class AnimeItoExtractor(private val client: OkHttpClient, private val headers: Headers) {
     private val tag = javaClass.simpleName
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
+    private val arraySepRegex = Regex("""\],\s*\[""")
+    private val keySepRegex = Regex("""\],\s*"""")
+    private val stringsRegex = Regex("\"([^\"]*?)\"")
 
     suspend fun videosFromUrl(url: String): List<Video> {
         val playerDoc = client.newCall(GET(url, headers)).awaitSuccess().useAsJsoup()
@@ -63,13 +66,13 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
 
         val params = mainContent.substring(funcCallStart + 2, funcCallEnd + 1)
 
-        val array1End = Regex("""\],\s*\[""").find(params)?.range?.first ?: -1
+        val array1End = arraySepRegex.find(params)?.range?.first ?: -1
         if (array1End < 0) {
             Log.w(tag, "Could not find first array boundary")
             return ""
         }
 
-        val array2End = Regex("""\],\s*"""").find(params)?.range?.first ?: -1
+        val array2End = keySepRegex.find(params)?.range?.first ?: -1
         if (array2End < 0) {
             Log.w(tag, "Could not find second array boundary")
             return ""
@@ -84,13 +87,14 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         val secondArrayStr = params.substring(secondArrayOpen, array2End + 1)
 
         val keyQuoteStart = params.indexOf('"', array2End + 1)
-        if (keyQuoteStart < 0) {
+        val keyQuoteEnd = params.indexOf('"', keyQuoteStart + 1)
+        if (keyQuoteStart < 0 || keyQuoteEnd < 0) {
             Log.w(tag, "Could not find key string")
             return ""
         }
-        val keyStr = params.substring(keyQuoteStart + 1, params.length - 1)
+        val keyStr = params.substring(keyQuoteStart + 1, keyQuoteEnd)
 
-        val strings = Regex("\"([^\"]*?)\"")
+        val strings = stringsRegex
             .findAll(firstArrayStr)
             .map { it.groupValues[1] }
             .toList()
@@ -122,8 +126,8 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
             return ""
         }
 
-        val decodedData = Base64.decode(joined, Base64.DEFAULT)
-        val key = Base64.decode(keyStr, Base64.DEFAULT)
+        val decodedData = runCatching { Base64.decode(joined, Base64.DEFAULT) }.getOrNull() ?: return ""
+        val key = runCatching { Base64.decode(keyStr, Base64.DEFAULT) }.getOrNull() ?: return ""
 
         if (decodedData.isEmpty() || key.isEmpty()) {
             Log.w(tag, "Decoded data or key is empty")

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
@@ -1,33 +1,36 @@
 package eu.kanade.tachiyomi.animeextension.pt.animeito.extractors
 
 import android.util.Base64
+import android.util.Log
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
-import keiyoushi.lib.unpacker.Unpacker
 import keiyoushi.utils.useAsJsoup
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 
 class AnimeItoExtractor(private val client: OkHttpClient, private val headers: Headers) {
+    private val tag = javaClass.simpleName
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
 
     suspend fun videosFromUrl(url: String): List<Video> {
         val playerDoc = client.newCall(GET(url, headers)).awaitSuccess().useAsJsoup()
-        val encodedScript = playerDoc.selectFirst("script:containsData(AnimeiTo.Run)")
-            ?.data()
 
-        val script = if (encodedScript != null) {
-            val decodedData = encodedScript.substringAfter("(").substringBefore(")")
-                .replace(Regex("\"\\s*\\+\\s*\""), "") // Remove concatenation
-                .replace(Regex("[^A-Za-z0-9+/=]"), "") // Remove non-base64 characters
-                .let { String(Base64.decode(it, Base64.DEFAULT)) }
-            Unpacker.unpack(decodedData).ifEmpty { return emptyList() }
-        } else {
+        val script = try {
+            val encodedScript = playerDoc.selectFirst("script:containsData(TextDecoder)")
+                ?.data() ?: error("")
+            Log.d(tag, "TextDecoder script found, length=${encodedScript.length}")
+            decodeTextDecoderScript(encodedScript).ifEmpty {
+                error("decodeTextDecoderScript returned empty")
+            }
+        } catch (e: Exception) {
+            Log.w(tag, "TextDecoder path failed: ${e.message}")
             playerDoc.selectFirst("script:containsData(const player)")?.data()
-                ?: return emptyList()
+                ?: return emptyList<Video>().also { Log.e(tag, "No const player script found") }
         }
+
+        Log.d(tag, "Script type: ${if ("googlevideo" in script) "direct" else "hls"}")
 
         return if ("googlevideo" in script) {
             script.substringAfter("sources:").substringBefore("]")
@@ -36,14 +39,82 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                 .map {
                     val videoUrl = it.substringAfter("file\":\"").substringBefore('"')
                     val quality = it.substringAfter("label\":\"").substringBefore('"')
+                    Log.d(tag, "Found video: $quality - ${videoUrl.take(80)}...")
                     Video(videoUrl, "Animei.to - $quality", videoUrl, headers)
                 }
         } else {
             val masterPlaylistUrl = script.substringAfter("sources:")
                 .substringAfter("file\":\"")
                 .substringBefore('"')
+            Log.d(tag, "HLS master URL: $masterPlaylistUrl")
 
             playlistUtils.extractFromHls(masterPlaylistUrl, videoNameGen = { "Animei.to - $it" })
         }
+    }
+
+    private fun decodeTextDecoderScript(script: String): String {
+        val mainContent = script.substringBefore("})();")
+
+        val funcCallStart = mainContent.indexOf("([\"")
+        val funcCallEnd = mainContent.lastIndexOf("\");")
+        if (funcCallStart < 0 || funcCallEnd < 0 || funcCallEnd <= funcCallStart + 1) {
+            Log.w(tag, "Could not find function call boundaries: start=$funcCallStart end=$funcCallEnd")
+            return ""
+        }
+
+        val params = mainContent.substring(funcCallStart + 2, funcCallEnd + 1)
+        Log.d(tag, "Params preview: ${params.take(200)}...${params.takeLast(100)}")
+
+        val array1End = Regex("""\],\s*\[""").find(params)?.range?.first ?: -1
+        if (array1End < 0) {
+            Log.w(tag, "Could not find first array boundary")
+            return ""
+        }
+
+        val array2End = Regex("""\],\s*"""").find(params)?.range?.first ?: -1
+        if (array2End < 0) {
+            Log.w(tag, "Could not find second array boundary")
+            return ""
+        }
+
+        val firstArrayStr = params.substring(0, array1End + 1)
+        val secondArrayOpen = params.indexOf('[', array1End + 1)
+        if (secondArrayOpen < 0 || secondArrayOpen >= array2End) {
+            Log.w(tag, "Could not find second array brackets")
+            return ""
+        }
+        val secondArrayStr = params.substring(secondArrayOpen, array2End + 1)
+
+        val keyQuoteStart = params.indexOf('"', array2End + 1)
+        if (keyQuoteStart < 0) {
+            Log.w(tag, "Could not find key string")
+            return ""
+        }
+        val keyStr = params.substring(keyQuoteStart + 1, params.length - 1)
+
+        val strings = Regex("\"([^\"]*?)\"")
+            .findAll(firstArrayStr)
+            .map { it.groupValues[1] }
+            .toList()
+
+        val indices = secondArrayStr
+            .removeSurrounding("[", "]")
+            .split(",")
+            .map { it.trim().toInt() }
+
+        Log.d(tag, "Decode: ${strings.size} strings, ${indices.size} indices, keyLen=${keyStr.length}")
+
+        val joined = indices.joinToString("") { strings[it] }
+        Log.d(tag, "Joined base64 length=${joined.length}")
+
+        val decodedData = Base64.decode(joined, Base64.DEFAULT)
+        val key = Base64.decode(keyStr, Base64.DEFAULT)
+        Log.d(tag, "Decoded data size=${decodedData.size}, key size=${key.size}")
+
+        val result = ByteArray(decodedData.size) { i ->
+            (decodedData[i].toInt() xor key[i % key.size].toInt()).toByte()
+        }
+
+        return String(result, Charsets.UTF_8)
     }
 }

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
@@ -87,9 +87,13 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         val secondArrayStr = params.substring(secondArrayOpen, array2End + 1)
 
         val keyQuoteStart = params.indexOf('"', array2End + 1)
+        if (keyQuoteStart < 0) {
+            Log.w(tag, "Could not find key string start")
+            return ""
+        }
         val keyQuoteEnd = params.indexOf('"', keyQuoteStart + 1)
-        if (keyQuoteStart < 0 || keyQuoteEnd < 0) {
-            Log.w(tag, "Could not find key string")
+        if (keyQuoteEnd < 0) {
+            Log.w(tag, "Could not find key string end")
             return ""
         }
         val keyStr = params.substring(keyQuoteStart + 1, keyQuoteEnd)


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the AnimeIto extractor to handle a new obfuscated player script format and bump the extension override version code.

Bug Fixes:
- Fix AnimeIto video extraction by supporting the current TextDecoder-based player script and falling back to the legacy player script when needed.

Enhancements:
- Add debug logging and a dedicated decoder helper to parse and decode obfuscated AnimeIto player scripts.

Build:
- Increase the AnimeIto extension overrideVersionCode to publish the updated extractor.