### PR TITLE
Cineby [EN]: Update API Domains, Servers & Add Seed

### DIFF
--- a/src/en/cineby/build.gradle
+++ b/src/en/cineby/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cineby'
     extClass = '.Cineby'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -45,9 +45,9 @@ class Cineby :
         get() = preferences.domainPref
 
     // Cineby/Videasy proxy
-    private val apiUrl = "https://db.videasy.to/3"
+    private val apiUrl = "https://db.wingsdatabase.com/3"
 
-    private fun apiOrigin(url: String): String = url.replace(Regex("""https?://www\."""), "https://")
+    private fun apiOrigin(url: String): String = url.toHttpUrl().run { "$scheme://$host" }
 
     override val lang = "en"
     override val supportsLatest = true
@@ -617,7 +617,7 @@ class Cineby :
         private const val MIN_VOTES_FOR_RECENT_SORT = "50"
 
         private const val PREF_DOMAIN_KEY = "pref_domain"
-        private val DOMAIN_ENTRIES = arrayOf("www.cineby.at", "www.cineplay.to", "www.fmovies.nz")
+        private val DOMAIN_ENTRIES = arrayOf("www.cineby.at", "www.cineplay.to", "www.fmovies.gd")
         private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }
         private val PREF_DOMAIN_DEFAULT = DOMAIN_VALUES.first()
 
@@ -632,6 +632,6 @@ class Cineby :
 
         private const val PREF_SERVERS_KEY = "pref_servers_v2"
         private val PREF_SERVERS_DEFAULT =
-            setOf("Neon", "Yoru", "Cypher", "Sage")
+            setOf("Jett", "Neon", "Yoru", "Tejo")
     }
 }

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyDto.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyDto.kt
@@ -133,6 +133,11 @@ data class EpisodeDto(
     val airDate: String? = null,
 )
 
+@Serializable
+data class SeedDto(
+    val seed: String,
+)
+
 // ============================ Videasy Decryption ============================
 @Serializable
 data class VideasyDecryptionDto(

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -77,6 +77,10 @@ class CinebyExtractor(
             (!server.movieOnly || isMovie) && server.displayName in enabledServers
         }
 
+        if (eligibleServers.isEmpty()) {
+            return emptyList()
+        }
+
         // API headers use full domain (preserving www. if present)
         val apiOrigin = getOrigin(baseUrl, stripWww = false)
         val backendHeaders = headers.newBuilder()

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -53,9 +53,10 @@ class CinebyExtractor(
         val lastFailureAtMillis: Long,
     )
 
-    private fun apiOrigin(url: String): String = url
-        .removePrefix("https://www.").removePrefix("http://www.")
-        .let { if (it.startsWith("http")) it else "https://$it" }
+    private fun getOrigin(url: String, stripWww: Boolean = true): String {
+        val origin = url.toHttpUrl().run { "$scheme://$host" }
+        return if (stripWww) origin.replace("://www.", "://") else origin
+    }
 
     @RequiresApi(Build.VERSION_CODES.N)
     suspend fun videosFromUrl(
@@ -70,10 +71,22 @@ class CinebyExtractor(
     ): List<Video> {
         val pathParts = path.split("/")
         val isMovie = pathParts.first() == "movie"
+        val tmdbId = pathParts[1]
 
         val eligibleServers = VIDEASY_SERVERS.filter { server ->
             (!server.movieOnly || isMovie) && server.displayName in enabledServers
         }
+
+        // API headers use full domain (preserving www. if present)
+        val apiOrigin = getOrigin(baseUrl, stripWww = false)
+        val backendHeaders = headers.newBuilder()
+            .set("Referer", "$apiOrigin/")
+            .set("Origin", apiOrigin)
+            .build()
+
+        val seed = client.newCall(
+            GET("https://api.wingsdatabase.com/seed?mediaId=$tmdbId", backendHeaders),
+        ).awaitSuccess().parseAs<SeedDto>().seed
 
         val videoList = eligibleServers.parallelCatchingFlatMap { server ->
             val now = System.currentTimeMillis()
@@ -107,25 +120,20 @@ class CinebyExtractor(
                     addQueryParameter("year", year)
                     addQueryParameter("episodeId", episodeId)
                     addQueryParameter("seasonId", seasonId)
-                    addQueryParameter("tmdbId", pathParts[1])
+                    addQueryParameter("tmdbId", tmdbId)
                     if (imdbId.isNotBlank()) addQueryParameter("imdbId", imdbId)
                     if (server.language != null) {
                         addQueryParameter("language", server.language)
                     }
+                    addQueryParameter("enc", "2")
+                    addQueryParameter("seed", seed)
                 }.build()
-
-                // API headers use stripped domain (Videasy expects no www.)
-                val apiOrigin = apiOrigin(baseUrl)
-                val backendHeaders = headers.newBuilder()
-                    .set("Referer", "$apiOrigin/")
-                    .set("Origin", apiOrigin)
-                    .build()
 
                 val encryptedText = client.newCall(
                     GET(serverUrl.toString(), backendHeaders),
                 ).awaitSuccess().bodyString()
 
-                val requestBody = mapOf("text" to encryptedText, "id" to pathParts[1])
+                val requestBody = mapOf("text" to encryptedText, "id" to tmdbId, "seed" to seed)
                     .toJsonRequestBody()
                 val decrypted = client.newCall(POST(DECRYPTION_API_URL, body = requestBody))
                     .awaitSuccess()
@@ -182,20 +190,26 @@ class CinebyExtractor(
     /**
      * Returns true if the given quality string is a language name masquerading
      * as a resolution label. Checks both audioLabel (e.g. "German" from meine)
-     * and qualityFilter (e.g. "English"/"Hindi" from hdmovie) since the
-     * audioLabel for English servers is now "Original" instead of "English".
+     * and qualityFilter (e.g. "English"/"Hindi" from hdmovie).
      */
-    private fun isLanguageAsQuality(server: VideasyServer, quality: String): Boolean = quality.equals(server.audioLabel, ignoreCase = true) ||
-        (server.qualityFilter != null && quality.equals(server.qualityFilter, ignoreCase = true))
+    private fun isLanguageAsQuality(server: VideasyServer, quality: String): Boolean {
+        if (qualityRegex.containsMatchIn(quality) || quality.contains("4k", ignoreCase = true)) {
+            return false
+        }
 
-    /**
-     * Returns true if the quality string already represents a real resolution
-     * (e.g. "1080p", "720p", "480p", "4K", "2160p", or bare digits like "1080").
-     * These don't need HLS expansion — the server already provided the correct label.
-     */
-    private fun isRealResolution(quality: String): Boolean = qualityRegex.containsMatchIn(quality) ||
-        quality.contains("4k", ignoreCase = true) ||
-        quality.all { it.isDigit() }
+        // Only hide if it matches a specific audio label that isn't a generic placeholder.
+        val isGeneric = quality.equals("Original", ignoreCase = true) ||
+            quality.equals("Auto", ignoreCase = true) ||
+            quality.contains("Video", ignoreCase = true) ||
+            quality.isBlank()
+
+        if (isGeneric) {
+            return true
+        }
+
+        return quality.equals(server.audioLabel, ignoreCase = true) ||
+            (server.qualityFilter != null && quality.equals(server.qualityFilter, ignoreCase = true))
+    }
 
     /**
      * Extracts a numeric quality value for sorting. Maps "4K" to 2160
@@ -224,10 +238,9 @@ class CinebyExtractor(
             }
             .take(subLimit.coerceAtLeast(0))
 
-        // Use stripped domain (no www.) for video headers — matches what the
-        // original working code sent. Some CDNs/Cloudflare configs are sensitive
-        // to the exact Referer value.
-        val streamOrigin = apiOrigin(baseUrl)
+        // Use full domain (preserve www.) for video headers — some CDNs
+        // (especially Jett's shegu.net) are sensitive to the exact Referer.
+        val streamOrigin = getOrigin(baseUrl, stripWww = false)
         val videoHeaders = headers.newBuilder()
             .set("Referer", "$streamOrigin/")
             .set("Origin", streamOrigin)
@@ -239,21 +252,21 @@ class CinebyExtractor(
             } ?: sources
         }
 
-        return when {
+        val videos = when {
             !filteredSources.isNullOrEmpty() -> {
-                filteredSources.flatMap { source ->
+                filteredSources.distinctBy { it.url }.flatMap { source ->
                     val rawQuality = source.quality?.takeIf { it.isNotBlank() } ?: "Auto"
                     val isHls = source.url.lowercase().contains(".m3u8")
+                    val isDash = source.url.lowercase().contains(".mpd")
                     val isLang = isLanguageAsQuality(server, rawQuality)
 
-                    // Expand when quality is NOT a real resolution AND either:
-                    // - URL is .m3u8 (standard HLS), or
-                    // - Quality is a language name (these are almost always HLS
-                    //   even if the URL doesn't contain .m3u8 explicitly)
-                    // Don't expand when quality is already "1080p" etc —
-                    // those servers provide correct labels per source.
-                    val needsExpansion = !isRealResolution(rawQuality) &&
-                        (isHls || isLang)
+                    // Always expand HLS/Dash to extract multiple audio tracks and resolutions.
+                    // For servers with generic playlists (like Yoru/Neon), we must expand
+                    // to find the actual resolutions.
+                    val isGeneric = rawQuality.equals("Original", ignoreCase = true) ||
+                        rawQuality.equals("Auto", ignoreCase = true) ||
+                        rawQuality.contains("HLS", ignoreCase = true)
+                    val needsExpansion = isHls || isDash || isLang || isGeneric
 
                     if (needsExpansion) {
                         val expanded = runCatching {
@@ -316,6 +329,19 @@ class CinebyExtractor(
             }
             else -> emptyList()
         }
+
+        return videos.distinctBy { it.videoUrl }.map { video ->
+            if (video.audioTracks.size > 1 && !video.quality.contains("Multi audio", ignoreCase = true)) {
+                val newQuality = if (video.quality.contains("audio")) {
+                    video.quality.replace(Regex("""\w+ audio"""), "Multi audio")
+                } else {
+                    video.quality + " · Multi audio"
+                }
+                video.copy(quality = newQuality)
+            } else {
+                video
+            }
+        }
     }
 
     private fun cacheKey(
@@ -332,17 +358,17 @@ class CinebyExtractor(
         url: String,
         subCount: Int,
     ): String {
-        val parts = mutableListOf("Server: ${server.displayName}")
+        val parts = mutableListOf(server.displayName)
 
-        // If the "quality" is actually a language name (e.g. "German" from
-        // meine, "English"/"Hindi" from hdmovie), don't show it as video
-        // quality — the audioLabel already conveys the language.
         if (!isLanguageAsQuality(server, quality)) {
             parts += quality
         }
 
-        val isUhd = quality.contains("2160") || quality.contains("4k", ignoreCase = true)
-        if (isUhd && !quality.contains("4k", ignoreCase = true)) parts += "4K"
+        val isUhd = quality.startsWith("2160") || quality.contains("4k", ignoreCase = true)
+        if (isUhd && !quality.contains("4k", ignoreCase = true)) {
+            parts += "4K"
+        }
+
         val lower = url.lowercase()
         val container = when {
             ".m3u8" in lower -> "HLS"
@@ -352,9 +378,14 @@ class CinebyExtractor(
             ".webm" in lower -> "WebM"
             else -> null
         }
-        if (container != null) parts += container
+        if (container != null) {
+            parts += container
+        }
+
         server.audioLabel?.let { parts += "$it audio" }
-        if (subCount > 0) parts += "$subCount subs"
+        if (subCount > 0) {
+            parts += "$subCount subs"
+        }
         return parts.joinToString(" · ")
     }
 
@@ -371,95 +402,92 @@ class CinebyExtractor(
         private val qualityRegex = Regex("""(\d{3,4})[pP]?""")
 
         //   Official servers (verified against website JS + reference table)
-        //   Neon    = mb-flix                                (api.videasy.to)
-        //   Yoru    = cdn          [MOVIE ONLY, MAY HAVE 4K] (api.videasy.to)
-        //   Cypher  = downloader2                            (api.videasy.to)
-        //   Sage    = 1movies                                (api.videasy.to)
-        //   Breach  = m4uhd                                  (api.videasy.to)
-        //   Vyse    = hdmovie      [FILTERS quality=English] (api.videasy.to)
-        //   Killjoy = meine ?lang=german  - German          (api.videasy.to)
-        //   Harbor  = meine ?lang=italian - Italian         (api.videasy.to)
-        //   Chamber = meine ?lang=french  - French [MOVIE ONLY] (api.videasy.to)
-        //   Fade    = hdmovie      [FILTERS quality=Hindi]  (api.videasy.to)
-        //   Omen    = lamovie             - Spanish          (api.videasy.to)
-        //   Raze    = superflix           - Portuguese       (api.videasy.to)
+        //   Jett    = jett                                   (api.wingsdatabase.com)
+        //   Yoru    = cdn          [MOVIE ONLY, MAY HAVE 4K] (api.wingsdatabase.com)
+        //   Tejo    = tejo                                   (api.wingsdatabase.com)
+        //   Neon    = neon2                                  (api.wingsdatabase.com)
+        //   Sage    = ym                                     (api.wingsdatabase.com)
+        //   Cypher  = downloader2                            (api.wingsdatabase.com)
+        //   Breach  = m4uhd                                  (api.wingsdatabase.com)
+        //   Vyse    = hdmovie      [FILTERS quality=English] (api.wingsdatabase.com)
+        //   Killjoy = meine ?lang=german  - German           (api.wingsdatabase.com)
+        //   Fade    = hdmovie      [FILTERS quality=Hindi]   (api.wingsdatabase.com)
+        //   Omen    = lamovie             - Spanish          (api.wingsdatabase.com)
+        //   Raze    = superflix           - Portuguese       (api.wingsdatabase.com)
         val VIDEASY_SERVERS = listOf(
             VideasyServer(
-                "Neon",
-                "https://api.videasy.to",
-                "mb-flix",
+                "Jett",
+                "https://api.wingsdatabase.com",
+                "jett",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Yoru",
-                "https://api.videasy.to",
+                "https://api.wingsdatabase.com",
                 "cdn",
                 mayHave4K = true,
                 audioLabel = "Original",
             ),
             VideasyServer(
-                "Cypher",
-                "https://api.videasy.to",
-                "downloader2",
+                "Tejo",
+                "https://api.wingsdatabase.com",
+                "tejo",
+                audioLabel = "Original",
+            ),
+            VideasyServer(
+                "Neon",
+                "https://api.wingsdatabase.com",
+                "neon2",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Sage",
-                "https://api.videasy.to",
-                "1movies",
+                "https://api.wingsdatabase.com",
+                "ym",
+                audioLabel = "Original",
+            ),
+            VideasyServer(
+                "Cypher",
+                "https://api.wingsdatabase.com",
+                "downloader2",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Breach",
-                "https://api.videasy.to",
+                "https://api.wingsdatabase.com",
                 "m4uhd",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Vyse",
-                "https://api.videasy.to",
+                "https://api.wingsdatabase.com",
                 "hdmovie",
                 qualityFilter = "English",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Killjoy",
-                "https://api.videasy.to",
+                "https://api.wingsdatabase.com",
                 "meine",
                 language = "german",
                 audioLabel = "German",
             ),
             VideasyServer(
-                "Harbor",
-                "https://api.videasy.to",
-                "meine",
-                language = "italian",
-                audioLabel = "Italian",
-            ),
-            VideasyServer(
-                "Chamber",
-                "https://api.videasy.to",
-                "meine",
-                language = "french",
-                movieOnly = true,
-                audioLabel = "French",
-            ),
-            VideasyServer(
                 "Fade",
-                "https://api.videasy.to",
+                "https://api.wingsdatabase.com",
                 "hdmovie",
                 qualityFilter = "Hindi",
                 audioLabel = "Hindi",
             ),
             VideasyServer(
                 "Omen",
-                "https://api.videasy.to",
+                "https://api.wingsdatabase.com",
                 "lamovie",
                 audioLabel = "Spanish",
             ),
             VideasyServer(
                 "Raze",
-                "https://api.videasy.to",
+                "https://api.wingsdatabase.com",
                 "superflix",
                 audioLabel = "Portuguese",
             ),

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -85,7 +85,7 @@ class CinebyExtractor(
             .build()
 
         val seed = client.newCall(
-            GET("https://api.wingsdatabase.com/seed?mediaId=$tmdbId", backendHeaders),
+            GET("$VIDEASY_API_BASE/seed?mediaId=$tmdbId", backendHeaders),
         ).awaitSuccess().parseAs<SeedDto>().seed
 
         val videoList = eligibleServers.parallelCatchingFlatMap { server ->
@@ -197,18 +197,19 @@ class CinebyExtractor(
             return false
         }
 
-        // Only hide if it matches a specific audio label that isn't a generic placeholder.
-        val isGeneric = quality.equals("Original", ignoreCase = true) ||
-            quality.equals("Auto", ignoreCase = true) ||
-            quality.contains("Video", ignoreCase = true) ||
-            quality.isBlank()
-
-        if (isGeneric) {
+        if (isGenericQuality(quality)) {
             return true
         }
 
         return quality.equals(server.audioLabel, ignoreCase = true) ||
             (server.qualityFilter != null && quality.equals(server.qualityFilter, ignoreCase = true))
+    }
+
+    private fun isGenericQuality(quality: String): Boolean {
+        val normalized = quality.trim().lowercase()
+        return normalized in GENERIC_QUALITY_PLACEHOLDERS ||
+            normalized.isBlank() ||
+            GENERIC_QUALITY_REGEX.matches(normalized)
     }
 
     /**
@@ -263,9 +264,7 @@ class CinebyExtractor(
                     // Always expand HLS/Dash to extract multiple audio tracks and resolutions.
                     // For servers with generic playlists (like Yoru/Neon), we must expand
                     // to find the actual resolutions.
-                    val isGeneric = rawQuality.equals("Original", ignoreCase = true) ||
-                        rawQuality.equals("Auto", ignoreCase = true) ||
-                        rawQuality.contains("HLS", ignoreCase = true)
+                    val isGeneric = isGenericQuality(rawQuality)
                     val needsExpansion = isHls || isDash || isLang || isGeneric
 
                     if (needsExpansion) {
@@ -364,7 +363,7 @@ class CinebyExtractor(
             parts += quality
         }
 
-        val isUhd = quality.startsWith("2160") || quality.contains("4k", ignoreCase = true)
+        val isUhd = quality.contains("2160") || quality.contains("4k", ignoreCase = true)
         if (isUhd && !quality.contains("4k", ignoreCase = true)) {
             parts += "4K"
         }
@@ -390,6 +389,7 @@ class CinebyExtractor(
     }
 
     companion object {
+        private const val VIDEASY_API_BASE = "https://api.wingsdatabase.com"
         private const val DECRYPTION_API_URL = "https://enc-dec.app/api/dec-videasy"
         private const val HEX = "0123456789ABCDEF"
 
@@ -400,6 +400,19 @@ class CinebyExtractor(
         private const val CIRCUIT_COOLDOWN_MS = 180_000L
 
         private val qualityRegex = Regex("""(\d{3,4})[pP]?""")
+
+        private val GENERIC_QUALITY_PLACEHOLDERS = setOf(
+            "original",
+            "auto",
+            "video",
+            "full video",
+            "watch video",
+            "play video",
+            "hls",
+            "dash",
+        )
+
+        private val GENERIC_QUALITY_REGEX = Regex("""^(video|stream|hls|dash)(\s+.*)?$""")
 
         //   Official servers (verified against website JS + reference table)
         //   Jett    = jett                                   (api.wingsdatabase.com)
@@ -417,77 +430,77 @@ class CinebyExtractor(
         val VIDEASY_SERVERS = listOf(
             VideasyServer(
                 "Jett",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "jett",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Yoru",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "cdn",
                 mayHave4K = true,
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Tejo",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "tejo",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Neon",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "neon2",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Sage",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "ym",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Cypher",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "downloader2",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Breach",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "m4uhd",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Vyse",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "hdmovie",
                 qualityFilter = "English",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Killjoy",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "meine",
                 language = "german",
                 audioLabel = "German",
             ),
             VideasyServer(
                 "Fade",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "hdmovie",
                 qualityFilter = "Hindi",
                 audioLabel = "Hindi",
             ),
             VideasyServer(
                 "Omen",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "lamovie",
                 audioLabel = "Spanish",
             ),
             VideasyServer(
                 "Raze",
-                "https://api.wingsdatabase.com",
+                VIDEASY_API_BASE,
                 "superflix",
                 audioLabel = "Portuguese",
             ),


### PR DESCRIPTION
Closes #527.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update Cineby extension to use new WingsDatabase API domains and servers, introduce seed-based backend requests, and improve stream selection and labelling.

New Features:
- Add support for seed retrieval from WingsDatabase to parameterize server and decryption requests.
- Expose a new SeedDto model to handle seed responses from the backend.
- Enhance video list labelling to indicate multi-audio streams when multiple audio tracks are present.

Bug Fixes:
- Prevent misclassification of real resolutions as language labels and ensure generic placeholders like Original/Auto are treated appropriately.
- Avoid duplicate video entries by de-duplicating sources and final video URLs before returning results.
- Update Cineby domain list to use the current fmovies.gd mirror and adjust default enabled servers to the new official set.

Enhancements:
- Switch Cineby and server endpoints from videasy.to to wingsdatabase.com and adjust default server preferences.
- Improve origin handling to respect www subdomains for API and stream headers to match CDN expectations.
- Refine language/quality detection and expansion logic to better handle HLS/DASH playlists, generic quality labels, and UHD detection.
- Simplify cache key formatting by focusing on display name, real quality markers, container type, audio language, and subtitle count.

Build:
- Bump the Cineby extension version code from 6 to 7.