### PR TITLE
AnimePahe [EN]: Support encrypted HLS playback

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -8,5 +8,5 @@ apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(":lib:unpacker"))
-    implementation("com.github.NanoHttpd.nanohttpd:nanohttpd:-SNAPSHOT")
+    implementation("com.github.NanoHttpd.nanohttpd:nanohttpd:nanohttpd-project-2.3.1")
 }

--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,11 +1,12 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 44
+    extVersionCode = 45
 }
 
 apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(":lib:unpacker"))
+    implementation("com.github.NanoHttpd.nanohttpd:nanohttpd:-SNAPSHOT")
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -29,6 +29,7 @@ import okhttp3.Response
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
+import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -263,21 +264,33 @@ class AnimePahe :
      * @see animeDetailsRequest
      */
     override fun episodeListRequest(anime: SAnime): Request {
-        val session = anime.getId()?.let { fetchSession(it) }
+        val animeId = anime.getId()
+        val session = animeId?.let { fetchSession(it) }
             ?: sessionIdRegex.find(anime.url)?.groupValues?.get(1)
             ?: throw IllegalStateException("Anime session not found")
-        return GET("$baseUrl/api?m=release&id=$session&sort=episode_asc&page=1")
+
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegment("api")
+            addQueryParameter("m", "release")
+            addQueryParameter("id", session)
+            addQueryParameter("sort", "episode_asc")
+            animeId?.let { addQueryParameter("anime_id", it) }
+            addQueryParameter("page", "1")
+        }.build()
+
+        return GET(url)
     }
 
     private val sessionIdRegex by lazy { Regex("""/anime/([\w-]+)""") }
-    private val animeSessionRegex by lazy { Regex("""&id=([\w-]+)&""") }
+    private val stableEpisodeRegex by lazy { Regex("""/play/anime/(\d+)/episode/([\d.]+)""") }
 
     override fun episodeListParse(response: Response): List<SEpisode> {
-        val url = response.request.url.toString()
-        val session = animeSessionRegex.find(url)?.groupValues?.get(1)
+        val url = response.request.url
+        val session = url.queryParameter("id")
             ?: throw IllegalStateException("Anime session not found in URL: $url")
+        val animeId = url.queryParameter("anime_id")
         val episodeList = mutableListOf<SEpisode>()
-        recursivePages(episodeList, response, session)
+        recursivePages(episodeList, response, session, animeId)
 
         return episodeList
             .mapIndexed { index, episode ->
@@ -289,11 +302,11 @@ class AnimePahe :
             .reversed()
     }
 
-    private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String): MutableList<SEpisode> = episodes.map { episode ->
+    private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String, animeId: String?): MutableList<SEpisode> = episodes.map { episode ->
         SEpisode.create().apply {
             date_upload = episode.createdAt.let { DATE_FORMATTER.tryParse(it) }
             val session = episode.session
-            setUrlWithoutDomain("/play/$animeSession/$session")
+            setUrlWithoutDomain(animeId?.let { "/play/anime/$it/episode/${episode.episodeNumber}" } ?: "/play/$animeSession/$session")
             val epNum = episode.episodeNumber
             episode_number = epNum
             val epName = if (floor(epNum) == ceil(epNum)) {
@@ -305,14 +318,14 @@ class AnimePahe :
         }
     }.toMutableList()
 
-    private fun recursivePages(episodeList: MutableList<SEpisode>, response: Response, animeSession: String) {
+    private fun recursivePages(episodeList: MutableList<SEpisode>, response: Response, animeSession: String, animeId: String?) {
         val episodesData = response.parseAs<ResponseDto<EpisodeDto>>()
         val page = episodesData.currentPage
         val hasNextPage = page < episodesData.lastPage
-        episodeList.addAll(parseEpisodePage(episodesData.items, animeSession))
+        episodeList.addAll(parseEpisodePage(episodesData.items, animeSession, animeId))
         if (hasNextPage) {
             nextPageRequest(response.request.url.toString(), page + 1).use { nextPage ->
-                recursivePages(episodeList, nextPage, animeSession)
+                recursivePages(episodeList, nextPage, animeSession, animeId)
             }
         }
     }
@@ -323,6 +336,17 @@ class AnimePahe :
     }
 
     // ============================ Video Links =============================
+
+    override fun videoListRequest(episode: SEpisode): Request {
+        val stableEpisode = stableEpisodeRegex.find(episode.url)
+            ?: return GET("$baseUrl${episode.url}")
+
+        val animeId = stableEpisode.groupValues[1]
+        val episodeNumber = stableEpisode.groupValues[2].toFloat()
+        val animeSession = fetchSession(animeId)
+        val episodeSession = fetchEpisodeSession(animeSession, episodeNumber)
+        return GET("$baseUrl/play/$animeSession/$episodeSession")
+    }
 
     override fun videoListParse(response: Response): List<Video> {
         val document = response.useAsJsoup()
@@ -441,6 +465,24 @@ class AnimePahe :
             it.request.url.pathSegments.last()
         }
         return sessionId
+    }
+
+    private fun fetchEpisodeSession(animeSession: String, episodeNumber: Float): String {
+        var page = 1
+        while (true) {
+            val request = GET("$baseUrl/api?m=release&id=$animeSession&sort=episode_asc&page=$page")
+            val episodesData = client.newCall(request).execute().use { response ->
+                response.parseAs<ResponseDto<EpisodeDto>>()
+            }
+
+            episodesData.items.firstOrNull { abs(it.episodeNumber - episodeNumber) < 0.001f }
+                ?.let { return it.session }
+
+            if (page >= episodesData.lastPage) break
+            page++
+        }
+
+        throw IllegalStateException("Episode session not found")
     }
 
     private fun parseStatus(statusString: String?): Int = when (statusString) {

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -396,14 +396,10 @@ class AnimePahe :
         return this.sortedWith(
             compareByDescending<Video> { it.quality.contains(preferredQuality) }
                 .thenByDescending {
-                    val quality = it.quality.lowercase()
-                    when {
-                        quality.contains("1080") -> 1080
-                        quality.contains("720") -> 720
-                        quality.contains("480") -> 480
-                        quality.contains("360") -> 360
-                        else -> 0
-                    }
+                    val quality = it.quality
+                    QUALITY_REGEX_P.find(quality)?.groupValues?.get(1)?.toIntOrNull()
+                        ?: QUALITY_REGEX.find(quality)?.groupValues?.get(1)?.toIntOrNull()
+                        ?: 0
                 }
                 .thenByDescending {
                     val quality = it.quality.lowercase()
@@ -429,14 +425,6 @@ class AnimePahe :
     // ============================== Settings ==============================
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         screen.addListPreference(
-            key = PREF_QUALITY_KEY,
-            title = PREF_QUALITY_TITLE,
-            entries = PREF_QUALITY_ENTRIES,
-            entryValues = PREF_QUALITY_ENTRIES,
-            default = PREF_QUALITY_DEFAULT,
-            summary = "%s",
-        )
-        screen.addListPreference(
             key = PREF_DOMAIN_KEY,
             title = PREF_DOMAIN_TITLE,
             entries = PREF_DOMAIN_ENTRIES,
@@ -444,6 +432,14 @@ class AnimePahe :
             default = PREF_DOMAIN_DEFAULT,
             summary = "%s",
             restartRequired = true,
+        )
+        screen.addListPreference(
+            key = PREF_QUALITY_KEY,
+            title = PREF_QUALITY_TITLE,
+            entries = PREF_QUALITY_ENTRIES,
+            entryValues = PREF_QUALITY_ENTRIES,
+            default = PREF_QUALITY_DEFAULT,
+            summary = "%s",
         )
         screen.addListPreference(
             key = PREF_SUB_KEY,
@@ -545,13 +541,16 @@ class AnimePahe :
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
         }
 
+        private val QUALITY_REGEX_P by lazy { Regex("""(\d+)p""") }
+        private val QUALITY_REGEX by lazy { Regex("""(\d+)""") }
+
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_TITLE = "Preferred Quality"
         private const val PREF_QUALITY_DEFAULT = "1080p"
         private val PREF_QUALITY_ENTRIES = listOf("1080p", "720p", "360p")
 
         private const val PREF_DOMAIN_KEY = "preferred_domain"
-        private const val PREF_DOMAIN_TITLE = "Preferred Domain (requires app restart)"
+        private const val PREF_DOMAIN_TITLE = "Preferred Domain (Requires App Restart)"
         private val PREF_DOMAIN_ENTRIES = listOf(
             "animepahe.pw",
             "animepahe.com",

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
+import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.EpisodeDto
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.LatestAnimeDto
@@ -291,12 +292,18 @@ class AnimePahe :
         val animeId = url.queryParameter("anime_id")
         val episodeList = mutableListOf<SEpisode>()
         recursivePages(episodeList, response, session, animeId)
+        val showSiteEpisodeNumber = preferences.getBoolean(PREF_SHOW_SITE_NUMBER_KEY, PREF_SHOW_SITE_NUMBER_DEFAULT)
 
         return episodeList
             .mapIndexed { index, episode ->
+                val siteEpisodeNumber = episode.name.removePrefix("Episode ")
                 episode.apply {
                     episode_number = (index + 1).toFloat()
-                    name = "Episode ${index + 1}"
+                    name = if (showSiteEpisodeNumber && siteEpisodeNumber != (index + 1).toString()) {
+                        "Episode ${index + 1} ($siteEpisodeNumber)"
+                    } else {
+                        "Episode ${index + 1}"
+                    }
                 }
             }
             .reversed()
@@ -382,17 +389,29 @@ class AnimePahe :
 
     override fun List<Video>.sort(): List<Video> {
         val subPreference = preferences.getString(PREF_SUB_KEY, PREF_SUB_DEFAULT)!!
-        val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
+        val preferredQuality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
         val shouldBeAv1 = preferences.getBoolean(PREF_AV1_KEY, PREF_AV1_DEFAULT)
         val shouldEndWithEng = subPreference == "eng"
 
         return this.sortedWith(
-            compareBy(
-                { it.quality.contains(quality) },
-                { Regex("""\beng\b""").containsMatchIn(it.quality.lowercase()) == shouldEndWithEng },
-                { it.quality.lowercase().contains("av1") == shouldBeAv1 },
-            ),
-        ).reversed()
+            compareByDescending<Video> { it.quality.contains(preferredQuality) }
+                .thenByDescending {
+                    val quality = it.quality.lowercase()
+                    when {
+                        quality.contains("1080") -> 1080
+                        quality.contains("720") -> 720
+                        quality.contains("480") -> 480
+                        quality.contains("360") -> 360
+                        else -> 0
+                    }
+                }
+                .thenByDescending {
+                    val quality = it.quality.lowercase()
+                    val isDub = quality.contains("eng") || quality.contains("dub")
+                    if (shouldEndWithEng) isDub else !isDub
+                }
+                .thenByDescending { it.quality.lowercase().contains("av1") == shouldBeAv1 },
+        )
     }
 
     // ============================== Filters ===============================
@@ -435,6 +454,12 @@ class AnimePahe :
             summary = "%s",
         )
         screen.addSwitchPreference(
+            key = PREF_SHOW_SITE_NUMBER_KEY,
+            title = PREF_SHOW_SITE_NUMBER_TITLE,
+            summary = PREF_SHOW_SITE_NUMBER_SUMMARY,
+            default = PREF_SHOW_SITE_NUMBER_DEFAULT,
+        )
+        screen.addSwitchPreference(
             key = PREF_LINK_TYPE_KEY,
             title = PREF_LINK_TYPE_TITLE,
             summary = PREF_LINK_TYPE_SUMMARY,
@@ -451,6 +476,14 @@ class AnimePahe :
             title = PREF_CF_UA_TITLE,
             summary = PREF_CF_UA_SUMMARY,
             default = PREF_CF_UA_DEFAULT,
+            onChange = { preference, newValue ->
+                if (newValue.isBlank()) {
+                    (preference as EditTextPreference).text = PREF_CF_UA_DEFAULT
+                    false
+                } else {
+                    true
+                }
+            },
         )
     }
 
@@ -498,10 +531,14 @@ class AnimePahe :
         ?: oldAnimeIdRegex.find(url)?.let { it.groupValues[1] }
 
     private val cfBypassUserAgent: String
-        get() = preferences.getString(PREF_CF_UA_KEY, PREF_CF_UA_DEFAULT)
-            ?.trim()
-            .takeIf { !it.isNullOrBlank() }
-            ?: PREF_CF_UA_DEFAULT
+        get() {
+            val stored = preferences.getString(PREF_CF_UA_KEY, PREF_CF_UA_DEFAULT)
+            return if (stored.isNullOrBlank()) {
+                PREF_CF_UA_DEFAULT
+            } else {
+                stored.trim()
+            }
+        }
 
     companion object {
         private val DATE_FORMATTER by lazy {
@@ -509,12 +546,12 @@ class AnimePahe :
         }
 
         private const val PREF_QUALITY_KEY = "preferred_quality"
-        private const val PREF_QUALITY_TITLE = "Preferred quality"
+        private const val PREF_QUALITY_TITLE = "Preferred Quality"
         private const val PREF_QUALITY_DEFAULT = "1080p"
         private val PREF_QUALITY_ENTRIES = listOf("1080p", "720p", "360p")
 
         private const val PREF_DOMAIN_KEY = "preferred_domain"
-        private const val PREF_DOMAIN_TITLE = "Preferred domain (requires app restart)"
+        private const val PREF_DOMAIN_TITLE = "Preferred Domain (requires app restart)"
         private val PREF_DOMAIN_ENTRIES = listOf(
             "animepahe.pw",
             "animepahe.com",
@@ -524,31 +561,36 @@ class AnimePahe :
         private val PREF_DOMAIN_DEFAULT = PREF_DOMAIN_VALUES.first()
 
         private const val PREF_SUB_KEY = "preferred_sub"
-        private const val PREF_SUB_TITLE = "Prefer subs or dubs?"
+        private const val PREF_SUB_TITLE = "Preferred Type"
         private const val PREF_SUB_DEFAULT = "jpn"
-        private val PREF_SUB_ENTRIES = listOf("sub", "dub")
+        private val PREF_SUB_ENTRIES = listOf("Sub", "Dub")
         private val PREF_SUB_VALUES = listOf("jpn", "eng")
 
         private const val PREF_LINK_TYPE_KEY = "preferred_link_type"
-        private const val PREF_LINK_TYPE_TITLE = "Use HLS links"
+        private const val PREF_LINK_TYPE_TITLE = "Use HLS Links"
         private const val PREF_LINK_TYPE_DEFAULT = true
         private val PREF_LINK_TYPE_SUMMARY = """Enable this if you are having Cloudflare issues.
-            |Note that this will break the ability to seek inside of the video unless the episode is downloaded in advance.
         """.trimMargin()
 
         // Big slap to whoever misspelled `preferred`
         private const val PREF_AV1_KEY = "preferred_av1"
-        private const val PREF_AV1_TITLE = "Use AV1 codec"
+        private const val PREF_AV1_TITLE = "Use AV1 Codec"
         private const val PREF_AV1_DEFAULT = false
         private val PREF_AV1_SUMMARY = """Enable to use AV1 if available
             |Turn off to never select av1 as preferred codec
         """.trimMargin()
+
+        private const val PREF_SHOW_SITE_NUMBER_KEY = "pref_show_site_number"
+        private const val PREF_SHOW_SITE_NUMBER_TITLE = "Show Site Episode Number"
+        private const val PREF_SHOW_SITE_NUMBER_DEFAULT = false
+        private const val PREF_SHOW_SITE_NUMBER_SUMMARY = "Show the actual episode number from the site in the episode title"
+
         const val UA = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36"
         private const val PREF_CF_UA_KEY = "cf_bypass_ua"
         private const val PREF_CF_UA_TITLE = "Custom User-Agent"
         private const val PREF_CF_UA_DEFAULT = UA
         private val PREF_CF_UA_SUMMARY = """Custom User-Agent string for the Cloudflare WebView bypass.
-            |Leave blank to use the default.
+            |Leave blank to revert to the default.
         """.trimMargin()
     }
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -338,11 +338,11 @@ class AnimePahe :
         val cfUA = cfBypassUserAgent // Get the custom UA once
 
         val videos = if (!useHLS) {
-            links.parallelCatchingFlatMapBlocking { (_, paheWinLink, quality) ->
+            val mp4Videos = links.parallelCatchingFlatMapBlocking { (_, paheWinLink, quality) ->
                 if (paheWinLink.isNullOrBlank()) return@parallelCatchingFlatMapBlocking emptyList()
-                KwikExtractor(client, headers, cfUA).getStreamVideo(paheWinLink, quality)
-                    .let(::listOf)
+                KwikExtractor(client, headers, cfUA).getStreamVideo(paheWinLink, quality).let(::listOf)
             }
+            AnimePaheHlsServer.processMp4VideoList(client, mp4Videos)
         } else {
             emptyList()
         }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -47,6 +47,15 @@ class AnimePahe :
         .addInterceptor(interceptor)
         .build()
 
+    private val extractorClient by lazy {
+        network.client.newBuilder().apply {
+            interceptors().clear()
+            networkInterceptors().clear()
+        }.build()
+    }
+
+    private val hlsServer by lazy { AnimePaheHlsServer(extractorClient) }
+
     override val name = "AnimePahe"
 
     override val baseUrl by lazy {
@@ -342,10 +351,11 @@ class AnimePahe :
         }
 
         return videos.ifEmpty {
-            links.parallelCatchingFlatMapBlocking { (kwikLink, _, quality) ->
-                KwikExtractor(client, headers, cfUA).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
+            val hlsVideos = links.parallelCatchingFlatMapBlocking { (kwikLink, _, quality) ->
+                KwikExtractor(extractorClient, headers, cfUA).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
                     .let(::listOf)
             }
+            hlsServer.processVideoList(hlsVideos)
         }
     }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -48,13 +48,10 @@ class AnimePahe :
         .build()
 
     private val extractorClient by lazy {
-        network.client.newBuilder().apply {
-            interceptors().clear()
-            networkInterceptors().clear()
+        client.newBuilder().apply {
+            interceptors().removeAll { it is DdosGuardInterceptor }
         }.build()
     }
-
-    private val hlsServer by lazy { AnimePaheHlsServer(extractorClient) }
 
     override val name = "AnimePahe"
 
@@ -355,7 +352,7 @@ class AnimePahe :
                 KwikExtractor(extractorClient, headers, cfUA).getHlsVideo(kwikLink, referer = "$baseUrl/", quality = "$quality (HLS)")
                     .let(::listOf)
             }
-            hlsServer.processVideoList(hlsVideos)
+            AnimePaheHlsServer.processVideoList(extractorClient, hlsVideos)
         }
     }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
@@ -1,0 +1,261 @@
+package eu.kanade.tachiyomi.animeextension.en.animepahe
+
+import eu.kanade.tachiyomi.animesource.model.Video
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.nanohttpd.protocols.http.IHTTPSession
+import org.nanohttpd.protocols.http.NanoHTTPD
+import org.nanohttpd.protocols.http.response.Response
+import org.nanohttpd.protocols.http.response.Response.newChunkedResponse
+import org.nanohttpd.protocols.http.response.Response.newFixedLengthResponse
+import org.nanohttpd.protocols.http.response.Status
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.net.URLEncoder
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class AnimePaheHlsServer(
+    private val client: OkHttpClient,
+    port: Int = 0,
+) : NanoHTTPD(port) {
+
+    val port: Int
+        get() = super.getListeningPort()
+
+    @Volatile
+    private var isRunning = false
+
+    private val hlsAttributeRegex = Regex("""([A-Z0-9-]+)=("[^"]*"|[^,]*)""")
+
+    private data class HlsKey(val url: String, val iv: String?)
+
+    override fun start() {
+        super.start()
+        isRunning = true
+    }
+
+    override fun stop() {
+        super.stop()
+        isRunning = false
+    }
+
+    fun processVideoList(videos: List<Video>): List<Video> {
+        ensureStarted()
+        return videos.map { video ->
+            if (video.url.contains(".m3u8", ignoreCase = true)) {
+                video.copyWithLocalUrl(createLocalM3u8Url(video.url))
+            } else {
+                video
+            }
+        }
+    }
+
+    override fun handle(session: IHTTPSession): Response = when {
+        session.uri.startsWith("/m3u8") -> handleM3u8Request(session)
+        session.uri.startsWith("/segment") -> handleSegmentRequest(session)
+        else -> newFixedLengthResponse(Status.NOT_FOUND, MIME_PLAINTEXT, "Not Found")
+    }
+
+    private fun handleM3u8Request(session: IHTTPSession): Response {
+        val url = session.parameters["url"]?.first()
+            ?: return newFixedLengthResponse(Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing url parameter")
+
+        return try {
+            val content = runBlocking {
+                val headers = extractHeadersFromSession(session)
+                val playlist = fetchString(url, headers)
+                rewritePlaylist(playlist, url)
+            }
+            newFixedLengthResponse(Status.OK, "application/vnd.apple.mpegurl", content)
+        } catch (e: Exception) {
+            newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
+        }
+    }
+
+    private fun handleSegmentRequest(session: IHTTPSession): Response {
+        val url = session.parameters["url"]?.first()
+            ?: return newFixedLengthResponse(Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing url parameter")
+
+        return try {
+            val data = runBlocking {
+                val headers = extractHeadersFromSession(session)
+                val keyUrl = session.parameters["key"]?.first()
+                val iv = session.parameters["iv"]?.first()
+                fetchSegment(url, headers, keyUrl, iv)
+            }
+            newChunkedResponse(Status.OK, "video/mp2t", ByteArrayInputStream(data))
+        } catch (e: Exception) {
+            newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
+        }
+    }
+
+    private fun ensureStarted() {
+        if (!isRunning) {
+            start()
+        }
+    }
+
+    private fun createLocalM3u8Url(m3u8Url: String): String {
+        val encodedUrl = URLEncoder.encode(m3u8Url, Charsets.UTF_8.name())
+        return "http://localhost:$port/m3u8?url=$encodedUrl"
+    }
+
+    private fun Video.copyWithLocalUrl(localUrl: String): Video = Video(
+        videoUrl = localUrl,
+        url = url,
+        quality = quality,
+        subtitleTracks = subtitleTracks,
+        audioTracks = audioTracks,
+        headers = headers,
+    )
+
+    private fun extractHeadersFromSession(session: IHTTPSession): Headers = Headers.Builder().apply {
+        session.headers.forEach { (key, value) ->
+            when (key.lowercase()) {
+                "user-agent", "referer", "origin", "accept", "accept-language",
+                "accept-encoding", "cache-control", "pragma",
+                -> add(key, value)
+            }
+        }
+    }.build()
+
+    private suspend fun fetchString(url: String, headers: Headers): String = withContext(Dispatchers.IO) {
+        client.newCall(Request.Builder().url(url).headers(headers).build()).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Failed to fetch playlist: ${response.code}")
+            }
+            response.body.string()
+        }
+    }
+
+    private suspend fun fetchSegment(
+        url: String,
+        headers: Headers,
+        keyUrl: String?,
+        iv: String?,
+    ): ByteArray = withContext(Dispatchers.IO) {
+        val rawData = fetchBytes(url, headers)
+        if (keyUrl.isNullOrBlank()) {
+            rawData
+        } else {
+            val ivHex = iv ?: throw IOException("Missing AES-128 IV for encrypted segment")
+            decryptAes128Cbc(rawData, fetchBytes(keyUrl, headers), ivHex)
+        }
+    }
+
+    private suspend fun fetchBytes(url: String, headers: Headers): ByteArray = withContext(Dispatchers.IO) {
+        client.newCall(Request.Builder().url(url).headers(headers).build()).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Failed to fetch resource: ${response.code}")
+            }
+            response.body.bytes()
+        }
+    }
+
+    private fun rewritePlaylist(content: String, originalUrl: String): String {
+        val baseHttpUrl = originalUrl.toHttpUrlOrNull()
+        val modifiedLines = mutableListOf<String>()
+        var mediaSequence = 0L
+        var segmentSequence = mediaSequence
+        var currentKey: HlsKey? = null
+
+        content.lines().forEach { line ->
+            when {
+                line.startsWith("#EXT-X-MEDIA-SEQUENCE:") -> {
+                    mediaSequence = line.substringAfter(":").trim().toLongOrNull() ?: mediaSequence
+                    segmentSequence = mediaSequence
+                    modifiedLines.add(line)
+                }
+                line.startsWith("#EXT-X-KEY:") -> {
+                    val attributes = parseHlsAttributes(line)
+                    when (attributes["METHOD"]?.uppercase()) {
+                        "AES-128" -> {
+                            val keyUri = attributes["URI"]
+                            if (keyUri.isNullOrBlank()) {
+                                currentKey = null
+                                modifiedLines.add(line)
+                            } else {
+                                currentKey = HlsKey(
+                                    url = resolveHlsUrl(baseHttpUrl, keyUri),
+                                    iv = attributes["IV"]?.normalizeHlsIv(),
+                                )
+                            }
+                        }
+                        "NONE" -> {
+                            currentKey = null
+                            modifiedLines.add(line)
+                        }
+                        else -> {
+                            currentKey = null
+                            modifiedLines.add(line)
+                        }
+                    }
+                }
+                line.startsWith("#") || line.isBlank() -> modifiedLines.add(line)
+                else -> {
+                    val segmentUrl = resolveHlsUrl(baseHttpUrl, line)
+                    modifiedLines.add(createLocalSegmentUrl(segmentUrl, currentKey, segmentSequence))
+                    segmentSequence++
+                }
+            }
+        }
+
+        return modifiedLines.joinToString("\n")
+    }
+
+    private fun parseHlsAttributes(line: String): Map<String, String> = hlsAttributeRegex.findAll(line.substringAfter(":")).associate {
+        it.groupValues[1] to it.groupValues[2].trim('"')
+    }
+
+    private fun resolveHlsUrl(baseHttpUrl: HttpUrl?, uri: String): String = baseHttpUrl?.resolve(uri)?.toString() ?: uri
+
+    private fun createLocalSegmentUrl(segmentUrl: String, key: HlsKey?, sequence: Long): String {
+        val encodedUrl = URLEncoder.encode(segmentUrl, Charsets.UTF_8.name())
+        return buildString {
+            append("http://localhost:$port/segment?url=$encodedUrl")
+            if (key != null) {
+                append("&key=")
+                append(URLEncoder.encode(key.url, Charsets.UTF_8.name()))
+                append("&iv=")
+                append(URLEncoder.encode(key.iv ?: sequence.toHlsIv(), Charsets.UTF_8.name()))
+            }
+        }
+    }
+
+    private fun decryptAes128Cbc(data: ByteArray, key: ByteArray, iv: String): ByteArray {
+        if (key.size != 16) {
+            throw IOException("Invalid AES-128 key length: ${key.size}")
+        }
+
+        val normalizedIv = iv.normalizeHlsIv()
+        if (normalizedIv.length != 32) {
+            throw IOException("Invalid AES-128 IV length: ${normalizedIv.length}")
+        }
+
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            SecretKeySpec(key, "AES"),
+            IvParameterSpec(normalizedIv.hexToByteArray()),
+        )
+        return cipher.doFinal(data)
+    }
+
+    private fun Long.toHlsIv(): String = toString(16).padStart(32, '0')
+
+    private fun String.normalizeHlsIv(): String = removePrefix("0x")
+        .removePrefix("0X")
+        .padStart(32, '0')
+
+    private fun String.hexToByteArray(): ByteArray = ByteArray(length / 2) { index ->
+        substring(index * 2, index * 2 + 2).toInt(16).toByte()
+    }
+}

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
@@ -1,37 +1,31 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
 import eu.kanade.tachiyomi.animesource.model.Video
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import fi.iki.elonen.NanoHTTPD
+import fi.iki.elonen.NanoHTTPD.Response.Status
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.nanohttpd.protocols.http.IHTTPSession
-import org.nanohttpd.protocols.http.NanoHTTPD
-import org.nanohttpd.protocols.http.response.Response
-import org.nanohttpd.protocols.http.response.Response.newChunkedResponse
-import org.nanohttpd.protocols.http.response.Response.newFixedLengthResponse
-import org.nanohttpd.protocols.http.response.Status
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.net.URLEncoder
+import java.security.GeneralSecurityException
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-class AnimePaheHlsServer(
-    private val client: OkHttpClient,
-    port: Int = 0,
-) : NanoHTTPD(port) {
+object AnimePaheHlsServer : NanoHTTPD(0) {
 
     val port: Int
         get() = super.getListeningPort()
 
     @Volatile
     private var isRunning = false
+
+    @Volatile
+    private var client: OkHttpClient? = null
 
     private val hlsAttributeRegex = Regex("""([A-Z0-9-]+)=("[^"]*"|[^,]*)""")
 
@@ -47,7 +41,8 @@ class AnimePaheHlsServer(
         isRunning = false
     }
 
-    fun processVideoList(videos: List<Video>): List<Video> {
+    fun processVideoList(client: OkHttpClient, videos: List<Video>): List<Video> {
+        this.client = client
         ensureStarted()
         return videos.map { video ->
             if (video.url.contains(".m3u8", ignoreCase = true)) {
@@ -58,7 +53,7 @@ class AnimePaheHlsServer(
         }
     }
 
-    override fun handle(session: IHTTPSession): Response = when {
+    override fun serve(session: IHTTPSession): Response = when {
         session.uri.startsWith("/m3u8") -> handleM3u8Request(session)
         session.uri.startsWith("/segment") -> handleSegmentRequest(session)
         else -> newFixedLengthResponse(Status.NOT_FOUND, MIME_PLAINTEXT, "Not Found")
@@ -69,11 +64,9 @@ class AnimePaheHlsServer(
             ?: return newFixedLengthResponse(Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing url parameter")
 
         return try {
-            val content = runBlocking {
-                val headers = extractHeadersFromSession(session)
-                val playlist = fetchString(url, headers)
-                rewritePlaylist(playlist, url)
-            }
+            val headers = extractHeadersFromSession(session)
+            val playlist = fetchString(url, headers)
+            val content = rewritePlaylist(playlist, url)
             newFixedLengthResponse(Status.OK, "application/vnd.apple.mpegurl", content)
         } catch (e: Exception) {
             newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
@@ -85,18 +78,17 @@ class AnimePaheHlsServer(
             ?: return newFixedLengthResponse(Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing url parameter")
 
         return try {
-            val data = runBlocking {
-                val headers = extractHeadersFromSession(session)
-                val keyUrl = session.parameters["key"]?.first()
-                val iv = session.parameters["iv"]?.first()
-                fetchSegment(url, headers, keyUrl, iv)
-            }
+            val headers = extractHeadersFromSession(session)
+            val keyUrl = session.parameters["key"]?.first()
+            val iv = session.parameters["iv"]?.first()
+            val data = fetchSegment(url, headers, keyUrl, iv)
             newChunkedResponse(Status.OK, "video/mp2t", ByteArrayInputStream(data))
         } catch (e: Exception) {
             newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
         }
     }
 
+    @Synchronized
     private fun ensureStarted() {
         if (!isRunning) {
             start()
@@ -127,23 +119,21 @@ class AnimePaheHlsServer(
         }
     }.build()
 
-    private suspend fun fetchString(url: String, headers: Headers): String = withContext(Dispatchers.IO) {
-        client.newCall(Request.Builder().url(url).headers(headers).build()).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IOException("Failed to fetch playlist: ${response.code}")
-            }
-            response.body.string()
+    private fun fetchString(url: String, headers: Headers): String = requireClient().newCall(Request.Builder().url(url).headers(headers).build()).execute().use { response ->
+        if (!response.isSuccessful) {
+            throw IOException("Failed to fetch playlist: ${response.code}")
         }
+        response.body.string()
     }
 
-    private suspend fun fetchSegment(
+    private fun fetchSegment(
         url: String,
         headers: Headers,
         keyUrl: String?,
         iv: String?,
-    ): ByteArray = withContext(Dispatchers.IO) {
+    ): ByteArray {
         val rawData = fetchBytes(url, headers)
-        if (keyUrl.isNullOrBlank()) {
+        return if (keyUrl.isNullOrBlank()) {
             rawData
         } else {
             val ivHex = iv ?: throw IOException("Missing AES-128 IV for encrypted segment")
@@ -151,14 +141,14 @@ class AnimePaheHlsServer(
         }
     }
 
-    private suspend fun fetchBytes(url: String, headers: Headers): ByteArray = withContext(Dispatchers.IO) {
-        client.newCall(Request.Builder().url(url).headers(headers).build()).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IOException("Failed to fetch resource: ${response.code}")
-            }
-            response.body.bytes()
+    private fun fetchBytes(url: String, headers: Headers): ByteArray = requireClient().newCall(Request.Builder().url(url).headers(headers).build()).execute().use { response ->
+        if (!response.isSuccessful) {
+            throw IOException("Failed to fetch resource: ${response.code}")
         }
+        response.body.bytes()
     }
+
+    private fun requireClient(): OkHttpClient = client ?: throw IOException("AnimePahe HLS server is not initialized")
 
     private fun rewritePlaylist(content: String, originalUrl: String): String {
         val baseHttpUrl = originalUrl.toHttpUrlOrNull()
@@ -201,9 +191,13 @@ class AnimePaheHlsServer(
                 }
                 line.startsWith("#") || line.isBlank() -> modifiedLines.add(line)
                 else -> {
-                    val segmentUrl = resolveHlsUrl(baseHttpUrl, line)
-                    modifiedLines.add(createLocalSegmentUrl(segmentUrl, currentKey, segmentSequence))
-                    segmentSequence++
+                    val resolvedUrl = resolveHlsUrl(baseHttpUrl, line)
+                    if (resolvedUrl.contains(".m3u8", ignoreCase = true)) {
+                        modifiedLines.add(createLocalM3u8Url(resolvedUrl))
+                    } else {
+                        modifiedLines.add(createLocalSegmentUrl(resolvedUrl, currentKey, segmentSequence))
+                        segmentSequence++
+                    }
                 }
             }
         }
@@ -240,13 +234,19 @@ class AnimePaheHlsServer(
             throw IOException("Invalid AES-128 IV length: ${normalizedIv.length}")
         }
 
-        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
-        cipher.init(
-            Cipher.DECRYPT_MODE,
-            SecretKeySpec(key, "AES"),
-            IvParameterSpec(normalizedIv.hexToByteArray()),
-        )
-        return cipher.doFinal(data)
+        return try {
+            val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                SecretKeySpec(key, "AES"),
+                IvParameterSpec(normalizedIv.hexToByteArray()),
+            )
+            cipher.doFinal(data)
+        } catch (e: GeneralSecurityException) {
+            throw IOException("Failed to decrypt AES-128 segment", e)
+        } catch (e: NumberFormatException) {
+            throw IOException("Invalid AES-128 IV", e)
+        }
     }
 
     private fun Long.toHlsIv(): String = toString(16).padStart(32, '0')

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
@@ -9,9 +9,11 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.ByteArrayInputStream
+import java.io.FilterInputStream
 import java.io.IOException
 import java.net.URLEncoder
 import java.security.GeneralSecurityException
+import java.util.concurrent.ConcurrentHashMap
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -26,6 +28,11 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
 
     @Volatile
     private var client: OkHttpClient? = null
+
+    @Volatile
+    private var mp4Client: OkHttpClient? = null
+
+    private val mp4Headers = ConcurrentHashMap<String, Headers>()
 
     private val hlsAttributeRegex = Regex("""([A-Z0-9-]+)=("[^"]*"|[^,]*)""")
 
@@ -53,9 +60,20 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
         }
     }
 
+    fun processMp4VideoList(client: OkHttpClient, videos: List<Video>): List<Video> {
+        mp4Client = client
+        ensureStarted()
+        return videos.map { video ->
+            val localUrl = createLocalMp4Url(video.url)
+            mp4Headers[video.url] = video.headers ?: Headers.Builder().build()
+            video.copyWithLocalMp4Url(localUrl)
+        }
+    }
+
     override fun serve(session: IHTTPSession): Response = when {
         session.uri.startsWith("/m3u8") -> handleM3u8Request(session)
         session.uri.startsWith("/segment") -> handleSegmentRequest(session)
+        session.uri.startsWith("/mp4") -> handleMp4Request(session)
         else -> newFixedLengthResponse(Status.NOT_FOUND, MIME_PLAINTEXT, "Not Found")
     }
 
@@ -88,6 +106,40 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
         }
     }
 
+    private fun handleMp4Request(session: IHTTPSession): Response {
+        val url = session.parameters["url"]?.first()
+            ?: return newFixedLengthResponse(Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing url parameter")
+
+        return try {
+            val upstream = fetchMp4(url, session)
+            val body = upstream.body
+            val contentLength = upstream.header("Content-Length")?.toLongOrNull() ?: -1L
+            val contentType = upstream.header("Content-Type") ?: "video/mp4"
+            val status = Status.lookup(upstream.code) ?: Status.OK
+            val stream = object : FilterInputStream(body.byteStream()) {
+                override fun close() {
+                    try {
+                        super.close()
+                    } finally {
+                        upstream.close()
+                    }
+                }
+            }
+
+            val localResponse = if (contentLength >= 0) {
+                newFixedLengthResponse(status, contentType, stream, contentLength)
+            } else {
+                newChunkedResponse(status, contentType, stream)
+            }
+            localResponse.apply {
+                upstream.header("Accept-Ranges")?.let { addHeader("Accept-Ranges", it) }
+                upstream.header("Content-Range")?.let { addHeader("Content-Range", it) }
+            }
+        } catch (e: Exception) {
+            newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
+        }
+    }
+
     @Synchronized
     private fun ensureStarted() {
         if (!isRunning) {
@@ -100,9 +152,23 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
         return "http://localhost:$port/m3u8?url=$encodedUrl"
     }
 
+    private fun createLocalMp4Url(mp4Url: String): String {
+        val encodedUrl = URLEncoder.encode(mp4Url, Charsets.UTF_8.name())
+        return "http://localhost:$port/mp4?url=$encodedUrl"
+    }
+
     private fun Video.copyWithLocalUrl(localUrl: String): Video = Video(
         videoUrl = localUrl,
         url = url,
+        quality = quality,
+        subtitleTracks = subtitleTracks,
+        audioTracks = audioTracks,
+        headers = headers,
+    )
+
+    private fun Video.copyWithLocalMp4Url(localUrl: String): Video = Video(
+        videoUrl = localUrl,
+        url = localUrl,
         quality = quality,
         subtitleTracks = subtitleTracks,
         audioTracks = audioTracks,
@@ -118,6 +184,25 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
             }
         }
     }.build()
+
+    private fun fetchMp4(url: String, session: IHTTPSession): okhttp3.Response {
+        val headers = Headers.Builder().apply {
+            mp4Headers[url]?.let { sourceHeaders ->
+                for (index in 0 until sourceHeaders.size) {
+                    add(sourceHeaders.name(index), sourceHeaders.value(index))
+                }
+            }
+            session.headers["range"]?.let { set("Range", it) }
+        }.build()
+
+        val response = requireMp4Client().newCall(Request.Builder().url(url).headers(headers).build()).execute()
+        if (!response.isSuccessful) {
+            val code = response.code
+            response.close()
+            throw IOException("Failed to fetch MP4: $code")
+        }
+        return response
+    }
 
     private fun fetchString(url: String, headers: Headers): String = requireClient().newCall(Request.Builder().url(url).headers(headers).build()).execute().use { response ->
         if (!response.isSuccessful) {
@@ -149,6 +234,8 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
     }
 
     private fun requireClient(): OkHttpClient = client ?: throw IOException("AnimePahe HLS server is not initialized")
+
+    private fun requireMp4Client(): OkHttpClient = mp4Client ?: throw IOException("AnimePahe MP4 server is not initialized")
 
     private fun rewritePlaylist(content: String, originalUrl: String): String {
         val baseHttpUrl = originalUrl.toHttpUrlOrNull()

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/Filters.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/Filters.kt
@@ -111,7 +111,7 @@ object Filters {
 
     class YearFilter :
         UriPartFilter(
-            "Browse by Season",
+            "Browse by Year",
             YEARS,
         ) {
         companion object {

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -41,6 +41,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 
 data class KwikContent(val cookies: String, val html: String, val finalUrl: String)
+private data class HlsStream(val url: String, val referer: String)
 
 class KwikExtractor(
     private val client: OkHttpClient,
@@ -68,26 +69,34 @@ class KwikExtractor(
     }
 
     suspend fun getHlsVideo(kwikUrl: String, referer: String, quality: String = ""): Video {
-        val videoUrl = getHlsStreamUrl(kwikUrl, referer)
+        val hlsStream = getHlsStream(kwikUrl, referer)
 
         return Video(
-            videoUrl,
+            hlsStream.url,
             quality,
-            videoUrl,
-            headers = kwikHeaders,
+            hlsStream.url,
+            headers = kwikHeaders.newBuilder()
+                .set("Referer", hlsStream.referer)
+                .build(),
         )
     }
 
-    suspend fun getHlsStreamUrl(kwikUrl: String, referer: String): String {
-        val eContent = client.newCall(GET(kwikUrl, headers.newBuilder().set("Referer", referer).build()))
-            .awaitSuccess().useAsJsoup()
-        val script = eContent.selectFirst("script:containsData(eval\\(function)")?.data()
-            ?.substringAfterLast("eval(function(")
-            ?: throw KwikException.ExtractionException("JsUnpacker not found.")
-        val unpacked = JsUnpacker.unpackAndCombine("eval(function($script")
-            ?: throw KwikException.ExtractionException("JsUnpacker failed to unpack Kwik script.")
-        return unpacked.substringAfter("const source=\\'").substringBefore("\\';")
-    }
+    suspend fun getHlsStreamUrl(kwikUrl: String, referer: String): String = getHlsStream(kwikUrl, referer).url
+
+    private suspend fun getHlsStream(kwikUrl: String, referer: String): HlsStream = client.newCall(GET(kwikUrl, headers.newBuilder().set("Referer", referer).build()))
+        .awaitSuccess().use { response ->
+            val finalUrl = response.request.url.toString()
+            val eContent = response.useAsJsoup()
+            val script = eContent.selectFirst("script:containsData(eval\\(function)")?.data()
+                ?.substringAfterLast("eval(function(")
+                ?: throw KwikException.ExtractionException("JsUnpacker not found.")
+            val unpacked = JsUnpacker.unpackAndCombine("eval(function($script")
+                ?: throw KwikException.ExtractionException("JsUnpacker failed to unpack Kwik script.")
+            HlsStream(
+                url = unpacked.substringAfter("const source=\\'").substringBefore("\\';"),
+                referer = finalUrl,
+            )
+        }
 
     suspend fun getStreamVideo(paheUrl: String, quality: String = ""): Video {
         val videoUrl = getStreamUrlFromKwik(paheUrl)

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -35,6 +35,7 @@ import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.lib.jsunpacker.JsUnpacker
 import keiyoushi.utils.bodyString
 import keiyoushi.utils.useAsJsoup
+import okhttp3.CookieJar
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.OkHttpClient
@@ -52,10 +53,18 @@ class KwikExtractor(
     private val kwikDUrl by lazy { Regex("action=\"([^\"]+)\"") }
     private val kwikDToken by lazy { Regex("value=\"([^\"]+)\"") }
 
-    // Clone the base client so interceptors, cookie jars, logging, etc. are preserved,
+    // MP4 extraction runs qualities in parallel; use explicit per-response cookies
+    // so one Kwik page does not overwrite another page's session in the app jar.
+    private val cookieFreeClient by lazy {
+        client.newBuilder()
+            .cookieJar(CookieJar.NO_COOKIES)
+            .build()
+    }
+
+    // Clone the base client so interceptors, logging, etc. are preserved,
     // and only override redirect behavior.
     private val noRedirectClient by lazy {
-        client.newBuilder()
+        cookieFreeClient.newBuilder()
             .followRedirects(false)
             .followSslRedirects(false)
             .build()
@@ -135,7 +144,7 @@ class KwikExtractor(
         var kwikLocation: String? = null
         var code = 419
         var tries = 0
-        val tryLimit = 5
+        val tryLimit = 2
 
         while (code != 302 && tries < tryLimit) {
             tries++
@@ -153,7 +162,7 @@ class KwikExtractor(
             }
 
             // Cloudflare/Session Timeout Handling
-            if (code == 403 || code == 419) {
+            if ((code == 403 || code == 419) && tries < tryLimit) {
                 // Pass the custom User-Agent to the bypass
                 cloudFlareBypassResult = CloudflareBypass().getCookies(kwikUrl, cfBypassUserAgent)
                     ?: throw KwikException.CloudflareBlockedException("Cloudflare bypass failed to return result.")
@@ -185,10 +194,10 @@ class KwikExtractor(
                 }
                 .build()
 
-            // Use the base client directly so all interceptors are preserved.
+            // Use the cookie-free client so interceptors are preserved without sharing Kwik sessions.
             return try {
                 // try-catch the `Failed to bypass Cloudflare` exception
-                client.newCall(GET(kwikUrl, headers)).awaitSuccess().use { resp ->
+                cookieFreeClient.newCall(GET(kwikUrl, headers)).awaitSuccess().use { resp ->
                     val html = resp.bodyString()
                     if (html.contains("eval(function(")) {
                         val respCookies = resp.extractCookies()

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/extractor/KwikExtractor.kt
@@ -165,7 +165,7 @@ class KwikExtractor(
             if ((code == 403 || code == 419) && tries < tryLimit) {
                 // Pass the custom User-Agent to the bypass
                 cloudFlareBypassResult = CloudflareBypass().getCookies(kwikUrl, cfBypassUserAgent)
-                    ?: throw KwikException.CloudflareBlockedException("Cloudflare bypass failed to return result.")
+                    ?: throw KwikException.CloudflareBlockedException("Failed to bypass Kwik Cloudflare. Try opening a Kwik video in WebView manually.")
 
                 // Prevent stacking multiple cf_clearance cookies
                 val cleanedCookies = fContentCookies.split("; ")
@@ -176,7 +176,7 @@ class KwikExtractor(
             }
         }
 
-        return kwikLocation ?: throw KwikException.ExtractionException("Failed to extract stream URI after $tries attempts.")
+        return kwikLocation ?: throw KwikException.ExtractionException("Failed to extract Kwik stream URI after $tries attempts. Try bypassing Kwik Cloudflare in WebView.")
     }
 
     private suspend fun fetchKwikHtml(kwikUrl: String): KwikContent {
@@ -218,11 +218,11 @@ class KwikExtractor(
 
         // 2. Try Cloudflare Bypass (Always fresh) with the custom User-Agent
         val cfResult = CloudflareBypass().getCookies(kwikUrl, cfBypassUserAgent)
-            ?: throw KwikException.CloudflareBlockedException("Bypass returned null result.")
+            ?: throw KwikException.CloudflareBlockedException("Failed to bypass Kwik Cloudflare. Try opening a Kwik video in WebView manually.")
 
         attemptKwikFetch(cfResult)?.let { return it }
 
-        throw KwikException.CloudflareBlockedException("Cloudflare challenge not solved.")
+        throw KwikException.CloudflareBlockedException("Failed to bypass Kwik Cloudflare. Try opening a Kwik video in WebView manually.")
     }
 
     private fun Response.extractCookies(): String = headers("set-cookie").joinToString("; ") { it.substringBefore(";") }


### PR DESCRIPTION
Fixes #572, Closes #562, supersedes #568

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add a local NanoHTTPD-based HLS proxy server to support playback of encrypted HLS streams from AnimePahe and wire it into the AnimePahe extension.

New Features:
- Introduce AnimePaheHlsServer that proxies HLS playlists and TS segments locally, handling AES-128 decryption of encrypted segments.
- Add support in AnimePahe to rewrite HLS video URLs through the local HLS server for compatible streams.

Enhancements:
- Extend KwikExtractor to retain the final redirect URL as the HLS referer when extracting streams, ensuring correct headers for playback.
- Use a dedicated OkHttpClient without app interceptors for extraction requests in the AnimePahe extension.

Build:
- Bump the AnimePahe extension version code and add NanoHTTPD as a dependency for the new embedded HLS server.