### PR TITLE
Torrentio & Torrentio Anime [Multi]: Hide Season 0 Episodes & Update Providers

### DIFF
--- a/src/all/torrentio/build.gradle
+++ b/src/all/torrentio/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = false
 }
 

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -321,10 +321,12 @@ class Torrentio :
             "series" -> {
                 episodeList.meta.videos
                     ?.let { videos ->
-                        if (preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)) {
-                            videos
-                        } else {
-                            videos.filter { video -> (video.released?.let { parseDate(it) } ?: 0L) <= System.currentTimeMillis() }
+                        val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
+                        val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
+
+                        videos.filter { video ->
+                            val isUpcoming = (video.released?.let { parseDate(it) } ?: 0L) > System.currentTimeMillis()
+                            (showUpcoming || !isUpcoming) && (!hideSeasonZero || video.season != 0)
                         }
                     }
                     ?.map { video ->
@@ -578,6 +580,15 @@ class Torrentio :
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
+            key = HIDE_SEASON_ZERO_KEY
+            title = "Hide Season 0 Episodes"
+            setDefaultValue(HIDE_SEASON_ZERO_DEFAULT)
+            setOnPreferenceChangeListener { _, newValue ->
+                preferences.edit().putBoolean(key, newValue as Boolean).commit()
+            }
+        }.also(screen::addPreference)
+
+        SwitchPreferenceCompat(screen.context).apply {
             key = IS_DUB_KEY
             title = "Dubbed Video Priority"
             setDefaultValue(IS_DUB_DEFAULT)
@@ -648,6 +659,7 @@ class Torrentio :
             "Premiumize",
             "AllDebrid",
             "DebridLink",
+            "EasyDebrid",
             "Offcloud",
             "TorBox",
         )
@@ -657,6 +669,7 @@ class Torrentio :
             "premiumize",
             "alldebrid",
             "debridlink",
+            "easydebrid",
             "offcloud",
             "torbox",
         )
@@ -692,15 +705,17 @@ class Torrentio :
             "NyaaSi",
             "TokyoTosho",
             "AniDex",
+            "nekoBT",
             "🇷🇺 Rutor",
             "🇷🇺 Rutracker",
             "🇵🇹 Comando",
             "🇵🇹 BluDV",
             "🇫🇷 Torrent9",
+            "🇮🇹 ilCorSaRoNero",
             "🇪🇸 MejorTorrent",
-            "🇲🇽 Cinecalidad",
-            "🇮🇹 ilCorsaroNero",
             "🇪🇸 Wolfmax4k",
+            "🇲🇽 Cinecalidad",
+            "🇵🇱 BestTorrents",
         )
 
         private val PREF_PROVIDERS_VALUE = arrayOf(
@@ -716,15 +731,17 @@ class Torrentio :
             "nyaasi",
             "tokyotosho",
             "anidex",
+            "nekobt",
             "rutor",
             "rutracker",
             "comando",
             "bludv",
             "torrent9",
-            "mejortorrent",
-            "cinecalidad",
             "ilcorsaronero",
+            "mejortorrent",
             "wolfmax4k",
+            "cinecalidad",
+            "besttorrents",
         )
 
         private val PREF_DEFAULT_PROVIDERS_VALUE = arrayOf(
@@ -740,6 +757,7 @@ class Torrentio :
             "nyaasi",
             "tokyotosho",
             "anidex",
+            "nekobt",
         )
         private val PREF_PROVIDERS_DEFAULT = PREF_DEFAULT_PROVIDERS_VALUE.toSet()
 
@@ -892,6 +910,9 @@ class Torrentio :
 
         private const val UPCOMING_EP_KEY = "upcoming_ep"
         private const val UPCOMING_EP_DEFAULT = false
+
+        private const val HIDE_SEASON_ZERO_KEY = "hide_season_zero"
+        private const val HIDE_SEASON_ZERO_DEFAULT = false
 
         private const val IS_DUB_KEY = "dubbed"
         private const val IS_DUB_DEFAULT = false

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -323,10 +323,11 @@ class Torrentio :
                     ?.let { videos ->
                         val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
                         val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
+                        val now = System.currentTimeMillis()
 
                         videos.filter { video ->
-                            val isUpcoming = (video.released?.let { parseDate(it) } ?: 0L) > System.currentTimeMillis()
-                            (showUpcoming || !isUpcoming) && (!hideSeasonZero || video.season != 0)
+                            val isNotSeasonZero = !hideSeasonZero || video.season != 0
+                            isNotSeasonZero && (showUpcoming || (video.released?.let { parseDate(it) } ?: 0L) <= now)
                         }
                     }
                     ?.map { video ->
@@ -583,9 +584,6 @@ class Torrentio :
             key = HIDE_SEASON_ZERO_KEY
             title = "Hide Season 0 Episodes"
             setDefaultValue(HIDE_SEASON_ZERO_DEFAULT)
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putBoolean(key, newValue as Boolean).commit()
-            }
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {

--- a/src/all/torrentioanime/build.gradle
+++ b/src/all/torrentioanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio Anime (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 18
+    extVersionCode = 19
     isNsfw = false
 }
 

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -318,12 +318,10 @@ class Torrentio :
             "TV", "ONA", "OVA" -> {
                 aniZipResponse.episodes
                     ?.let { episodes ->
-                        val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
-                        val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
-
-                        episodes.filter { (_, episode) ->
-                            val isUpcoming = episode?.airDate.let(DATE_FORMATTER::tryParse) > System.currentTimeMillis()
-                            (showUpcoming || !isUpcoming) && (!hideSeasonZero || episode?.seasonNumber != 0)
+                        if (preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)) {
+                            episodes
+                        } else {
+                            episodes.filter { (_, episode) -> episode?.airDate.let(DATE_FORMATTER::tryParse) <= System.currentTimeMillis() }
                         }
                     }
                     ?.mapNotNull { (_, episode) ->
@@ -579,15 +577,6 @@ class Torrentio :
             key = UPCOMING_EP_KEY
             title = "Show Upcoming Episodes"
             setDefaultValue(UPCOMING_EP_DEFAULT)
-        }.also(screen::addPreference)
-
-        SwitchPreferenceCompat(screen.context).apply {
-            key = HIDE_SEASON_ZERO_KEY
-            title = "Hide Season 0 Episodes"
-            setDefaultValue(HIDE_SEASON_ZERO_DEFAULT)
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putBoolean(key, newValue as Boolean).commit()
-            }
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
@@ -902,9 +891,6 @@ class Torrentio :
 
         private const val UPCOMING_EP_KEY = "upcoming_ep"
         private const val UPCOMING_EP_DEFAULT = false
-
-        private const val HIDE_SEASON_ZERO_KEY = "hide_season_zero"
-        private const val HIDE_SEASON_ZERO_DEFAULT = false
 
         private const val IS_DUB_KEY = "dubbed"
         private const val IS_DUB_DEFAULT = false

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -318,10 +318,12 @@ class Torrentio :
             "TV", "ONA", "OVA" -> {
                 aniZipResponse.episodes
                     ?.let { episodes ->
-                        if (preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)) {
-                            episodes
-                        } else {
-                            episodes.filter { (_, episode) -> episode?.airDate.let(DATE_FORMATTER::tryParse) <= System.currentTimeMillis() }
+                        val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
+                        val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
+
+                        episodes.filter { (_, episode) ->
+                            val isUpcoming = episode?.airDate.let(DATE_FORMATTER::tryParse) > System.currentTimeMillis()
+                            (showUpcoming || !isUpcoming) && (!hideSeasonZero || episode?.seasonNumber != 0)
                         }
                     }
                     ?.mapNotNull { (_, episode) ->
@@ -580,6 +582,15 @@ class Torrentio :
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
+            key = HIDE_SEASON_ZERO_KEY
+            title = "Hide Season 0 Episodes"
+            setDefaultValue(HIDE_SEASON_ZERO_DEFAULT)
+            setOnPreferenceChangeListener { _, newValue ->
+                preferences.edit().putBoolean(key, newValue as Boolean).commit()
+            }
+        }.also(screen::addPreference)
+
+        SwitchPreferenceCompat(screen.context).apply {
             key = IS_DUB_KEY
             title = "Dubbed Video Priority"
             setDefaultValue(IS_DUB_DEFAULT)
@@ -628,6 +639,7 @@ class Torrentio :
             "Premiumize",
             "AllDebrid",
             "DebridLink",
+            "EasyDebrid",
             "Offcloud",
             "TorBox",
         )
@@ -637,6 +649,7 @@ class Torrentio :
             "premiumize",
             "alldebrid",
             "debridlink",
+            "easydebrid",
             "offcloud",
             "torbox",
         )
@@ -671,15 +684,17 @@ class Torrentio :
             "NyaaSi",
             "TokyoTosho",
             "AniDex",
+            "nekoBT",
             "🇷🇺 Rutor",
             "🇷🇺 Rutracker",
             "🇵🇹 Comando",
             "🇵🇹 BluDV",
             "🇫🇷 Torrent9",
+            "🇮🇹 ilCorSaRoNero",
             "🇪🇸 MejorTorrent",
-            "🇲🇽 Cinecalidad",
-            "🇮🇹 ilCorsaroNero",
             "🇪🇸 Wolfmax4k",
+            "🇲🇽 Cinecalidad",
+            "🇵🇱 BestTorrents",
         )
 
         private val PREF_PROVIDERS_VALUE = arrayOf(
@@ -695,15 +710,17 @@ class Torrentio :
             "nyaasi",
             "tokyotosho",
             "anidex",
+            "nekobt",
             "rutor",
             "rutracker",
             "comando",
             "bludv",
             "torrent9",
-            "mejortorrent",
-            "cinecalidad",
             "ilcorsaronero",
+            "mejortorrent",
             "wolfmax4k",
+            "cinecalidad",
+            "besttorrents",
         )
 
         private val PREF_DEFAULT_PROVIDERS_VALUE = arrayOf(
@@ -719,6 +736,7 @@ class Torrentio :
             "nyaasi",
             "tokyotosho",
             "anidex",
+            "nekobt",
         )
         private val PREF_PROVIDERS_DEFAULT = PREF_DEFAULT_PROVIDERS_VALUE.toSet()
 
@@ -884,6 +902,9 @@ class Torrentio :
 
         private const val UPCOMING_EP_KEY = "upcoming_ep"
         private const val UPCOMING_EP_DEFAULT = false
+
+        private const val HIDE_SEASON_ZERO_KEY = "hide_season_zero"
+        private const val HIDE_SEASON_ZERO_DEFAULT = false
 
         private const val IS_DUB_KEY = "dubbed"
         private const val IS_DUB_DEFAULT = false


### PR DESCRIPTION
Closes #102.
Closes #232.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Introduce an option to hide Season 0 episodes in Torrentio and update provider configurations for both Torrentio and Torrentio Anime, including new providers and version code increments.

New Features:
- Add a user preference to hide Season 0 episodes for Torrentio series listings.

Enhancements:
- Expand and reorganize torrent and debrid provider lists, adding EasyDebrid, nekoBT, ilCorSaRoNero, and BestTorrents for both Torrentio extensions.

Build:
- Bump extVersionCode for Torrentio and Torrentio Anime extensions.