### PR TITLE
AnimeVerse [EN]: Extension Overhaul

### DIFF
--- a/src/en/animeverse/build.gradle
+++ b/src/en/animeverse/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeVerse'
     extClass = '.AnimeVerse'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
@@ -66,7 +66,7 @@ class AnimeVerse :
 
     override val client: OkHttpClient by lazy {
         network.client.newBuilder()
-            .addInterceptor { chain -> authInterceptor(chain, network.client, fingerprint) }
+            .addInterceptor { chain -> authInterceptor(chain, network.client, fingerprint, baseUrl) }
             .build()
     }
 
@@ -77,6 +77,7 @@ class AnimeVerse :
 
     @Volatile
     private var catalogCache: List<JsonElement>? = null
+    private var catalogCacheLoadedTime: Long = 0L
     private val catalogCacheFile: File by lazy {
         applicationContext.cacheDir.resolve("source_$id/catalog.json")
     }
@@ -84,34 +85,44 @@ class AnimeVerse :
     private fun getCatalog(): List<JsonElement> = synchronized(cacheLock) {
         val now = System.currentTimeMillis()
 
-        catalogCache?.takeIf { now - catalogCacheFile.lastModified() < cacheTtl }?.let { return it }
+        catalogCache?.takeIf { now - catalogCacheLoadedTime < cacheTtl }?.let { return it }
 
-        if (catalogCacheFile.exists() && now - catalogCacheFile.lastModified() < cacheTtl) {
-            runCatching {
-                val fileArr = extractArray(catalogCacheFile.readText().parseAs<JsonElement>(json))
-                if (fileArr.isNotEmpty()) {
-                    catalogCache = fileArr
-                    return fileArr
+        if (catalogCacheFile.exists()) {
+            val lastMod = catalogCacheFile.lastModified()
+            if (now - lastMod < cacheTtl) {
+                runCatching {
+                    val fileArr = extractArray(catalogCacheFile.readText().parseAs<JsonElement>(json))
+                    if (fileArr.isNotEmpty()) {
+                        catalogCache = fileArr
+                        catalogCacheLoadedTime = lastMod
+                        return fileArr
+                    }
                 }
             }
         }
 
         try {
-            val resp = client.newCall(GET("$baseUrl/api/v1/catalog")).execute()
-            val body = resp.bodyString()
-            val arr = extractArray(body.parseAs<JsonElement>(json))
-            resp.close()
+            val (body, arr) = client.newCall(GET("$baseUrl/api/v1/catalog")).execute().use { resp ->
+                if (!resp.isSuccessful) throw Exception("HTTP ${resp.code}")
+                val body = resp.bodyString()
+                body to extractArray(body.parseAs<JsonElement>(json))
+            }
 
             if (arr.isNotEmpty()) {
                 saveJsonToFile(catalogCacheFile, body, arr)
                 catalogCache = arr
+                catalogCacheLoadedTime = now
                 return arr
             }
         } catch (e: Exception) {
             if (catalogCacheFile.exists()) {
                 runCatching {
                     val fileArr = extractArray(catalogCacheFile.readText().parseAs<JsonElement>(json))
-                    if (fileArr.isNotEmpty()) return fileArr
+                    if (fileArr.isNotEmpty()) {
+                        catalogCache = fileArr
+                        catalogCacheLoadedTime = catalogCacheFile.lastModified()
+                        return fileArr
+                    }
                 }
             }
             throw Exception("Failed to fetch catalog: ${e.message}")
@@ -132,10 +143,11 @@ class AnimeVerse :
         }
 
         try {
-            val resp = client.newCall(GET("$baseUrl/api/v1/schedule?day=$day")).execute()
-            val body = resp.bodyString()
-            val arr = extractArray(body.parseAs<JsonElement>(json))
-            resp.close()
+            val (body, arr) = client.newCall(GET("$baseUrl/api/v1/schedule?day=$day")).execute().use { resp ->
+                if (!resp.isSuccessful) throw Exception("HTTP ${resp.code}")
+                val body = resp.bodyString()
+                body to extractArray(body.parseAs<JsonElement>(json))
+            }
 
             if (arr.isNotEmpty()) {
                 saveJsonToFile(scheduleFile, body, arr)
@@ -155,11 +167,8 @@ class AnimeVerse :
     private fun saveJsonToFile(file: File, body: String, list: List<JsonElement>) {
         if (list.isEmpty()) return
         try {
-            val currentBody = if (file.exists()) file.readText() else ""
-            if (body != currentBody) {
-                file.parentFile?.mkdirs()
-                file.writeText(body)
-            }
+            file.parentFile?.mkdirs()
+            file.writeText(body)
         } catch (_: Exception) {}
     }
 
@@ -184,7 +193,7 @@ class AnimeVerse :
                 (id != null && catO.string("id") == id) || (slug != null && catO.string("slug") == slug)
             } ?: el
 
-            jsonToAnime(catEl, useAltTitle)
+            jsonToAnime(catEl, useAltTitle, baseUrl)
         }
 
         return AnimesPage(animes, hasNext)
@@ -208,14 +217,14 @@ class AnimeVerse :
             }
 
             if (catEl != null) {
-                val sAnime = jsonToAnime(catEl, useAltTitle)
+                val sAnime = jsonToAnime(catEl, useAltTitle, baseUrl)
                 val recentInfo = o.string("language")?.uppercase() ?: o.string("releaseTime")
                 if (!recentInfo.isNullOrEmpty()) {
                     sAnime.genre = if (!sAnime.genre.isNullOrEmpty()) "${sAnime.genre}, $recentInfo" else recentInfo
                 }
                 sAnime
             } else {
-                recentToAnime(el)
+                recentToAnime(el, baseUrl)
             }
         }
 
@@ -255,14 +264,16 @@ class AnimeVerse :
                     val matchesQuery = q.isBlank() || o.string("searchTitle")?.lowercase()?.contains(q) == true ||
                         o.string("title")?.lowercase()?.contains(q) == true ||
                         o.string("alternativeTitle")?.lowercase()?.contains(q) == true
+                    val genres = o.stringArray("genres")
                     val matchesGenre = if (genreMode) {
-                        includedGenres.all { it in o.stringArray("genres") } &&
-                            (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
+                        includedGenres.all { it in genres } &&
+                            (excludedGenres.isEmpty() || genres.intersect(excludedGenres).isEmpty())
                     } else {
-                        (includedGenres.isEmpty() || o.stringArray("genres").intersect(includedGenres).isNotEmpty()) &&
-                            (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
+                        (includedGenres.isEmpty() || genres.intersect(includedGenres).isNotEmpty()) &&
+                            (excludedGenres.isEmpty() || genres.intersect(excludedGenres).isEmpty())
                     }
-                    val matchesStudio = selectedStudios.isEmpty() || o.stringArray("studios").intersect(selectedStudios).isNotEmpty()
+                    val studios = o.stringArray("studios")
+                    val matchesStudio = selectedStudios.isEmpty() || studios.intersect(selectedStudios).isNotEmpty()
                     val matchesYear = year.isEmpty() || o.int("year").toString() == year
                     val matchesSeason = season.isEmpty() || o.string("premiered")?.startsWith(season, ignoreCase = true) == true
                     val matchesRating = ratingLabel.isEmpty() || o.string("ratingLabel") == ratingLabel
@@ -284,14 +295,14 @@ class AnimeVerse :
                 }
 
                 if (catEl != null) {
-                    val sAnime = jsonToAnime(catEl, useAltTitle)
+                    val sAnime = jsonToAnime(catEl, useAltTitle, baseUrl)
                     val recentInfo = o.string("language")?.uppercase() ?: o.string("releaseTime")
                     if (!recentInfo.isNullOrEmpty()) {
                         sAnime.genre = if (!sAnime.genre.isNullOrEmpty()) "${sAnime.genre}, $recentInfo" else recentInfo
                     }
                     sAnime
                 } else {
-                    recentToAnime(el)
+                    recentToAnime(el, baseUrl)
                 }
             }
 
@@ -304,14 +315,16 @@ class AnimeVerse :
                 val matchesQuery = q.isBlank() || o.string("searchTitle")?.lowercase()?.contains(q) == true ||
                     o.string("title")?.lowercase()?.contains(q) == true ||
                     o.string("alternativeTitle")?.lowercase()?.contains(q) == true
+                val genres = o.stringArray("genres")
                 val matchesGenre = if (genreMode) {
-                    includedGenres.all { it in o.stringArray("genres") } &&
-                        (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
+                    includedGenres.all { it in genres } &&
+                        (excludedGenres.isEmpty() || genres.intersect(excludedGenres).isEmpty())
                 } else {
-                    (includedGenres.isEmpty() || o.stringArray("genres").intersect(includedGenres).isNotEmpty()) &&
-                        (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
+                    (includedGenres.isEmpty() || genres.intersect(includedGenres).isNotEmpty()) &&
+                        (excludedGenres.isEmpty() || genres.intersect(excludedGenres).isEmpty())
                 }
-                val matchesStudio = selectedStudios.isEmpty() || o.stringArray("studios").intersect(selectedStudios).isNotEmpty()
+                val studios = o.stringArray("studios")
+                val matchesStudio = selectedStudios.isEmpty() || studios.intersect(selectedStudios).isNotEmpty()
                 val matchesYear = year.isEmpty() || o.int("year").toString() == year
                 val matchesSeason = season.isEmpty() || o.string("premiered")?.startsWith(season, ignoreCase = true) == true
                 val matchesRating = ratingLabel.isEmpty() || o.string("ratingLabel") == ratingLabel
@@ -325,7 +338,7 @@ class AnimeVerse :
                 filtered
             }
 
-            AnimesPage(sorted.map { jsonToAnime(it, useAltTitle) }, false)
+            AnimesPage(sorted.map { jsonToAnime(it, useAltTitle, baseUrl) }, false)
         }
     }
 
@@ -396,7 +409,7 @@ class AnimeVerse :
         return SAnime.create().apply {
             title = displayTitle
             url = "/series/${o.string("slug")}"
-            thumbnail_url = resolveImage(o.string("cover") ?: o.string("thumb"))
+            thumbnail_url = resolveImage(baseUrl, o.string("cover") ?: o.string("thumb"))
             this.description = description
             author = studios
             genre = genres

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
@@ -1,7 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.animeverse
 
-import android.annotation.SuppressLint
-import android.util.Base64
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import aniyomi.lib.playlistutils.PlaylistUtils
@@ -11,39 +9,29 @@ import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
-import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import keiyoushi.utils.addSwitchPreference
+import keiyoushi.utils.applicationContext
 import keiyoushi.utils.bodyString
-import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.getPreferences
 import keiyoushi.utils.parseAs
-import keiyoushi.utils.toJsonBody
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import okhttp3.Headers
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import java.net.URLDecoder
-import java.net.URLEncoder
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
-import kotlin.math.roundToInt
+import java.io.File
 
 class AnimeVerse :
     AnimeHttpSource(),
@@ -59,8 +47,10 @@ class AnimeVerse :
         isLenient = true
     }
 
-    private val preferences by getPreferencesLazy()
+    private val preferences = getPreferences()
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
+    private val useAltTitle: Boolean
+        get() = preferences.getBoolean(PREF_USE_ALT_TITLE, PREF_USE_ALT_TITLE_DEFAULT)
 
     private val fingerprint: String by lazy {
         preferences.getString("fp_json", null) ?: run {
@@ -72,207 +62,105 @@ class AnimeVerse :
         }.also { preferences.edit().putString("fp_json", it).apply() }
     }
 
-    // ============================== Auth ==============================
-
-    private val lock = Any()
-    private var sessionCookie = ""
-    private var authKey = ""
-    private var authExpires = 0L
-
-    private fun getAuth(): Pair<String, String> = synchronized(lock) {
-        if (authKey.isNotEmpty() && System.currentTimeMillis() / 1000 < authExpires) {
-            return authKey to sessionCookie
-        }
-
-        val body = """{"fp":$fingerprint}""".toJsonBody()
-
-        val sessionReq = Request.Builder()
-            .url("$baseUrl/api/v1/session")
-            .post(body)
-            .header("Content-Type", "application/json")
-            .build()
-
-        val sessionResp = network.client.newCall(sessionReq).execute()
-        val respBody = sessionResp.bodyString()
-
-        if (!sessionResp.isSuccessful) {
-            invalidateAuth()
-            throw Exception("Session failed (${sessionResp.code}): $respBody")
-        }
-
-        sessionResp.headers("Set-Cookie")
-            .firstOrNull { it.startsWith("av_session=") }
-            ?.substringAfter("=")?.substringBefore(";")
-            ?.let { sessionCookie = it }
-
-        val obj = try {
-            respBody.parseAs<JsonElement>(json).jsonObject
-        } catch (_: Exception) {
-            invalidateAuth()
-            throw Exception("Invalid session JSON: $respBody")
-        }
-
-        val key = obj["clientAuthKey"]?.jsonPrimitive?.contentOrNull
-        if (key.isNullOrEmpty()) {
-            invalidateAuth()
-            throw Exception("No clientAuthKey in response: $respBody")
-        }
-
-        authKey = key
-        authExpires = obj["expiresAt"]?.jsonPrimitive?.longOrNull
-            ?: (System.currentTimeMillis() / 1000 + 3600)
-        sessionResp.close()
-
-        authKey to sessionCookie
-    }
-
-    private fun invalidateAuth() = synchronized(lock) {
-        authKey = ""
-        authExpires = 0L
-        sessionCookie = ""
-    }
-
     // ======================= Client + Interceptor =========================
 
     override val client: OkHttpClient by lazy {
         network.client.newBuilder()
-            .addInterceptor(::authInterceptor)
+            .addInterceptor { chain -> authInterceptor(chain, network.client, fingerprint) }
             .build()
     }
 
-    private fun authInterceptor(chain: Interceptor.Chain): Response {
-        val req = chain.request()
-        if (!req.url.encodedPath.startsWith("/api/v1/")) return chain.proceed(req)
+    // ========================= Catalog & Schedule Cache ==========================
 
-        val signed = sign(req)
-        val resp = chain.proceed(signed)
-        if (resp.code != 401) return resp
-        resp.close()
-
-        invalidateAuth()
-        return chain.proceed(sign(req))
-    }
-
-    private fun sign(request: Request): Request {
-        val (key, cookie) = getAuth()
-        if (key.isEmpty()) return request
-
-        val ts = System.currentTimeMillis().toString()
-        val mac = Mac.getInstance("HmacSHA256").apply {
-            init(SecretKeySpec(base64UrlDecode(key), "HmacSHA256"))
-        }
-        val sig = base64UrlEncode(
-            mac.doFinal("${request.method}|${request.url.encodedPath}|$ts".toByteArray()).copyOf(16),
-        )
-        return request.newBuilder()
-            .header("x-av-ts", ts)
-            .header("x-av-sig", sig)
-            .header("Cookie", "av_session=$cookie")
-            .build()
-    }
-
-    // ========================= Catalog Cache ==========================
+    private val cacheTtl = 24 * 60 * 60 * 1000L // 24 hours
+    private val cacheLock = Any()
 
     @Volatile
     private var catalogCache: List<JsonElement>? = null
-    private var catalogCacheTime: Long = 0L
-    private val catalogCacheLock = Any()
+    private val catalogCacheFile: File by lazy {
+        applicationContext.cacheDir.resolve("source_$id/catalog.json")
+    }
 
-    private val catalogCacheTtl = 5 * 60 * 1000L // 5 minutes
-
-    private fun getCatalog(existingResponse: Response? = null): List<JsonElement> = synchronized(catalogCacheLock) {
+    private fun getCatalog(): List<JsonElement> = synchronized(cacheLock) {
         val now = System.currentTimeMillis()
-        catalogCache?.takeIf { now - catalogCacheTime < catalogCacheTtl }?.let { return it }
 
-        val arr = if (existingResponse != null) {
-            extractArray(existingResponse.bodyString().parseAs<JsonElement>(json))
-        } else {
+        catalogCache?.takeIf { now - catalogCacheFile.lastModified() < cacheTtl }?.let { return it }
+
+        if (catalogCacheFile.exists() && now - catalogCacheFile.lastModified() < cacheTtl) {
+            runCatching {
+                val fileArr = extractArray(catalogCacheFile.readText().parseAs<JsonElement>(json))
+                if (fileArr.isNotEmpty()) {
+                    catalogCache = fileArr
+                    return fileArr
+                }
+            }
+        }
+
+        try {
             val resp = client.newCall(GET("$baseUrl/api/v1/catalog")).execute()
-            val list = extractArray(resp.bodyString().parseAs<JsonElement>(json))
+            val body = resp.bodyString()
+            val arr = extractArray(body.parseAs<JsonElement>(json))
             resp.close()
-            list
+
+            if (arr.isNotEmpty()) {
+                saveJsonToFile(catalogCacheFile, body, arr)
+                catalogCache = arr
+                return arr
+            }
+        } catch (e: Exception) {
+            if (catalogCacheFile.exists()) {
+                runCatching {
+                    val fileArr = extractArray(catalogCacheFile.readText().parseAs<JsonElement>(json))
+                    if (fileArr.isNotEmpty()) return fileArr
+                }
+            }
+            throw Exception("Failed to fetch catalog: ${e.message}")
         }
 
-        catalogCache = arr
-        catalogCacheTime = now
-        arr
+        return emptyList()
     }
 
-    // =========================== Helpers ==============================
+    private fun getSchedule(day: String): List<JsonElement> = synchronized(cacheLock) {
+        val scheduleFile = applicationContext.cacheDir.resolve("source_$id/schedule_$day.json")
+        val now = System.currentTimeMillis()
 
-    private fun SAnime.slug(): String = url.substringAfter("/series/")
-
-    private fun resolveImage(path: String?): String? {
-        if (path.isNullOrEmpty()) return null
-        if (path.startsWith("http")) return path
-        if (path.startsWith("/i/")) {
-            runCatching { String(base64UrlDecode(path.substringAfter("/i/"))) }
-                .getOrNull()?.takeIf { it.startsWith("http") }?.let { return it }
+        if (scheduleFile.exists() && now - scheduleFile.lastModified() < cacheTtl) {
+            runCatching {
+                val fileArr = extractArray(scheduleFile.readText().parseAs<JsonElement>(json))
+                if (fileArr.isNotEmpty()) return fileArr
+            }
         }
-        return "$baseUrl$path"
-    }
 
-    @SuppressLint("DefaultLocale")
-    private fun formatRating(rating10: Double): String {
-        if (rating10 <= 0) return ""
-        val fullStars = (rating10 / 2.0).roundToInt().coerceIn(0, 5)
-        val emptyStars = 5 - fullStars
-        val stars = "★".repeat(fullStars) + "☆".repeat(emptyStars)
-        return "$stars ${String.format("%.2f", rating10)}"
-    }
+        try {
+            val resp = client.newCall(GET("$baseUrl/api/v1/schedule?day=$day")).execute()
+            val body = resp.bodyString()
+            val arr = extractArray(body.parseAs<JsonElement>(json))
+            resp.close()
 
-    private fun base64UrlEncode(data: ByteArray): String = Base64.encodeToString(data, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
-
-    private fun base64UrlDecode(str: String): ByteArray = Base64.decode(str, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
-
-    private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull
-
-    private fun JsonObject.int(key: String): Int = this[key]?.jsonPrimitive?.intOrNull ?: 0
-
-    private fun JsonObject.double(key: String): Double = this[key]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: 0.0
-
-    private fun JsonObject.stringArray(key: String): List<String> = (this[key] as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
-
-    private fun cleanQuality(q: String): String {
-        Regex("""(\d{3,4})p""").find(q)?.let { return it.value }
-        Regex("""\dx(\d+)""").find(q)?.groupValues?.get(1)?.let { return "${it}p" }
-        return q.substringBefore(" - ").substringBefore("(").trim()
-    }
-
-    private fun jsonToAnime(el: JsonElement): SAnime {
-        val o = el.jsonObject
-        val genres = o.stringArray("genres")
-        val studios = o.stringArray("studios")
-        val mainTitle = o.string("title") ?: "Unknown"
-        val altTitle = o.string("alternativeTitle")?.takeIf { it.isNotEmpty() }
-        val useAlt = preferences.getBoolean(PREF_USE_ALT_TITLE, PREF_USE_ALT_TITLE_DEFAULT)
-
-        return SAnime.create().apply {
-            title = if (useAlt) altTitle ?: mainTitle else mainTitle
-            url = "/series/${o.string("slug")}"
-            thumbnail_url = resolveImage(o.string("cover") ?: o.string("thumb"))
-            author = studios.takeIf { it.isNotEmpty() }?.joinToString(", ")
-            genre = genres.takeIf { it.isNotEmpty() }?.joinToString(", ")
-            status = SAnime.UNKNOWN
+            if (arr.isNotEmpty()) {
+                saveJsonToFile(scheduleFile, body, arr)
+                return arr
+            }
+        } catch (_: Exception) {
+            if (scheduleFile.exists()) {
+                runCatching {
+                    val fileArr = extractArray(scheduleFile.readText().parseAs<JsonElement>(json))
+                    if (fileArr.isNotEmpty()) return fileArr
+                }
+            }
         }
+        emptyList()
     }
 
-    private fun recentToAnime(el: JsonElement): SAnime {
-        val o = el.jsonObject
-        return SAnime.create().apply {
-            title = o.string("seriesTitle") ?: "Unknown"
-            url = "/series/${o.string("seriesSlug")}"
-            thumbnail_url = resolveImage(o.string("thumb"))
-            genre = o.string("language")?.uppercase() ?: o.string("releaseTime")
-            status = SAnime.UNKNOWN
-        }
-    }
-
-    private fun extractArray(root: JsonElement): List<JsonElement> = when (root) {
-        is JsonArray -> root
-        is JsonObject -> (root["items"] ?: root["data"] ?: root.values.firstOrNull { it is JsonArray })
-            as? JsonArray ?: emptyList()
-        else -> emptyList()
+    private fun saveJsonToFile(file: File, body: String, list: List<JsonElement>) {
+        if (list.isEmpty()) return
+        try {
+            val currentBody = if (file.exists()) file.readText() else ""
+            if (body != currentBody) {
+                file.parentFile?.mkdirs()
+                file.writeText(body)
+            }
+        } catch (_: Exception) {}
     }
 
     // ============================== Popular ==============================
@@ -282,9 +170,24 @@ class AnimeVerse :
     override fun popularAnimeParse(response: Response): AnimesPage {
         val root = response.bodyString().parseAs<JsonElement>(json)
         val arr = extractArray(root)
-        val hasNext = (root as? JsonObject)
-            ?.get("hasNext")?.jsonPrimitive?.booleanOrNull == true
-        return AnimesPage(arr.map(::jsonToAnime), hasNext)
+        val hasNext = (root as? JsonObject)?.get("hasNext")?.jsonPrimitive?.booleanOrNull == true
+
+        val catalogArr = getCatalog()
+
+        val animes = arr.map { el ->
+            val o = el.jsonObject
+            val id = o.string("id")
+            val slug = o.string("slug")
+
+            val catEl = catalogArr.firstOrNull {
+                val catO = it.jsonObject
+                (id != null && catO.string("id") == id) || (slug != null && catO.string("slug") == slug)
+            } ?: el
+
+            jsonToAnime(catEl, useAltTitle)
+        }
+
+        return AnimesPage(animes, hasNext)
     }
 
     // ============================== Latest ==============================
@@ -294,73 +197,141 @@ class AnimeVerse :
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val root = response.bodyString().parseAs<JsonElement>(json)
         val items = extractArray(root)
-        return AnimesPage(items.map(::recentToAnime), false)
+        val catalogArr = getCatalog()
+
+        val animes = items.map { el ->
+            val o = el.jsonObject
+            val seriesSlug = o.string("seriesSlug")
+
+            val catEl = seriesSlug?.let { slug ->
+                catalogArr.firstOrNull { it.jsonObject.string("slug") == slug }
+            }
+
+            if (catEl != null) {
+                val sAnime = jsonToAnime(catEl, useAltTitle)
+                val recentInfo = o.string("language")?.uppercase() ?: o.string("releaseTime")
+                if (!recentInfo.isNullOrEmpty()) {
+                    sAnime.genre = if (!sAnime.genre.isNullOrEmpty()) "${sAnime.genre}, $recentInfo" else recentInfo
+                }
+                sAnime
+            } else {
+                recentToAnime(el)
+            }
+        }
+
+        return AnimesPage(animes, false)
     }
 
     // ============================== Search ==============================
 
-    override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
+    override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
         val dayFilter = filters.filterIsInstance<ScheduleDayFilter>().firstOrNull()
         val day = dayFilter?.getValue()
+        val q = query.lowercase()
+
+        val genreFilter = filters.filterIsInstance<GenreFilter>().firstOrNull()
+        val genreMode = filters.filterIsInstance<GenreModeFilter>().firstOrNull()?.isAnd() ?: false
+        val includedGenres = genreFilter?.state?.filter { it.state == AnimeFilter.TriState.STATE_INCLUDE }?.map { it.name }?.toSet() ?: emptySet()
+        val excludedGenres = genreFilter?.state?.filter { it.state == AnimeFilter.TriState.STATE_EXCLUDE }?.map { it.name }?.toSet() ?: emptySet()
+
+        val studioFilter = filters.filterIsInstance<StudioFilter>().firstOrNull()
+        val selectedStudios = studioFilter?.state?.filter { it.state }?.map { it.name }?.toSet() ?: emptySet()
+        val year = filters.filterIsInstance<YearFilter>().firstOrNull()?.getValue() ?: ""
+        val season = filters.filterIsInstance<SeasonFilter>().firstOrNull()?.getValue() ?: ""
+        val ratingLabel = filters.filterIsInstance<RatingLabelFilter>().firstOrNull()?.getValue() ?: ""
+
+        val isFilterApplied = q.isNotBlank() || includedGenres.isNotEmpty() || excludedGenres.isNotEmpty() ||
+            selectedStudios.isNotEmpty() || year.isNotEmpty() || season.isNotEmpty() || ratingLabel.isNotEmpty()
 
         return if (!day.isNullOrEmpty()) {
-            val url = if (query.isNotBlank()) {
-                "$baseUrl/api/v1/schedule?day=$day&q=${URLEncoder.encode(query, "UTF-8")}"
+            val scheduleArr = getSchedule(day)
+            val catalogArr = getCatalog()
+
+            val filteredSchedule = if (!isFilterApplied) {
+                scheduleArr
             } else {
-                "$baseUrl/api/v1/schedule?day=$day"
-            }
-            GET(url)
-        } else {
-            val fragment = if (query.isNotBlank()) URLEncoder.encode(query, "UTF-8") else ""
-            GET("$baseUrl/api/v1/catalog#$fragment")
-        }
-    }
-
-    override fun searchAnimeParse(response: Response): AnimesPage {
-        val url = response.request.url.toString()
-
-        return if (url.contains("/api/v1/schedule")) {
-            val root = response.bodyString().parseAs<JsonElement>(json)
-            val items = extractArray(root)
-            val q = response.request.url.queryParameter("q")?.lowercase().orEmpty()
-
-            val filtered = if (q.isBlank()) {
-                items
-            } else {
-                val catalogArr = getCatalog()
-
                 val matchingSlugs = catalogArr.filter { el ->
                     val o = el.jsonObject
-                    o.string("searchTitle")?.lowercase()?.contains(q) == true ||
+                    val matchesQuery = q.isBlank() || o.string("searchTitle")?.lowercase()?.contains(q) == true ||
                         o.string("title")?.lowercase()?.contains(q) == true ||
                         o.string("alternativeTitle")?.lowercase()?.contains(q) == true
+                    val matchesGenre = if (genreMode) {
+                        includedGenres.all { it in o.stringArray("genres") } &&
+                            (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
+                    } else {
+                        (includedGenres.isEmpty() || o.stringArray("genres").intersect(includedGenres).isNotEmpty()) &&
+                            (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
+                    }
+                    val matchesStudio = selectedStudios.isEmpty() || o.stringArray("studios").intersect(selectedStudios).isNotEmpty()
+                    val matchesYear = year.isEmpty() || o.int("year").toString() == year
+                    val matchesSeason = season.isEmpty() || o.string("premiered")?.startsWith(season, ignoreCase = true) == true
+                    val matchesRating = ratingLabel.isEmpty() || o.string("ratingLabel") == ratingLabel
+
+                    matchesQuery && matchesGenre && matchesStudio && matchesYear && matchesSeason && matchesRating
                 }.mapNotNull { it.jsonObject.string("slug") }.toSet()
 
-                items.filter { el ->
-                    val o = el.jsonObject
-                    o.string("seriesTitle")?.lowercase()?.contains(q) == true ||
-                        o.string("seriesSlug") in matchingSlugs
+                scheduleArr.filter { el ->
+                    el.jsonObject.string("seriesSlug") in matchingSlugs
                 }
             }
-            AnimesPage(filtered.map(::recentToAnime), false)
+
+            val animes = filteredSchedule.map { el ->
+                val o = el.jsonObject
+                val seriesSlug = o.string("seriesSlug")
+
+                val catEl = seriesSlug?.let { slug ->
+                    catalogArr.firstOrNull { it.jsonObject.string("slug") == slug }
+                }
+
+                if (catEl != null) {
+                    val sAnime = jsonToAnime(catEl, useAltTitle)
+                    val recentInfo = o.string("language")?.uppercase() ?: o.string("releaseTime")
+                    if (!recentInfo.isNullOrEmpty()) {
+                        sAnime.genre = if (!sAnime.genre.isNullOrEmpty()) "${sAnime.genre}, $recentInfo" else recentInfo
+                    }
+                    sAnime
+                } else {
+                    recentToAnime(el)
+                }
+            }
+
+            AnimesPage(animes, false)
         } else {
-            val catalogArr = getCatalog(response)
-            val q = URLDecoder.decode(response.request.url.fragment ?: "", "UTF-8").lowercase()
+            val catalogArr = getCatalog()
 
-            val filtered = if (q.isBlank()) {
-                catalogArr
-            } else {
-                catalogArr.filter { el ->
-                    val o = el.jsonObject
-                    o.string("searchTitle")?.lowercase()?.contains(q) == true ||
-                        o.string("title")?.lowercase()?.contains(q) == true ||
-                        o.string("alternativeTitle")?.lowercase()?.contains(q) == true
+            val filtered = catalogArr.filter { el ->
+                val o = el.jsonObject
+                val matchesQuery = q.isBlank() || o.string("searchTitle")?.lowercase()?.contains(q) == true ||
+                    o.string("title")?.lowercase()?.contains(q) == true ||
+                    o.string("alternativeTitle")?.lowercase()?.contains(q) == true
+                val matchesGenre = if (genreMode) {
+                    includedGenres.all { it in o.stringArray("genres") } &&
+                        (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
+                } else {
+                    (includedGenres.isEmpty() || o.stringArray("genres").intersect(includedGenres).isNotEmpty()) &&
+                        (excludedGenres.isEmpty() || o.stringArray("genres").intersect(excludedGenres).isEmpty())
                 }
+                val matchesStudio = selectedStudios.isEmpty() || o.stringArray("studios").intersect(selectedStudios).isNotEmpty()
+                val matchesYear = year.isEmpty() || o.int("year").toString() == year
+                val matchesSeason = season.isEmpty() || o.string("premiered")?.startsWith(season, ignoreCase = true) == true
+                val matchesRating = ratingLabel.isEmpty() || o.string("ratingLabel") == ratingLabel
+
+                matchesQuery && matchesGenre && matchesStudio && matchesYear && matchesSeason && matchesRating
             }
 
-            AnimesPage(filtered.map(::jsonToAnime), false)
+            val sorted = if (q.isBlank()) {
+                filtered.sortedByDescending { it.jsonObject.double("rating") }
+            } else {
+                filtered
+            }
+
+            AnimesPage(sorted.map { jsonToAnime(it, useAltTitle) }, false)
         }
     }
+
+    override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request = throw UnsupportedOperationException()
+
+    override fun searchAnimeParse(response: Response): AnimesPage = throw UnsupportedOperationException()
 
     // ============================== Anime Details ==============================
 
@@ -369,25 +340,30 @@ class AnimeVerse :
     override fun animeDetailsParse(response: Response): SAnime {
         val slug = response.request.url.encodedPath.substringAfter("/series/")
 
-        val o = client.newCall(GET("$baseUrl/api/v1/anime/$slug"))
-            .execute().bodyString()
-            .parseAs<JsonElement>(json) as? JsonObject
-            ?: throw Exception("Invalid anime data")
+        val o = client.newCall(GET("$baseUrl/api/v1/anime/$slug")).execute().use { res ->
+            res.bodyString().parseAs<JsonElement>(json) as? JsonObject
+        } ?: throw Exception("Invalid anime data")
 
-        val cat = getCatalog().firstOrNull { it.jsonObject.string("slug") == slug }?.jsonObject
+        val networkId = o.string("id")
+        val cat = if (!networkId.isNullOrEmpty()) {
+            getCatalog().firstOrNull { it.jsonObject.string("id") == networkId }?.jsonObject
+        } else {
+            getCatalog().firstOrNull { it.jsonObject.string("slug") == slug }?.jsonObject
+        }
 
         val rating = o.double("rating")
         val synopsis = o.string("synopsis").orEmpty()
         val ratingLine = formatRating(rating)
         val epCount = (o["episodes"] as? JsonArray)?.size ?: 0
 
-        val mainTitle = o.string("title") ?: "Unknown"
+        val mainTitle = cat?.string("title")?.takeIf { it.isNotEmpty() } ?: o.string("title") ?: "Unknown"
         val altTitle = cat?.string("alternativeTitle")?.takeIf { it.isNotEmpty() && it != mainTitle }
-        val useAlt = preferences.getBoolean(PREF_USE_ALT_TITLE, PREF_USE_ALT_TITLE_DEFAULT)
-        val displayTitle = if (useAlt) altTitle ?: mainTitle else mainTitle
+            ?: o.string("alternativeTitle")?.takeIf { it.isNotEmpty() && it != mainTitle }
 
-        val genres = cat?.stringArray("genres")?.takeIf { it.isNotEmpty() }?.joinToString(", ")
-        val studios = cat?.stringArray("studios")?.takeIf { it.isNotEmpty() }?.joinToString(", ")
+        val displayTitle = if (useAltTitle) altTitle ?: mainTitle else mainTitle
+
+        val genres = cat?.stringArray("genres")?.takeIf { it.isNotEmpty() }?.joinToString()
+        val studios = cat?.stringArray("studios")?.takeIf { it.isNotEmpty() }?.joinToString()
         val premiered = cat?.string("premiered")
         val year = cat?.int("year")?.takeIf { it > 0 }
         val animeType = cat?.string("type") ?: o.string("type")
@@ -442,7 +418,7 @@ class AnimeVerse :
             .mapNotNull { it as? JsonObject }
             .groupBy { it.int("number") }
             .map { (num, epList) ->
-                val kinds = epList.mapNotNull { it.string("kind")?.uppercase() }.distinct().sorted().joinToString(", ")
+                val kinds = epList.mapNotNull { it.string("kind")?.uppercase() }.distinct().sorted().joinToString()
                 val payload = buildJsonObject {
                     put("slug", slug)
                     put("ep", num)
@@ -495,7 +471,6 @@ class AnimeVerse :
             for (serverName in SERVERS) {
                 val serverLabel = SERVERS_DISPLAY[SERVERS.indexOf(serverName)]
 
-                // Skip excluded hosts
                 if (hosterExclusion.contains(serverLabel)) continue
 
                 try {
@@ -503,48 +478,36 @@ class AnimeVerse :
                     if (serverName == "chiki" && malId > 0) {
                         val megaplayUrl = "https://megaplay.buzz/stream/mal/$malId/$epNum/$kindPath"
                         try {
-                            val megaplayId = extractMegaplayId(megaplayUrl)
+                            val megaplayId = extractMegaplayId(client, megaplayUrl, baseUrl)
 
                             if (!megaplayId.isNullOrEmpty()) {
-                                val megaplayVideos = fetchMegaplayVideos(megaplayId, megaplayUrl, kind, serverLabel)
+                                val megaplayVideos = fetchMegaplayVideos(client, playlistUtils, megaplayId, megaplayUrl, kind, serverLabel)
                                 megaplayVideos.filter { seenUrls.add(it.url) }.also { videos.addAll(it) }
                             }
                         } catch (_: Exception) {}
                         continue
                     }
 
-                    // Handle AnimeVerse and Choi via API
+                    // Handle AnimeVerse via API
                     val apiUrl = buildString {
                         append("$baseUrl/api/v1/anime/$slug/stream/$epNum")
                         append("?server=$serverName")
                         if (id.isNotEmpty()) append("&id=$id")
                     }
 
-                    val streamResp = client.newCall(GET(apiUrl)).execute()
-                    val streamObjects = when (val streamBody = streamResp.bodyString().parseAs<JsonElement>(json)) {
-                        is JsonArray -> streamBody.mapNotNull { it as? JsonObject }
-                        is JsonObject -> listOf(streamBody)
-                        else -> emptyList()
+                    val streamObjects = client.newCall(GET(apiUrl)).execute().use { res ->
+                        when (val streamBody = res.bodyString().parseAs<JsonElement>(json)) {
+                            is JsonArray -> streamBody.mapNotNull { it as? JsonObject }
+                            is JsonObject -> listOf(streamBody)
+                            else -> emptyList()
+                        }
                     }
 
                     for (streamObj in streamObjects) {
                         val streamPath = streamObj.string("stream") ?: continue
 
-                        // Handle Choi / Vidnest
-                        if (streamPath.contains("vidnest.fun")) {
-                            val vidnestVideos = fetchVidnestVideos(streamPath, kind, serverLabel)
-                            vidnestVideos.filter { seenUrls.add(it.url) }.also { videos.addAll(it) }
-                        } else if (streamPath.startsWith("/hianime/")) {
-                            val vidnestUrl = "https://new.vidnest.fun$streamPath"
-                            val vidnestVideos = fetchVidnestVideos(vidnestUrl, kind, serverLabel)
-                            vidnestVideos.filter { seenUrls.add(it.url) }.also { videos.addAll(it) }
-                        } else if (streamPath.matches(Regex("^\\d+$")) && serverName.equals("choi", ignoreCase = true)) {
-                            val vidnestUrl = "https://new.vidnest.fun/hianime/anime/$streamPath/$epNum/$kindPath"
-                            val vidnestVideos = fetchVidnestVideos(vidnestUrl, kind, serverLabel)
-                            vidnestVideos.filter { seenUrls.add(it.url) }.also { videos.addAll(it) }
-                        }
                         // Fallback for MegaPlay if AnimeVerse returns a link directly
-                        else if (isMegaplayStream(streamPath)) {
+                        if (isMegaplayStream(streamPath)) {
                             val fullUrl = if (streamPath.startsWith("http")) {
                                 streamPath
                             } else {
@@ -559,33 +522,23 @@ class AnimeVerse :
                             }
 
                             if (megaplayId.isEmpty()) {
-                                megaplayId = extractMegaplayId(fullUrl) ?: ""
+                                megaplayId = extractMegaplayId(client, fullUrl, baseUrl) ?: ""
                             }
 
                             if (megaplayId.isNotEmpty()) {
-                                val megaplayVideos = fetchMegaplayVideos(megaplayId, fullUrl, kind, serverLabel)
+                                val megaplayVideos = fetchMegaplayVideos(client, playlistUtils, megaplayId, fullUrl, kind, serverLabel)
                                 megaplayVideos.filter { seenUrls.add(it.url) }.also { videos.addAll(it) }
                             }
                         }
-                        // Standard AnimeVerse Direct streams (Removed Proxy due to 404)
-                        else {
+                        // Standard Direct streams (Only process if it's a direct http/https link)
+                        else if (streamPath.startsWith("http")) {
                             val videoHeaders = Headers.Builder()
                                 .add("Referer", "$baseUrl/")
                                 .add("Origin", baseUrl)
                                 .build()
 
-                            val directUrl = when {
-                                streamPath.startsWith("/r/") -> {
-                                    runCatching { String(base64UrlDecode(streamPath.substringAfter("/r/").substringBefore("."))) }.getOrDefault("")
-                                }
-                                streamPath.startsWith("http") -> streamPath
-                                else -> ""
-                            }
-
-                            if (directUrl.startsWith("http")) {
-                                val video = Video(directUrl, "$kind - $serverLabel", directUrl, videoHeaders)
-                                if (seenUrls.add(video.url)) videos.add(video)
-                            }
+                            val video = Video(streamPath, "$kind - $serverLabel", streamPath, videoHeaders)
+                            if (seenUrls.add(video.url)) videos.add(video)
                         }
                     }
                 } catch (_: Exception) {
@@ -597,169 +550,59 @@ class AnimeVerse :
         return videos
     }
 
-    // ========================= MegaPlay / VidWish ==========================
-
-    private fun extractBaseUrl(url: String): String {
-        val schemeEnd = url.indexOf("://")
-        if (schemeEnd < 0) return url
-        val pathStart = url.indexOf("/", schemeEnd + 3)
-        return if (pathStart > 0) url.substring(0, pathStart) else url
-    }
-
-    private fun isMegaplayStream(path: String): Boolean = path.contains("/stream/mal/") ||
-        path.contains("/stream/ani/") ||
-        path.contains("/stream/s-") ||
-        path.contains("megaplay") ||
-        path.contains("vidwish")
-
-    private fun extractMegaplayId(pageUrl: String): String? {
-        val pageHeaders = Headers.Builder()
-            .add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-            .add("Referer", "$baseUrl/")
-            .add("Sec-Fetch-Dest", "iframe")
-            .add("Sec-Fetch-Mode", "navigate")
-            .add("Sec-Fetch-Site", "cross-site")
-            .build()
-
-        val pageResp = client.newCall(GET(pageUrl, pageHeaders)).execute()
-        val pageBody = pageResp.bodyString()
-
-        return Regex("""data-id\s*=\s*["']([^"']+)["']""").find(pageBody)?.groupValues?.get(1)
-    }
-
-    private fun extractM3u8FromSources(sources: JsonElement): String? = when (sources) {
-        is JsonObject -> sources["file"]?.jsonPrimitive?.contentOrNull
-        is JsonArray -> sources.firstOrNull()?.let {
-            when (it) {
-                is JsonObject -> it["file"]?.jsonPrimitive?.contentOrNull
-                is JsonPrimitive -> it.contentOrNull
-                else -> null
-            }
-        }
-        is JsonPrimitive -> sources.contentOrNull
-        else -> null
-    }
-
-    private fun fetchMegaplayVideos(id: String, referer: String, kind: String, serverName: String): List<Video> {
-        val videos = mutableListOf<Video>()
-        try {
-            val base = extractBaseUrl(referer)
-            val sourcesUrl = "$base/stream/getSources?id=$id&id=$id"
-
-            val headers = Headers.Builder()
-                .add("Accept", "application/json, text/javascript, */*; q=0.01")
-                .add("X-Requested-With", "XMLHttpRequest")
-                .add("Referer", referer)
-                .add("Origin", base)
-                .add("Sec-Fetch-Dest", "empty")
-                .add("Sec-Fetch-Mode", "cors")
-                .add("Sec-Fetch-Site", "same-origin")
-                .build()
-
-            val resp = client.newCall(GET(sourcesUrl, headers)).execute()
-            if (!resp.isSuccessful) return videos
-
-            val obj = resp.bodyString().parseAs<JsonElement>(json) as? JsonObject ?: return videos
-
-            val masterUrl = extractM3u8FromSources(obj["sources"] ?: return videos)
-                ?.takeIf { it.startsWith("http") }
-                ?: return videos
-
-            val subtitleTracks = (obj["tracks"] as? JsonArray)
-                ?.mapNotNull { trackEl ->
-                    val trackObj = trackEl as? JsonObject ?: return@mapNotNull null
-                    val file = trackObj.string("file") ?: return@mapNotNull null
-                    val label = trackObj.string("label") ?: ""
-                    val trackKind = trackObj.string("kind") ?: ""
-                    if (trackKind.equals("captions", true)) Track(file, label) else null
-                } ?: emptyList()
-
-            videos.addAll(
-                playlistUtils.extractFromHls(
-                    masterUrl,
-                    videoNameGen = { q -> "$kind - $serverName - ${cleanQuality(q)}" },
-                    subtitleList = subtitleTracks,
-                    referer = "$base/",
-                ),
-            )
-        } catch (_: Exception) {
-            // Network error, skip this source
-        }
-        return videos
-    }
-
-    // ========================= Vidnest Extractor ==========================
-
-    private val vidnestCustomAlphabet = "RB0fpH8ZEyVLkv7c2i6MAJ5u3IKFDxlS1NTsnGaqmXYdUrtzjwObCgQP94hoeW+/"
-    private val standardAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-
-    private fun decryptVidNestData(encryptedData: String): String {
-        val translated = encryptedData.map { char ->
-            val index = vidnestCustomAlphabet.indexOf(char)
-            if (index >= 0) standardAlphabet[index] else char
-        }.joinToString("")
-
-        return String(Base64.decode(translated, Base64.NO_WRAP), Charsets.UTF_8)
-    }
-
-    private fun fetchVidnestVideos(url: String, kind: String, serverName: String): List<Video> {
-        val videos = mutableListOf<Video>()
-        try {
-            val headers = Headers.Builder()
-                .add("Referer", "https://vidnest.fun/")
-                .add("Origin", "https://vidnest.fun")
-                .build()
-
-            val resp = client.newCall(GET(url, headers)).execute()
-            val body = resp.bodyString()
-
-            try {
-                val jsonElement = body.parseAs<JsonElement>(json)
-                val sourcesArr = if (jsonElement is JsonObject) {
-                    jsonElement["source"] as? JsonArray ?: jsonElement["sources"] as? JsonArray
-                } else {
-                    null
-                }
-
-                if (sourcesArr != null) {
-                    for (source in sourcesArr) {
-                        val srcObj = source as? JsonObject ?: continue
-                        val file = srcObj.string("file") ?: srcObj.string("url") ?: continue
-                        val quality = srcObj.string("quality") ?: srcObj.string("label") ?: ""
-                        val type = srcObj.string("type") ?: ""
-                        val label = buildString {
-                            append(kind)
-                            append(" - ")
-                            append(serverName)
-                            if (quality.isNotBlank()) {
-                                append(" - ")
-                                append(quality)
-                            }
-                            if (type.equals("hls", ignoreCase = true)) {
-                                append(" - HLS")
-                            }
-                        }
-                        videos.add(Video(file, label, file, headers))
-                    }
-                }
-            } catch (_: Exception) {
-                if (body.contains("#EXTM3U") || url.contains(".m3u8")) {
-                    videos.add(Video(url, "$kind - $serverName - HLS", url, headers))
-                } else if (url.contains(".mp4")) {
-                    videos.add(Video(url, "$kind - $serverName - MP4", url, headers))
-                }
-            }
-        } catch (_: Exception) {
-            // Network error, skip this source
-        }
-        return videos
-    }
-
     // ============================== Filters ==============================
 
-    override fun getFilterList(): AnimeFilterList = AnimeFilterList(
-        ScheduleDayFilter(),
-    )
+    override fun getFilterList(): AnimeFilterList {
+        val genres = mutableSetOf<String>()
+        val studios = mutableSetOf<String>()
+        val years = mutableSetOf<String>()
+        val ratingLabels = mutableSetOf<String>()
+        val seasons = mutableSetOf<String>()
+
+        if (catalogCacheFile.exists()) {
+            runCatching {
+                val catalogArr = extractArray(catalogCacheFile.readText().parseAs<JsonElement>(json))
+                catalogArr.forEach { el ->
+                    val o = el.jsonObject
+                    genres.addAll(o.stringArray("genres"))
+                    studios.addAll(o.stringArray("studios"))
+                    o.int("year").takeIf { it > 0 }?.let { years.add(it.toString()) }
+                    o.string("ratingLabel")?.takeIf { it.isNotEmpty() }?.let { ratingLabels.add(it) }
+                    o.string("premiered")?.substringBefore(" ")?.takeIf { it.isNotEmpty() }?.let { seasons.add(it) }
+                }
+            }
+        }
+
+        val filters = mutableListOf<AnimeFilter<*>>(
+            ScheduleDayFilter(),
+        )
+
+        if (genres.isNotEmpty()) {
+            filters.add(GenreModeFilter())
+            filters.add(GenreFilter(genres.sortedWith(String.CASE_INSENSITIVE_ORDER)))
+            filters.add(StudioFilter(studios.sortedWith(String.CASE_INSENSITIVE_ORDER)))
+            filters.add(SeasonFilter(seasons.sortWithNA()))
+            filters.add(YearFilter(years.sortedDescending()))
+            filters.add(RatingLabelFilter(ratingLabels.sortRatingLabels()))
+        } else {
+            filters.add(AnimeFilter.Header("Press 'Reset' to load filters"))
+            filters.add(AnimeFilter.Separator())
+        }
+
+        return AnimeFilterList(filters)
+    }
+
+    private fun Iterable<String>.sortWithNA(): List<String> = this.filter { !it.equals("N/A", true) }
+
+    private fun Iterable<String>.sortRatingLabels(): List<String> {
+        val order = listOf("G", "PG", "PG-13", "R - 17+", "R+", "Rx", "Safe to watch")
+        return this.sortedWith(
+            compareBy<String> { label ->
+                val index = order.indexOfFirst { label.contains(it, ignoreCase = true) }
+                if (index == -1) Int.MAX_VALUE else index
+            }.thenBy(String.CASE_INSENSITIVE_ORDER) { it },
+        )
+    }
 
     private class ScheduleDayFilter :
         AnimeFilter.Select<String>(
@@ -768,6 +611,29 @@ class AnimeVerse :
         ) {
         private val apiValues = arrayOf("", "mon", "tue", "wed", "thu", "fri", "sat", "sun")
         fun getValue(): String = apiValues[state]
+    }
+
+    private class GenreFilter(values: List<String>) : AnimeFilter.Group<GenreTriState>("Genres", values.map { GenreTriState(it) })
+
+    private class GenreTriState(name: String) : AnimeFilter.TriState(name)
+
+    private class GenreModeFilter : AnimeFilter.Select<String>("Genre Mode", arrayOf("OR", "AND"), 0) {
+        fun isAnd(): Boolean = state == 1
+    }
+
+    private class StudioFilter(values: List<String>) : AnimeFilter.Group<StudioCheckBox>("Studios", values.map { StudioCheckBox(it, false) })
+    private class StudioCheckBox(name: String, state: Boolean) : AnimeFilter.CheckBox(name, state)
+
+    private class YearFilter(private val years: List<String>) : AnimeFilter.Select<String>("Year", arrayOf("None") + years.toTypedArray()) {
+        fun getValue(): String = if (state == 0) "" else years[state - 1]
+    }
+
+    private class SeasonFilter(private val seasons: List<String>) : AnimeFilter.Select<String>("Season", arrayOf("None") + seasons.toTypedArray()) {
+        fun getValue(): String = if (state == 0) "" else seasons[state - 1]
+    }
+
+    private class RatingLabelFilter(private val labels: List<String>) : AnimeFilter.Select<String>("Rating Label", arrayOf("None") + labels.toTypedArray()) {
+        fun getValue(): String = if (state == 0) "" else labels[state - 1]
     }
 
     // ============================== Preferences ==============================
@@ -794,8 +660,8 @@ class AnimeVerse :
         private const val PREF_USE_ALT_TITLE = "use_alt_title"
         private const val PREF_USE_ALT_TITLE_DEFAULT = false
 
-        private val SERVERS = arrayOf("animeverse", "choi", "chiki")
-        private val SERVERS_DISPLAY = arrayOf("AnimeVerse", "Choi", "Chiki")
+        private val SERVERS = arrayOf("animeverse", "chiki")
+        private val SERVERS_DISPLAY = arrayOf("AnimeVerse", "Chiki")
 
         private const val PREF_HOSTER_EXCLUDE_KEY = "hoster_exclusion"
         private const val PREF_HOSTER_EXCLUDE_TITLE = "Excluded Hosts"

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
@@ -41,6 +41,7 @@ class AnimeVerse :
     override val baseUrl = "https://animeverse.to"
     override val lang = "en"
     override val supportsLatest = true
+    override val disableRelatedAnimesBySearch = true
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -340,6 +341,37 @@ class AnimeVerse :
 
             AnimesPage(sorted.map { jsonToAnime(it, useAltTitle, baseUrl) }, false)
         }
+    }
+
+    override suspend fun fetchRelatedAnimeList(anime: SAnime): List<SAnime> {
+        val keywords = anime.title.stripKeywordForRelatedAnimes()
+        val catalog = getCatalog()
+        val currentSlug = anime.slug()
+
+        val currentGenres = anime.genre?.split(", ")?.map { it.trim() }?.toSet() ?: emptySet()
+
+        return catalog.asSequence()
+            .map { it.jsonObject }
+            .filter { it.string("slug") != currentSlug }
+            .map { o ->
+                val title = o.string("title")?.lowercase().orEmpty()
+                val alt = o.string("alternativeTitle")?.lowercase().orEmpty()
+
+                val titleMatchScore = if (keywords.isEmpty()) 0 else keywords.count { title.contains(it) || alt.contains(it) }
+
+                val genres = o.stringArray("genres")
+                val sharedGenres = if (currentGenres.isNotEmpty()) genres.intersect(currentGenres).size else 0
+
+                Triple(o, titleMatchScore, sharedGenres)
+            }
+            .filter { (_, titleMatchScore, sharedGenres) -> titleMatchScore > 0 || sharedGenres >= 3 }
+            .sortedWith(
+                compareByDescending<Triple<JsonObject, Int, Int>> { it.second }
+                    .thenByDescending { it.third },
+            )
+            .take(20)
+            .map { jsonToAnime(it.first, useAltTitle, baseUrl) }
+            .toList()
     }
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request = throw UnsupportedOperationException()

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerse.kt
@@ -85,6 +85,13 @@ class AnimeVerse :
 
     private fun getCatalog(): List<JsonElement> = synchronized(cacheLock) {
         val now = System.currentTimeMillis()
+        val forceRefresh = preferences.getBoolean(PREF_FORCE_REFRESH_CACHE, false)
+
+        if (forceRefresh) {
+            catalogCache = null
+            catalogCacheFile.delete()
+            preferences.edit().putBoolean(PREF_FORCE_REFRESH_CACHE, false).apply()
+        }
 
         catalogCache?.takeIf { now - catalogCacheLoadedTime < cacheTtl }?.let { return it }
 
@@ -345,31 +352,35 @@ class AnimeVerse :
 
     override suspend fun fetchRelatedAnimeList(anime: SAnime): List<SAnime> {
         val keywords = anime.title.stripKeywordForRelatedAnimes()
+        if (keywords.isEmpty()) return emptyList()
+
         val catalog = getCatalog()
         val currentSlug = anime.slug()
-
         val currentGenres = anime.genre?.split(", ")?.map { it.trim() }?.toSet() ?: emptySet()
 
         return catalog.asSequence()
             .map { it.jsonObject }
             .filter { it.string("slug") != currentSlug }
             .map { o ->
-                val title = o.string("title")?.lowercase().orEmpty()
-                val alt = o.string("alternativeTitle")?.lowercase().orEmpty()
+                val searchTitle = if (useAltTitle) {
+                    o.string("alternativeTitle")?.takeIf { it.isNotEmpty() } ?: o.string("title")
+                } else {
+                    o.string("title")
+                }?.lowercase().orEmpty()
 
-                val titleMatchScore = if (keywords.isEmpty()) 0 else keywords.count { title.contains(it) || alt.contains(it) }
+                val titleMatchScore = keywords.count { searchTitle.contains(it) }
 
                 val genres = o.stringArray("genres")
                 val sharedGenres = if (currentGenres.isNotEmpty()) genres.intersect(currentGenres).size else 0
 
                 Triple(o, titleMatchScore, sharedGenres)
             }
-            .filter { (_, titleMatchScore, sharedGenres) -> titleMatchScore > 0 || sharedGenres >= 3 }
+            .filter { (_, titleMatchScore, sharedGenres) -> titleMatchScore >= 2 || sharedGenres >= 1 }
             .sortedWith(
                 compareByDescending<Triple<JsonObject, Int, Int>> { it.second }
                     .thenByDescending { it.third },
             )
-            .take(20)
+            .take(24)
             .map { jsonToAnime(it.first, useAltTitle, baseUrl) }
             .toList()
     }
@@ -691,6 +702,13 @@ class AnimeVerse :
             default = PREF_USE_ALT_TITLE_DEFAULT,
         )
 
+        screen.addSwitchPreference(
+            key = PREF_FORCE_REFRESH_CACHE,
+            title = "Force Refresh Catalog Cache",
+            summary = "Clears the local catalog file and fetches a fresh one on the next catalog request.",
+            default = false,
+        )
+
         MultiSelectListPreference(screen.context).apply {
             key = PREF_HOSTER_EXCLUDE_KEY
             title = PREF_HOSTER_EXCLUDE_TITLE
@@ -711,5 +729,7 @@ class AnimeVerse :
         private const val PREF_HOSTER_EXCLUDE_KEY = "hoster_exclusion"
         private const val PREF_HOSTER_EXCLUDE_TITLE = "Excluded Hosts"
         private val PREF_HOSTER_EXCLUDE_DEFAULT = emptySet<String>()
+
+        private const val PREF_FORCE_REFRESH_CACHE = "force_refresh_cache"
     }
 }

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseAuth.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseAuth.kt
@@ -1,0 +1,114 @@
+package eu.kanade.tachiyomi.animeextension.en.animeverse
+
+import keiyoushi.utils.bodyString
+import keiyoushi.utils.parseAs
+import keiyoushi.utils.toJsonBody
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+private val authLock = Any()
+private var sessionCookie = ""
+private var authKey = ""
+private var authExpires = 0L
+
+private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+fun getAuth(networkClient: OkHttpClient, fingerprint: String): Pair<String, String> = synchronized(authLock) {
+    if (authKey.isNotEmpty() && System.currentTimeMillis() / 1000 < authExpires) {
+        return authKey to sessionCookie
+    }
+
+    val body = """{"fp":$fingerprint}""".toJsonBody()
+
+    val sessionReq = Request.Builder()
+        .url("https://animeverse.to/api/v1/session")
+        .post(body)
+        .header("Content-Type", "application/json")
+        .build()
+
+    val sessionResp = networkClient.newCall(sessionReq).execute()
+    val respBody = sessionResp.bodyString()
+
+    if (!sessionResp.isSuccessful) {
+        invalidateAuth()
+        sessionResp.close()
+        throw Exception("Session failed (${sessionResp.code}): $respBody")
+    }
+
+    sessionResp.headers("Set-Cookie")
+        .firstOrNull { it.startsWith("av_session=") }
+        ?.substringAfter("=")?.substringBefore(";")
+        ?.let { sessionCookie = it }
+
+    val obj = try {
+        respBody.parseAs<JsonElement>(json).jsonObject
+    } catch (_: Exception) {
+        invalidateAuth()
+        sessionResp.close()
+        throw Exception("Invalid session JSON: $respBody")
+    }
+
+    val key = obj["clientAuthKey"]?.jsonPrimitive?.contentOrNull
+    if (key.isNullOrEmpty()) {
+        invalidateAuth()
+        sessionResp.close()
+        throw Exception("No clientAuthKey in response: $respBody")
+    }
+
+    authKey = key
+    authExpires = obj["expiresAt"]?.jsonPrimitive?.longOrNull
+        ?: (System.currentTimeMillis() / 1000 + 3600)
+    sessionResp.close()
+
+    authKey to sessionCookie
+}
+
+fun invalidateAuth() = synchronized(authLock) {
+    authKey = ""
+    authExpires = 0L
+    sessionCookie = ""
+}
+
+fun authInterceptor(chain: Interceptor.Chain, networkClient: OkHttpClient, fingerprint: String): Response {
+    val req = chain.request()
+    if (!req.url.encodedPath.startsWith("/api/v1/")) return chain.proceed(req)
+
+    val signed = sign(req, networkClient, fingerprint)
+    val resp = chain.proceed(signed)
+    if (resp.code != 401) return resp
+    resp.close()
+
+    invalidateAuth()
+    return chain.proceed(sign(req, networkClient, fingerprint))
+}
+
+private fun sign(request: Request, networkClient: OkHttpClient, fingerprint: String): Request {
+    val (key, cookie) = getAuth(networkClient, fingerprint)
+    if (key.isEmpty()) return request
+
+    val ts = System.currentTimeMillis().toString()
+    val mac = Mac.getInstance("HmacSHA256").apply {
+        init(SecretKeySpec(base64UrlDecode(key), "HmacSHA256"))
+    }
+    val sig = base64UrlEncode(
+        mac.doFinal("${request.method}|${request.url.encodedPath}|$ts".toByteArray()).copyOf(16),
+    )
+    return request.newBuilder()
+        .header("x-av-ts", ts)
+        .header("x-av-sig", sig)
+        .header("Cookie", "av_session=$cookie")
+        .build()
+}

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseAuth.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseAuth.kt
@@ -26,7 +26,7 @@ private val json = Json {
     isLenient = true
 }
 
-fun getAuth(networkClient: OkHttpClient, fingerprint: String): Pair<String, String> = synchronized(authLock) {
+fun getAuth(networkClient: OkHttpClient, fingerprint: String, baseUrl: String): Pair<String, String> = synchronized(authLock) {
     if (authKey.isNotEmpty() && System.currentTimeMillis() / 1000 < authExpires) {
         return authKey to sessionCookie
     }
@@ -34,44 +34,44 @@ fun getAuth(networkClient: OkHttpClient, fingerprint: String): Pair<String, Stri
     val body = """{"fp":$fingerprint}""".toJsonBody()
 
     val sessionReq = Request.Builder()
-        .url("https://animeverse.to/api/v1/session")
+        .url("$baseUrl/api/v1/session")
         .post(body)
         .header("Content-Type", "application/json")
         .build()
 
-    val sessionResp = networkClient.newCall(sessionReq).execute()
-    val respBody = sessionResp.bodyString()
-
-    if (!sessionResp.isSuccessful) {
-        invalidateAuth()
-        sessionResp.close()
-        throw Exception("Session failed (${sessionResp.code}): $respBody")
+    var cookie: String? = null
+    val (respBody, isSuccessful, code) = networkClient.newCall(sessionReq).execute().use { resp ->
+        cookie = resp.headers("Set-Cookie")
+            .firstOrNull { it.startsWith("av_session=") }
+            ?.substringAfter("=")?.substringBefore(";")
+        Triple(resp.bodyString(), resp.isSuccessful, resp.code)
     }
 
-    sessionResp.headers("Set-Cookie")
-        .firstOrNull { it.startsWith("av_session=") }
-        ?.substringAfter("=")?.substringBefore(";")
-        ?.let { sessionCookie = it }
+    if (cookie != null) {
+        sessionCookie = cookie!!
+    }
+
+    if (!isSuccessful) {
+        invalidateAuth()
+        throw Exception("Session failed ($code): $respBody")
+    }
 
     val obj = try {
         respBody.parseAs<JsonElement>(json).jsonObject
     } catch (_: Exception) {
         invalidateAuth()
-        sessionResp.close()
         throw Exception("Invalid session JSON: $respBody")
     }
 
     val key = obj["clientAuthKey"]?.jsonPrimitive?.contentOrNull
     if (key.isNullOrEmpty()) {
         invalidateAuth()
-        sessionResp.close()
         throw Exception("No clientAuthKey in response: $respBody")
     }
 
     authKey = key
     authExpires = obj["expiresAt"]?.jsonPrimitive?.longOrNull
         ?: (System.currentTimeMillis() / 1000 + 3600)
-    sessionResp.close()
 
     authKey to sessionCookie
 }
@@ -82,21 +82,21 @@ fun invalidateAuth() = synchronized(authLock) {
     sessionCookie = ""
 }
 
-fun authInterceptor(chain: Interceptor.Chain, networkClient: OkHttpClient, fingerprint: String): Response {
+fun authInterceptor(chain: Interceptor.Chain, networkClient: OkHttpClient, fingerprint: String, baseUrl: String): Response {
     val req = chain.request()
     if (!req.url.encodedPath.startsWith("/api/v1/")) return chain.proceed(req)
 
-    val signed = sign(req, networkClient, fingerprint)
+    val signed = sign(req, networkClient, fingerprint, baseUrl)
     val resp = chain.proceed(signed)
     if (resp.code != 401) return resp
     resp.close()
 
     invalidateAuth()
-    return chain.proceed(sign(req, networkClient, fingerprint))
+    return chain.proceed(sign(req, networkClient, fingerprint, baseUrl))
 }
 
-private fun sign(request: Request, networkClient: OkHttpClient, fingerprint: String): Request {
-    val (key, cookie) = getAuth(networkClient, fingerprint)
+private fun sign(request: Request, networkClient: OkHttpClient, fingerprint: String, baseUrl: String): Request {
+    val (key, cookie) = getAuth(networkClient, fingerprint, baseUrl)
     if (key.isEmpty()) return request
 
     val ts = System.currentTimeMillis().toString()

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseExtractors.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseExtractors.kt
@@ -1,0 +1,103 @@
+package eu.kanade.tachiyomi.animeextension.en.animeverse
+
+import aniyomi.lib.playlistutils.PlaylistUtils
+import eu.kanade.tachiyomi.animesource.model.Track
+import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.network.GET
+import keiyoushi.utils.bodyString
+import keiyoushi.utils.parseAs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+
+private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+fun extractMegaplayId(client: OkHttpClient, pageUrl: String, baseUrl: String): String? {
+    val pageHeaders = Headers.Builder()
+        .add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        .add("Referer", "$baseUrl/")
+        .add("Sec-Fetch-Dest", "iframe")
+        .add("Sec-Fetch-Mode", "navigate")
+        .add("Sec-Fetch-Site", "cross-site")
+        .build()
+
+    val pageBody = client.newCall(GET(pageUrl, pageHeaders)).execute().use { it.bodyString() }
+
+    return Regex("""data-id\s*=\s*["']([^"']+)["']""").find(pageBody)?.groupValues?.get(1)
+}
+
+private fun extractM3u8FromSources(sources: JsonElement): String? = when (sources) {
+    is JsonObject -> sources["file"]?.jsonPrimitive?.contentOrNull
+    is JsonArray -> sources.firstOrNull()?.let {
+        when (it) {
+            is JsonObject -> it["file"]?.jsonPrimitive?.contentOrNull
+            is JsonPrimitive -> it.contentOrNull
+            else -> null
+        }
+    }
+    is JsonPrimitive -> sources.contentOrNull
+}
+
+fun fetchMegaplayVideos(
+    client: OkHttpClient,
+    playlistUtils: PlaylistUtils,
+    id: String,
+    referer: String,
+    kind: String,
+    serverName: String,
+): List<Video> {
+    val videos = mutableListOf<Video>()
+    try {
+        val base = extractBaseUrl(referer)
+        val sourcesUrl = "$base/stream/getSources?id=$id&id=$id"
+
+        val headers = Headers.Builder()
+            .add("Accept", "application/json, text/javascript, */*; q=0.01")
+            .add("X-Requested-With", "XMLHttpRequest")
+            .add("Referer", referer)
+            .add("Origin", base)
+            .add("Sec-Fetch-Dest", "empty")
+            .add("Sec-Fetch-Mode", "cors")
+            .add("Sec-Fetch-Site", "same-origin")
+            .build()
+
+        val obj = client.newCall(GET(sourcesUrl, headers)).execute().use { res ->
+            if (!res.isSuccessful) return videos
+            res.bodyString().parseAs<JsonElement>(json) as? JsonObject
+        } ?: return videos
+
+        val masterUrl = extractM3u8FromSources(obj["sources"] ?: return videos)
+            ?.takeIf { it.startsWith("http") }
+            ?: return videos
+
+        val subtitleTracks = (obj["tracks"] as? JsonArray)
+            ?.mapNotNull { trackEl ->
+                val trackObj = trackEl as? JsonObject ?: return@mapNotNull null
+                val file = trackObj.string("file") ?: return@mapNotNull null
+                val label = trackObj.string("label") ?: ""
+                val trackKind = trackObj.string("kind") ?: ""
+                if (trackKind.equals("captions", true)) Track(file, label) else null
+            } ?: emptyList()
+
+        videos.addAll(
+            playlistUtils.extractFromHls(
+                masterUrl,
+                videoNameGen = { q -> "$kind - $serverName - ${cleanQuality(q)}" },
+                subtitleList = subtitleTracks,
+                referer = "$base/",
+            ),
+        )
+    } catch (_: Exception) {
+        // Network error, skip this source
+    }
+    return videos
+}

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseUtils.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseUtils.kt
@@ -14,7 +14,7 @@ import kotlin.math.roundToInt
 
 // =========================== SAnime Mappers ==============================
 
-fun jsonToAnime(el: JsonElement, useAlt: Boolean): SAnime {
+fun jsonToAnime(el: JsonElement, useAlt: Boolean, baseUrl: String): SAnime {
     val o = el.jsonObject
     val genres = o.stringArray("genres")
     val studios = o.stringArray("studios")
@@ -24,19 +24,19 @@ fun jsonToAnime(el: JsonElement, useAlt: Boolean): SAnime {
     return SAnime.create().apply {
         title = if (useAlt) altTitle ?: mainTitle else mainTitle
         url = "/series/${o.string("slug")}"
-        thumbnail_url = resolveImage(o.string("cover") ?: o.string("thumb"))
+        thumbnail_url = resolveImage(baseUrl, o.string("cover") ?: o.string("thumb"))
         author = studios.takeIf { it.isNotEmpty() }?.joinToString(", ")
         genre = genres.takeIf { it.isNotEmpty() }?.joinToString(", ")
         status = SAnime.UNKNOWN
     }
 }
 
-fun recentToAnime(el: JsonElement): SAnime {
+fun recentToAnime(el: JsonElement, baseUrl: String): SAnime {
     val o = el.jsonObject
     return SAnime.create().apply {
         title = o.string("seriesTitle") ?: "Unknown"
         url = "/series/${o.string("seriesSlug")}"
-        thumbnail_url = resolveImage(o.string("thumb"))
+        thumbnail_url = resolveImage(baseUrl, o.string("thumb"))
         genre = o.string("language")?.uppercase() ?: o.string("releaseTime")
         status = SAnime.UNKNOWN
     }
@@ -46,14 +46,14 @@ fun recentToAnime(el: JsonElement): SAnime {
 
 fun SAnime.slug(): String = url.substringAfter("/series/")
 
-fun resolveImage(path: String?): String? {
+fun resolveImage(baseUrl: String, path: String?): String? {
     if (path.isNullOrEmpty()) return null
     if (path.startsWith("http")) return path
     if (path.startsWith("/i/")) {
-        runCatching { String(base64UrlDecode(path.substringAfter("/i/"))) }
+        runCatching { String(base64UrlDecode(path.substringAfter("/i/")), Charsets.UTF_8) }
             .getOrNull()?.takeIf { it.startsWith("http") }?.let { return it }
     }
-    return "https://animeverse.to$path"
+    return "$baseUrl$path"
 }
 
 @SuppressLint("DefaultLocale")

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseUtils.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseUtils.kt
@@ -1,0 +1,108 @@
+package eu.kanade.tachiyomi.animeextension.en.animeverse
+
+import android.annotation.SuppressLint
+import android.util.Base64
+import eu.kanade.tachiyomi.animesource.model.SAnime
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.math.roundToInt
+
+// =========================== SAnime Mappers ==============================
+
+fun jsonToAnime(el: JsonElement, useAlt: Boolean): SAnime {
+    val o = el.jsonObject
+    val genres = o.stringArray("genres")
+    val studios = o.stringArray("studios")
+    val mainTitle = o.string("title") ?: "Unknown"
+    val altTitle = o.string("alternativeTitle")?.takeIf { it.isNotEmpty() }
+
+    return SAnime.create().apply {
+        title = if (useAlt) altTitle ?: mainTitle else mainTitle
+        url = "/series/${o.string("slug")}"
+        thumbnail_url = resolveImage(o.string("cover") ?: o.string("thumb"))
+        author = studios.takeIf { it.isNotEmpty() }?.joinToString(", ")
+        genre = genres.takeIf { it.isNotEmpty() }?.joinToString(", ")
+        status = SAnime.UNKNOWN
+    }
+}
+
+fun recentToAnime(el: JsonElement): SAnime {
+    val o = el.jsonObject
+    return SAnime.create().apply {
+        title = o.string("seriesTitle") ?: "Unknown"
+        url = "/series/${o.string("seriesSlug")}"
+        thumbnail_url = resolveImage(o.string("thumb"))
+        genre = o.string("language")?.uppercase() ?: o.string("releaseTime")
+        status = SAnime.UNKNOWN
+    }
+}
+
+// =========================== Helpers ==============================
+
+fun SAnime.slug(): String = url.substringAfter("/series/")
+
+fun resolveImage(path: String?): String? {
+    if (path.isNullOrEmpty()) return null
+    if (path.startsWith("http")) return path
+    if (path.startsWith("/i/")) {
+        runCatching { String(base64UrlDecode(path.substringAfter("/i/"))) }
+            .getOrNull()?.takeIf { it.startsWith("http") }?.let { return it }
+    }
+    return "https://animeverse.to$path"
+}
+
+@SuppressLint("DefaultLocale")
+fun formatRating(rating10: Double): String {
+    if (rating10 <= 0) return ""
+    val fullStars = (rating10 / 2.0).roundToInt().coerceIn(0, 5)
+    val emptyStars = 5 - fullStars
+    val stars = "★".repeat(fullStars) + "☆".repeat(emptyStars)
+    return "$stars ${String.format("%.2f", rating10)}"
+}
+
+fun base64UrlEncode(data: ByteArray): String = Base64.encodeToString(data, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+
+fun base64UrlDecode(str: String): ByteArray = Base64.decode(str, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+
+// =========================== JSON Extensions ==============================
+
+fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull
+
+fun JsonObject.int(key: String): Int = this[key]?.jsonPrimitive?.intOrNull ?: 0
+
+fun JsonObject.double(key: String): Double = this[key]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: 0.0
+
+fun JsonObject.stringArray(key: String): List<String> = (this[key] as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+
+fun extractArray(root: JsonElement): List<JsonElement> = when (root) {
+    is JsonArray -> root
+    is JsonObject -> (root["items"] ?: root["data"] ?: root.values.firstOrNull { it is JsonArray })
+        as? JsonArray ?: emptyList()
+    else -> emptyList()
+}
+
+// =========================== Video Helpers ==============================
+
+fun cleanQuality(q: String): String {
+    Regex("""(\d{3,4})p""").find(q)?.let { return it.value }
+    Regex("""\dx(\d+)""").find(q)?.groupValues?.get(1)?.let { return "${it}p" }
+    return q.substringBefore(" - ").substringBefore("(").trim()
+}
+
+fun extractBaseUrl(url: String): String {
+    val schemeEnd = url.indexOf("://")
+    if (schemeEnd < 0) return url
+    val pathStart = url.indexOf("/", schemeEnd + 3)
+    return if (pathStart > 0) url.substring(0, pathStart) else url
+}
+
+fun isMegaplayStream(path: String): Boolean = path.contains("/stream/mal/") ||
+    path.contains("/stream/ani/") ||
+    path.contains("/stream/s-") ||
+    path.contains("megaplay") ||
+    path.contains("vidwish")

--- a/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseUtils.kt
+++ b/src/en/animeverse/src/eu/kanade/tachiyomi/animeextension/en/animeverse/AnimeVerseUtils.kt
@@ -46,6 +46,18 @@ fun recentToAnime(el: JsonElement, baseUrl: String): SAnime {
 
 fun SAnime.slug(): String = url.substringAfter("/series/")
 
+private val regexSpecialCharacters = Regex("""[^a-zA-Z0-9\s]""")
+private val regexWhitespace = Regex("""\s+""")
+private val regexNumberOnly = Regex("""^\d+$""")
+
+fun String.stripKeywordForRelatedAnimes(): List<String> = replace(regexSpecialCharacters, " ")
+    .split(regexWhitespace)
+    .map {
+        it.replace(regexNumberOnly, "")
+            .lowercase()
+    }
+    .filter { it.length > 2 } // Increase minimum length to 3 to ignore short common words
+
 fun resolveImage(baseUrl: String, path: String?): String? {
     if (path.isNullOrEmpty()) return null
     if (path.startsWith("http")) return path


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Refactor the AnimeVerse extension to use shared auth and utility helpers, add catalog-based caching and richer search/filter capabilities, and simplify supported streaming servers while bumping the extension version.

New Features:
- Introduce disk-backed caching for catalog and schedule data to reduce repeated network calls.
- Add advanced search and filter options including genres, studios, year, season, rating label, and schedule-day-aware filtering.
- Enrich popular and latest anime lists by merging schedule and catalog metadata for better titles and details.

Bug Fixes:
- Fix auth handling by centralizing session and request signing logic and improving error handling and reuse.
- Improve anime details resolution by correlating API responses with catalog entries via both ID and slug when available.

Enhancements:
- Extract authentication, JSON mapping, and video extractor logic into separate helper files to improve maintainability and reuse.
- Refine search implementation to work off cached catalog data with client-side filtering and rating-based sorting when no query is provided.
- Generate filter options dynamically from cached catalog metadata with sensible ordering for seasons and rating labels.
- Simplify supported streaming sources by removing unused hosts and treating only valid direct HTTP(S) streams as standard videos.

Build:
- Bump the AnimeVerse extension version code from 3 to 4.