### PR TITLE
Jellyfin [ALL]: Fix search for generated season titles

### DIFF
--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jellyfin'
     extClass = '.JellyfinFactory'
-    extVersionCode = 30
+    extVersionCode = 31
     extNames = ["Jellyfin (1)", "Jellyfin (2)", "Jellyfin (3)"]
 }
 

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -194,7 +194,7 @@ class Jellyfin(private val suffix: String) :
             seriesQuery != searchQuery &&
             items.items.none { it.name.equals(searchQuery, ignoreCase = true) }
         ) {
-            items = client.get(getSearchUrl(seriesQuery)).parseAs(json)
+            items = client.get(getSearchUrl(seriesQuery)).parseAs<ItemListDto>(json)
             searchQuery
         } else {
             null
@@ -229,7 +229,7 @@ class Jellyfin(private val suffix: String) :
         val matchingAnime = requestedSeasonTitle?.let { title ->
             animeList.filter { it.title.equals(title, ignoreCase = true) }
         } ?: animeList
-        val hasNextPage = requestedSeasonTitle == null && SERIES_FETCH_LIMIT * page < items.totalRecordCount
+        val hasNextPage = SERIES_FETCH_LIMIT * page < items.totalRecordCount
 
         return AnimesPage(matchingAnime, hasNextPage)
     }

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -176,7 +176,7 @@ class Jellyfin(private val suffix: String) :
         checkPreferences()
 
         val startIndex = (page - 1) * SERIES_FETCH_LIMIT
-        val url = getItemsUrl(startIndex).newBuilder().apply {
+        fun getSearchUrl(searchTerm: String) = getItemsUrl(startIndex).newBuilder().apply {
             // Search for series, rather than seasons, since season names can just be "Season 1"
             // Add "Episode" to search for episodes too, but this can lead to less relevant results
             setQueryParameter(
@@ -184,10 +184,21 @@ class Jellyfin(private val suffix: String) :
                 if (preferences.searchEpisodes) "Movie,Series,Episode" else "Movie,Series",
             )
             setQueryParameter("Limit", SERIES_FETCH_LIMIT.toString())
-            setQueryParameter("SearchTerm", query)
+            setQueryParameter("SearchTerm", searchTerm)
         }.build()
 
-        val items = client.get(url).parseAs<ItemListDto>(json)
+        val searchQuery = query.trim()
+        var items = client.get(getSearchUrl(searchQuery)).parseAs<ItemListDto>(json)
+        val seriesQuery = searchQuery.replace(SEASON_TITLE_SUFFIX_REGEX, "").ifBlank { searchQuery }
+        val requestedSeasonTitle = if (
+            seriesQuery != searchQuery &&
+            items.items.none { it.name.equals(searchQuery, ignoreCase = true) }
+        ) {
+            items = client.get(getSearchUrl(seriesQuery)).parseAs(json)
+            searchQuery
+        } else {
+            null
+        }
         val animeList = coroutineScope {
             items.items.parallelFlatMap { series ->
                 when (series.type) {
@@ -215,9 +226,12 @@ class Jellyfin(private val suffix: String) :
             }
         }
 
-        val hasNextPage = SERIES_FETCH_LIMIT * page < items.totalRecordCount
+        val matchingAnime = requestedSeasonTitle?.let { title ->
+            animeList.filter { it.title.equals(title, ignoreCase = true) }
+        } ?: animeList
+        val hasNextPage = requestedSeasonTitle == null && SERIES_FETCH_LIMIT * page < items.totalRecordCount
 
-        return AnimesPage(animeList, hasNextPage)
+        return AnimesPage(matchingAnime, hasNextPage)
     }
 
     // =========================== Anime Details ============================
@@ -581,6 +595,10 @@ class Jellyfin(private val suffix: String) :
     companion object {
         private const val SEASONS_FETCH_LIMIT = 20
         private const val SERIES_FETCH_LIMIT = 5
+        private val SEASON_TITLE_SUFFIX_REGEX = Regex(
+            """\s+(?:Season\s+\d+|Specials)\s*$""",
+            RegexOption.IGNORE_CASE,
+        )
         private val LIBRARY_BLACKLIST = listOf(
             "music",
             "musicvideos",


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve Jellyfin search handling to correctly find series when users search using generated season titles.

Bug Fixes:
- Fix search results so queries including generated season titles (e.g., "Series Name Season 1" or "Specials") can still match the underlying series.
- Ensure pagination metadata is accurate when search results are narrowed to a specific matching season title.

Enhancements:
- Normalize and strip season/specials suffixes from search terms to better align user queries with Jellyfin series titles.
- Prioritize exact title matches when a requested season title differs from the base series name.

Build:
- Bump Jellyfin extension version code to 31.