### PR TITLE
AnimeStream: fix synopsis extraction and language filtering for AnimeXin

### DIFF
--- a/lib-multisrc/animestream/build.gradle.kts
+++ b/lib-multisrc/animestream/build.gradle.kts
@@ -4,4 +4,4 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 6
+baseVersionCode = 7

--- a/lib-multisrc/animestream/src/eu/kanade/tachiyomi/multisrc/animestream/AnimeStream.kt
+++ b/lib-multisrc/animestream/src/eu/kanade/tachiyomi/multisrc/animestream/AnimeStream.kt
@@ -269,7 +269,7 @@ abstract class AnimeStream(
         else -> "Alternative name(s): "
     }
 
-    protected open fun getAnimeDescription(document: Document) = document.selectFirst(animeDescriptionSelector)?.text()
+    protected open fun getAnimeDescription(document: Document) = document.select(animeDescriptionSelector).lastOrNull()?.text()
 
     override fun animeDetailsParse(document: Document): SAnime = SAnime.create().apply {
         setUrlWithoutDomain(document.location())

--- a/src/all/animexin/src/eu/kanade/tachiyomi/animeextension/all/animexin/AnimeXin.kt
+++ b/src/all/animexin/src/eu/kanade/tachiyomi/animeextension/all/animexin/AnimeXin.kt
@@ -22,6 +22,25 @@ class AnimeXin :
     ) {
     override val id = 4620219025406449669
 
+    // =========================== Anime Details ============================
+    override fun getAnimeDescription(document: Document): String? {
+        val description = super.getAnimeDescription(document) ?: return null
+        val englishIdx = description.indexOf("English", ignoreCase = true)
+        val indonesiaIdx = description.indexOf("Indonesia", ignoreCase = true)
+
+        return if (englishIdx != -1 && indonesiaIdx != -1 && englishIdx < indonesiaIdx) {
+            val isIndo = preferences.langPref == "Indonesia"
+            val result = if (isIndo) {
+                description.substring(indonesiaIdx + "Indonesia".length)
+            } else {
+                description.substring(englishIdx + "English".length, indonesiaIdx)
+            }
+            result.trim().removePrefix(":").trim()
+        } else {
+            description
+        }
+    }
+
     // ============================ Video Links =============================
     private val dailymotionExtractor by lazy { DailymotionExtractor(client, headers) }
     private val doodExtractor by lazy { DoodExtractor(client) }
@@ -70,22 +89,6 @@ class AnimeXin :
     }
 
     private val SharedPreferences.langPref by preferences.delegate(PREF_LANG_KEY, PREF_LANG_DEFAULT)
-
-    // =========================== Anime Details ============================
-    override fun getAnimeDescription(document: Document): String? {
-        val description = super.getAnimeDescription(document) ?: return null
-        return when {
-            description.contains("English", true) && description.contains("Indonesia", true) -> {
-                val isIndo = preferences.langPref == "Indonesia"
-                if (isIndo) {
-                    description.substringAfter("Indonesia").removePrefix(":").trim()
-                } else {
-                    description.substringAfter("English").substringBefore("Indonesia").removePrefix(":").trim()
-                }
-            }
-            else -> description
-        }
-    }
 
     // ============================= Utilities ==============================
     override fun List<Video>.sort(): List<Video> {

--- a/src/all/animexin/src/eu/kanade/tachiyomi/animeextension/all/animexin/AnimeXin.kt
+++ b/src/all/animexin/src/eu/kanade/tachiyomi/animeextension/all/animexin/AnimeXin.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.multisrc.animestream.AnimeStream
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.delegate
+import org.jsoup.nodes.Document
 
 class AnimeXin :
     AnimeStream(
@@ -69,6 +70,22 @@ class AnimeXin :
     }
 
     private val SharedPreferences.langPref by preferences.delegate(PREF_LANG_KEY, PREF_LANG_DEFAULT)
+
+    // =========================== Anime Details ============================
+    override fun getAnimeDescription(document: Document): String? {
+        val description = super.getAnimeDescription(document) ?: return null
+        return when {
+            description.contains("English", true) && description.contains("Indonesia", true) -> {
+                val isIndo = preferences.langPref == "Indonesia"
+                if (isIndo) {
+                    description.substringAfter("Indonesia").removePrefix(":").trim()
+                } else {
+                    description.substringAfter("English").substringBefore("Indonesia").removePrefix(":").trim()
+                }
+            }
+            else -> description
+        }
+    }
 
     // ============================= Utilities ==============================
     override fun List<Video>.sort(): List<Video> {


### PR DESCRIPTION
- Update synopsis extraction to target the last description element in the multisrc base.
- Implement language-specific synopsis filtering for AnimeXin.
- Bump AnimeStream multisrc version to 7.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Adjust AnimeStream synopsis extraction and add AnimeXin-specific language filtering for anime descriptions.

New Features:
- Add language-aware synopsis selection in AnimeXin based on user language preference.

Enhancements:
- Update AnimeStream base to extract the last matching description element instead of the first.
- Bump AnimeStream multisrc base version code to 7 to propagate the updated description behavior.