### PR TITLE
Animetsu [Multi]: Improve SAnime (Related Anime)

### DIFF
--- a/src/all/animetsu/build.gradle
+++ b/src/all/animetsu/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animetsu'
     extClass = '.Animetsu'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -24,6 +24,9 @@ import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parallelFlatMap
 import keiyoushi.utils.parseAs
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -37,6 +40,8 @@ class Animetsu :
     ConfigurableAnimeSource {
 
     override val name = "Animetsu"
+
+    override val disableRelatedAnimesBySearch = true
 
     private val preferences: SharedPreferences by getPreferencesLazy { clearOldPrefs() }
 
@@ -221,12 +226,70 @@ class Animetsu :
 
     // ============================== Related ===============================
 
+    override suspend fun fetchRelatedAnimeList(anime: SAnime): List<SAnime> = coroutineScope {
+        val referer = getAnimeUrl(anime)
+        val infoResponse = client.newCall(GET("$apiUrl/anime/info/${anime.url}", apiHeaders(referer))).awaitSuccess()
+        val dto = infoResponse.parseAs<AnimetsuAnimeDto>()
+
+        val explicitRelated = parseRelatedAnime(dto)
+
+        val title = dto.title?.preferredTitle(titleLanguage) ?: anime.title
+        val genres = dto.genres.orEmpty()
+
+        val titleSearch = async {
+            val titleWords = title.split(" ")
+                .map { it.filter { c -> c.isLetterOrDigit() } }
+                .filter { it.length >= 2 }
+                .take(3)
+
+            if (titleWords.isEmpty()) return@async emptyList()
+
+            val query = titleWords.joinToString(" ")
+            runCatching {
+                val searchUrl = "$apiUrl/anime/search/".toHttpUrl().newBuilder().apply {
+                    addQueryParameter("sort", "trending")
+                    addQueryParameter("page", "1")
+                    addQueryParameter("per_page", "35")
+                    addQueryParameter("query", query)
+                }.build()
+                val resp = client.newCall(GET(searchUrl, apiHeaders())).awaitSuccess()
+                resp.parseAs<AnimetsuSearchDto>().results
+                    .filter { it.id != dto.id && (!hideAdult || !it.isAdult) }
+                    .mapNotNull { it.toSAnime(titleLanguage, showTags, baseUrl = baseUrl) }
+            }.getOrDefault(emptyList())
+        }
+
+        val genreSearch = async {
+            if (genres.isEmpty()) return@async emptyList()
+
+            val genreQuery = genres.take(2).joinToString(",")
+            runCatching {
+                val searchUrl = "$apiUrl/anime/search/".toHttpUrl().newBuilder().apply {
+                    addQueryParameter("sort", "trending")
+                    addQueryParameter("page", "1")
+                    addQueryParameter("per_page", "35")
+                    addQueryParameter("genres", genreQuery)
+                }.build()
+                val resp = client.newCall(GET(searchUrl, apiHeaders())).awaitSuccess()
+                resp.parseAs<AnimetsuSearchDto>().results
+                    .filter { it.id != dto.id && (!hideAdult || !it.isAdult) }
+                    .mapNotNull { it.toSAnime(titleLanguage, showTags, baseUrl = baseUrl) }
+            }.getOrDefault(emptyList())
+        }
+
+        (explicitRelated + listOf(titleSearch, genreSearch).awaitAll().flatten())
+            .distinctBy { it.url }
+    }
+
     override fun relatedAnimeListParse(response: Response): List<SAnime> {
         val dto = response.parseAs<AnimetsuAnimeDto>()
+        return parseRelatedAnime(dto)
+    }
 
+    private fun parseRelatedAnime(dto: AnimetsuAnimeDto): List<SAnime> {
         return buildList {
             dto.seasons?.mapNotNull { season ->
-                if (season.id.isBlank()) return@mapNotNull null
+                if (season.id.isBlank() || season.id == dto.id) return@mapNotNull null
                 val seasonTitle = season.title?.preferredTitle(titleLanguage) ?: return@mapNotNull null
 
                 SAnime.create().apply {
@@ -237,7 +300,7 @@ class Animetsu :
             }?.let(::addAll)
 
             dto.relations?.mapNotNull { rel ->
-                if (rel.id.isBlank()) return@mapNotNull null
+                if (rel.id.isBlank() || rel.id == dto.id) return@mapNotNull null
                 val relTitle = rel.title?.preferredTitle(titleLanguage) ?: return@mapNotNull null
 
                 SAnime.create().apply {
@@ -248,13 +311,14 @@ class Animetsu :
             }?.let(::addAll)
 
             dto.recommendations?.mapNotNull { rec ->
-                if (rec.id.isBlank()) return@mapNotNull null
+                if (rec.id.isBlank() || rec.id == dto.id) return@mapNotNull null
                 val recTitle = rec.title?.preferredTitle(titleLanguage) ?: return@mapNotNull null
 
                 SAnime.create().apply {
                     url = rec.id
                     title = recTitle
                     status = parseStatus(rec.status)
+                    thumbnail_url = (rec.coverImage?.large ?: rec.coverImage?.medium)
                 }
             }?.let(::addAll)
         }
@@ -656,7 +720,8 @@ class Animetsu :
         fun parseStatus(status: String?): Int = when (status) {
             "RELEASING" -> SAnime.ONGOING
             "FINISHED" -> SAnime.COMPLETED
-            "NOT_YET_RELEASED" -> SAnime.UNKNOWN
+            "NOT_YET_RELEASED" -> SAnime.LICENSED
+            "CANCELLED" -> SAnime.CANCELLED
             else -> SAnime.UNKNOWN
         }
 

--- a/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
+++ b/src/all/animetsu/src/eu/kanade/tachiyomi/animeextension/all/animetsu/Animetsu.kt
@@ -245,7 +245,7 @@ class Animetsu :
             if (titleWords.isEmpty()) return@async emptyList()
 
             val query = titleWords.joinToString(" ")
-            runCatching {
+            try {
                 val searchUrl = "$apiUrl/anime/search/".toHttpUrl().newBuilder().apply {
                     addQueryParameter("sort", "trending")
                     addQueryParameter("page", "1")
@@ -256,14 +256,17 @@ class Animetsu :
                 resp.parseAs<AnimetsuSearchDto>().results
                     .filter { it.id != dto.id && (!hideAdult || !it.isAdult) }
                     .mapNotNull { it.toSAnime(titleLanguage, showTags, baseUrl = baseUrl) }
-            }.getOrDefault(emptyList())
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                emptyList()
+            }
         }
 
         val genreSearch = async {
             if (genres.isEmpty()) return@async emptyList()
 
             val genreQuery = genres.take(2).joinToString(",")
-            runCatching {
+            try {
                 val searchUrl = "$apiUrl/anime/search/".toHttpUrl().newBuilder().apply {
                     addQueryParameter("sort", "trending")
                     addQueryParameter("page", "1")
@@ -274,7 +277,10 @@ class Animetsu :
                 resp.parseAs<AnimetsuSearchDto>().results
                     .filter { it.id != dto.id && (!hideAdult || !it.isAdult) }
                     .mapNotNull { it.toSAnime(titleLanguage, showTags, baseUrl = baseUrl) }
-            }.getOrDefault(emptyList())
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                emptyList()
+            }
         }
 
         (explicitRelated + listOf(titleSearch, genreSearch).awaitAll().flatten())
@@ -630,6 +636,7 @@ class Animetsu :
                 m3u8ServerManager.stopServer()
                 delay(500L)
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 Log.e("Animetsu", "M3U8 server start failed on attempt ${attempt + 1}: ${e.message}")
                 m3u8ServerManager.stopServer()
                 delay(500L)
@@ -720,7 +727,6 @@ class Animetsu :
         fun parseStatus(status: String?): Int = when (status) {
             "RELEASING" -> SAnime.ONGOING
             "FINISHED" -> SAnime.COMPLETED
-            "NOT_YET_RELEASED" -> SAnime.LICENSED
             "CANCELLED" -> SAnime.CANCELLED
             else -> SAnime.UNKNOWN
         }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve Animetsu related anime handling with API-based recommendations and status updates.

New Features:
- Add a coroutine-based related anime fetch that combines explicit relations with title and genre search results.

Enhancements:
- Disable generic search-based related anime in favor of explicit API-driven results.
- Prevent self-references in seasons, relations, and recommendations when building related lists.
- Include cover thumbnails for recommended anime and refine status mapping, including licensed and cancelled states.

Build:
- Bump Animetsu extension version code to 7.