### PR TITLE
SmartAnimes [PT]: Fix SendNow extractor (fix #576)

### DIFF
--- a/src/pt/smartanimes/build.gradle
+++ b/src/pt/smartanimes/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SmartAnimes'
     themePkg = 'animestream'
     baseUrl = 'https://smartanimes.com'
-    overrideVersionCode = 0
+    overrideVersionCode = 1
     isNsfw = true
 }
 

--- a/src/pt/smartanimes/build.gradle
+++ b/src/pt/smartanimes/build.gradle
@@ -2,7 +2,7 @@ ext {
     extName = 'SmartAnimes'
     extClass = '.SmartAnimes'
     themePkg = 'animestream'
-    baseUrl = 'https://smartanimes.com'
+    baseUrl = 'https://smartanimes.net'
     overrideVersionCode = 1
     isNsfw = true
 }

--- a/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/SmartAnimes.kt
+++ b/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/SmartAnimes.kt
@@ -23,6 +23,8 @@ class SmartAnimes :
 
     override val prefQualityValues = listOf("1080p", "720p", "480p", "360p", "240p")
 
+    override val animeDescriptionSelector = ".entry-content[itemprop=description]"
+
     // ============================ Video Links =============================
     override fun videoListSelector() = ".dlbox li:not(.head)"
 

--- a/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SendNowExtractor.kt
+++ b/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SendNowExtractor.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.withTimeout
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import kotlin.coroutines.resume
 
@@ -42,7 +43,7 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
         val isMobile = userAgent.contains("Android") || userAgent.contains("Mobile")
 
         val secChUa =
-            "\"Google Chrome\";v=\"$chromeVersion\", \"Chromium\";v=\"$chromeVersion\", \"Not A(Brand)\";v=\"24\""
+            "\"Google Chrome\";v=\"$chromeVersion\", \"Chromium\";v=\"$chromeVersion\", \"Not A(Brand\";v=\"24\""
 
         val platform = when {
             userAgent.contains("Windows") -> "\"Windows\""
@@ -78,7 +79,7 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
         // same page the WebView loaded (avoids a second OkHttp GET that would re-trigger Cloudflare).
         Log.d(tag, "Opening WebView to solve Cloudflare Turnstile...")
         val result = try {
-            withTimeout(30_000) { solveTurnstile(url, userAgent) }
+            withTimeout(45_000) { solveTurnstile(url, userAgent) }
         } catch (_: TimeoutCancellationException) {
             Log.e(tag, "Turnstile solving timed out")
             return emptyList()
@@ -92,7 +93,7 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
 
         val host = url.toHttpUrl().host
         val cookies = webViewCookies("https://$host/")
-        Log.d(tag, "Challenge page loaded: id='${result.id}' rand='${result.rand}' referer='${result.referer}'")
+        Log.d(tag, "Challenge page loaded: id='${result.id}' rand='${result.rand}' refererHost='${result.referer.toHttpUrlOrNull()?.host ?: "unknown"}'")
 
         val postHeaders = newHeaders.newBuilder().apply {
             set("Origin", "https://$host")
@@ -120,7 +121,7 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
         }
 
         val videoUrl = source.attr("src")
-        Log.d(tag, "Video source found: $videoUrl")
+        Log.d(tag, "Video source found: ${videoUrl.toHttpUrlOrNull()?.host ?: "unknown"}")
 
         val videoHeaders = Headers.headersOf("Referer", "https://$host/")
 
@@ -134,49 +135,52 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
         return withContext(Dispatchers.Main) {
             suspendCancellableCoroutine { continuation ->
                 val handler = Handler(Looper.getMainLooper())
-                lateinit var wv: WebView
+                var injected = false
 
+                val webView = WebView(applicationContext)
                 val jsInterface = TurnstileJsInterface { res ->
                     if (continuation.isActive) {
-                        handler.post { wv.destroy() }
+                        handler.post { webView.destroy() }
                         continuation.resume(res)
                     }
                 }
 
-                wv = WebView(applicationContext).apply {
-                    settings.javaScriptEnabled = true
-                    settings.domStorageEnabled = true
-                    settings.userAgentString = userAgent
-                    // Cloudflare's challenge runs on challenges.cloudflare.com (cross-origin from
-                    // the target host). Without third-party cookies the challenge state can't be
-                    // persisted, so Turnstile errors out and never issues a token.
-                    CookieManager.getInstance().setAcceptCookie(true)
-                    CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
-                    addJavascriptInterface(jsInterface, "turnstileBridge")
-                    webViewClient = object : WebViewClient() {
-                        override fun onPageFinished(view: WebView?, loadedUrl: String?) {
-                            if (loadedUrl?.contains("/cdn-cgi/") == true) return
-                            view?.evaluateJavascript(POLL_SCRIPT) {}
-                        }
+                webView.settings.javaScriptEnabled = true
+                webView.settings.domStorageEnabled = true
+                webView.settings.userAgentString = userAgent
+                // Cloudflare's challenge runs on challenges.cloudflare.com (cross-origin from
+                // the target host). Without third-party cookies the challenge state can't be
+                // persisted, so Turnstile errors out and never issues a token.
+                CookieManager.getInstance().setAcceptCookie(true)
+                CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
+                webView.addJavascriptInterface(jsInterface, "turnstileBridge")
+                webView.webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView?, loadedUrl: String?) {
+                        if (loadedUrl?.contains("/cdn-cgi/") == true) return
+                        if (injected) return
+                        injected = true
+                        view?.evaluateJavascript(POLL_SCRIPT) {}
                     }
-                    loadUrl(url)
                 }
+                webView.loadUrl(url)
 
                 continuation.invokeOnCancellation {
-                    handler.post { wv.destroy() }
+                    handler.post { webView.destroy() }
                 }
             }
         }
     }
 
-    private fun webViewCookies(url: String): String = runCatching {
-        CookieManager.getInstance()
-            .getCookie(url)
-            ?.split(";")
-            ?.map { it.trim() }
-            ?.filter { it.isNotBlank() }
-            ?.joinToString("; ")
-    }.getOrNull().orEmpty()
+    private suspend fun webViewCookies(url: String): String = withContext(Dispatchers.Main) {
+        runCatching {
+            CookieManager.getInstance()
+                .getCookie(url)
+                ?.split(";")
+                ?.map { it.trim() }
+                ?.filter { it.isNotBlank() }
+                ?.joinToString("; ")
+        }.getOrNull().orEmpty()
+    }
 
     private data class TurnstileResult(
         val token: String,

--- a/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SendNowExtractor.kt
+++ b/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SendNowExtractor.kt
@@ -1,24 +1,48 @@
 package eu.kanade.tachiyomi.animeextension.pt.smartanimes.extractors
 
+import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.webkit.CookieManager
+import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import eu.kanade.tachiyomi.animesource.model.Video
-import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.applicationContext
 import keiyoushi.utils.useAsJsoup
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
+import kotlin.coroutines.resume
 
 class SendNowExtractor(private val client: OkHttpClient, private val headers: Headers) {
+    private val tag by lazy { javaClass.simpleName }
+
     suspend fun videosFromUrl(url: String, name: String): List<Video> {
-        // Client hints from: https://github.com/keiyoushi/extensions-source/blob/8f70beda06a70f84c79d793367fbdf6b9ea09b5a/src/pt/mangastop/src/eu/kanade/tachiyomi/extension/pt/mangastop/ClientHintsInterceptor.kt#L27
-        val userAgent = headers["User-Agent"]
-            ?: "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36"
+        // Use the WebView's native UA so its Chrome version matches the actual engine.
+        // Cloudflare Turnstile fails (runs the challenge but never issues a token) when the
+        // UA's Chrome version doesn't match the WebView engine version (Mihon #3177).
+        val userAgent = WebSettings.getDefaultUserAgent(applicationContext).ifBlank {
+            headers["User-Agent"]
+                ?: "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36"
+        }
+        Log.d(tag, "Using UA: $userAgent")
 
         val chromeVersion = CHROME_REGEX.find(userAgent)?.groupValues?.get(1) ?: "143"
         val isMobile = userAgent.contains("Android") || userAgent.contains("Mobile")
 
         val secChUa =
-            "\"Google Chrome\";v=\"$chromeVersion\", \"Chromium\";v=\"$chromeVersion\", \"Not A(Brand\";v=\"24\""
+            "\"Google Chrome\";v=\"$chromeVersion\", \"Chromium\";v=\"$chromeVersion\", \"Not A(Brand)\";v=\"24\""
 
         val platform = when {
             userAgent.contains("Windows") -> "\"Windows\""
@@ -50,20 +74,156 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
             set("User-Agent", userAgent)
         }.build()
 
-        val document = client.newCall(GET(url, newHeaders)).awaitSuccess().useAsJsoup()
+        // Solve Cloudflare Turnstile in a WebView and capture the token + form fields from the
+        // same page the WebView loaded (avoids a second OkHttp GET that would re-trigger Cloudflare).
+        Log.d(tag, "Opening WebView to solve Cloudflare Turnstile...")
+        val result = try {
+            withTimeout(30_000) { solveTurnstile(url, userAgent) }
+        } catch (_: TimeoutCancellationException) {
+            Log.e(tag, "Turnstile solving timed out")
+            return emptyList()
+        }
 
-        val source = document.selectFirst("source") ?: return emptyList()
+        if (result.token.isBlank()) {
+            Log.e(tag, "Turnstile token is blank")
+            return emptyList()
+        }
+        Log.d(tag, "Turnstile solved (token length=${result.token.length})")
+
+        val host = url.toHttpUrl().host
+        val cookies = webViewCookies("https://$host/")
+        Log.d(tag, "Challenge page loaded: id='${result.id}' rand='${result.rand}' referer='${result.referer}'")
+
+        val postHeaders = newHeaders.newBuilder().apply {
+            set("Origin", "https://$host")
+            set("Sec-Fetch-Site", "same-origin")
+            if (cookies.isNotBlank()) set("Cookie", cookies)
+        }.build()
+
+        val formBody = FormBody.Builder()
+            .add("op", "download1")
+            .add("id", result.id)
+            .add("rand", result.rand)
+            .add("referer", result.referer)
+            .add("cf-turnstile-response", result.token)
+            .add("download_a", "CONTINUE")
+            .build()
+
+        val postDoc = client.newCall(POST("https://$host/", postHeaders, formBody))
+            .awaitSuccess()
+            .useAsJsoup()
+
+        val source = postDoc.selectFirst("source")
+        if (source == null) {
+            Log.e(tag, "No <source> element in POST response")
+            return emptyList()
+        }
 
         val videoUrl = source.attr("src")
+        Log.d(tag, "Video source found: $videoUrl")
 
-        val videoHeaders = Headers.headersOf("Referer", "https://${url.toHttpUrl().host}/")
+        val videoHeaders = Headers.headersOf("Referer", "https://$host/")
 
         return listOf(
             Video(videoUrl, name, videoUrl, videoHeaders),
         )
     }
 
+    @SuppressLint("SetJavaScriptEnabled")
+    private suspend fun solveTurnstile(url: String, userAgent: String): TurnstileResult {
+        return withContext(Dispatchers.Main) {
+            suspendCancellableCoroutine { continuation ->
+                val handler = Handler(Looper.getMainLooper())
+                lateinit var wv: WebView
+
+                val jsInterface = TurnstileJsInterface { res ->
+                    if (continuation.isActive) {
+                        handler.post { wv.destroy() }
+                        continuation.resume(res)
+                    }
+                }
+
+                wv = WebView(applicationContext).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.userAgentString = userAgent
+                    // Cloudflare's challenge runs on challenges.cloudflare.com (cross-origin from
+                    // the target host). Without third-party cookies the challenge state can't be
+                    // persisted, so Turnstile errors out and never issues a token.
+                    CookieManager.getInstance().setAcceptCookie(true)
+                    CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+                    addJavascriptInterface(jsInterface, "turnstileBridge")
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: WebView?, loadedUrl: String?) {
+                            if (loadedUrl?.contains("/cdn-cgi/") == true) return
+                            view?.evaluateJavascript(POLL_SCRIPT) {}
+                        }
+                    }
+                    loadUrl(url)
+                }
+
+                continuation.invokeOnCancellation {
+                    handler.post { wv.destroy() }
+                }
+            }
+        }
+    }
+
+    private fun webViewCookies(url: String): String = runCatching {
+        CookieManager.getInstance()
+            .getCookie(url)
+            ?.split(";")
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() }
+            ?.joinToString("; ")
+    }.getOrNull().orEmpty()
+
+    private data class TurnstileResult(
+        val token: String,
+        val id: String,
+        val rand: String,
+        val referer: String,
+    )
+
+    private class TurnstileJsInterface(private val onResult: (TurnstileResult) -> Unit) {
+        private var delivered = false
+
+        @JavascriptInterface
+        fun onResult(token: String, id: String, rand: String, referer: String) {
+            if (delivered) return
+            delivered = true
+            onResult(TurnstileResult(token, id, rand, referer))
+        }
+    }
+
     companion object {
         private val CHROME_REGEX = Regex("""Chrome/(\d+)""")
+
+        private val POLL_SCRIPT = """
+            (function() {
+                var tries = 0;
+                var interval = setInterval(function() {
+                    tries++;
+                    var input = document.querySelector('input[name="cf-turnstile-response"]');
+                    var token = (input && input.value) ? input.value
+                        : (document.getElementById('turnstile_callback') ? document.getElementById('turnstile_callback').value : '');
+                    if (token) {
+                        clearInterval(interval);
+                        var idEl = document.querySelector('input[name="id"]');
+                        var randEl = document.querySelector('input[name="rand"]');
+                        var refEl = document.querySelector('input[name="referer"]');
+                        turnstileBridge.onResult(
+                            token,
+                            idEl ? idEl.value : '',
+                            randEl ? randEl.value : '',
+                            refEl ? refEl.value : ''
+                        );
+                    } else if (tries > 120) {
+                        clearInterval(interval);
+                        turnstileBridge.onResult('', '', '', '');
+                    }
+                }, 250);
+            })();
+        """.trimIndent()
     }
 }

--- a/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SendNowExtractor.kt
+++ b/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SendNowExtractor.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.applicationContext
 import keiyoushi.utils.useAsJsoup
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -33,10 +34,14 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
         // Use the WebView's native UA so its Chrome version matches the actual engine.
         // Cloudflare Turnstile fails (runs the challenge but never issues a token) when the
         // UA's Chrome version doesn't match the WebView engine version (Mihon #3177).
-        val userAgent = WebSettings.getDefaultUserAgent(applicationContext).ifBlank {
+        // getDefaultUserAgent can throw on devices without the WebView package, so fall back.
+        val fallbackUa =
             headers["User-Agent"]
                 ?: "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36"
-        }
+        val userAgent = runCatching { WebSettings.getDefaultUserAgent(applicationContext) }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: fallbackUa
         Log.d(tag, "Using UA: $userAgent")
 
         val chromeVersion = CHROME_REGEX.find(userAgent)?.groupValues?.get(1) ?: "143"
@@ -82,6 +87,11 @@ class SendNowExtractor(private val client: OkHttpClient, private val headers: He
             withTimeout(45_000) { solveTurnstile(url, userAgent) }
         } catch (_: TimeoutCancellationException) {
             Log.e(tag, "Turnstile solving timed out")
+            return emptyList()
+        } catch (e: Exception) {
+            // Preserve coroutine cancellation; only treat other failures as "no videos".
+            if (e is CancellationException) throw e
+            Log.e(tag, "Turnstile solving failed", e)
             return emptyList()
         }
 

--- a/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SmartAnimesExtractor.kt
+++ b/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SmartAnimesExtractor.kt
@@ -1,9 +1,11 @@
 package eu.kanade.tachiyomi.animeextension.pt.smartanimes.extractors
 
+import android.util.Log
 import aniyomi.lib.googledriveplayerextractor.GoogleDrivePlayerExtractor
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.bodyString
 import keiyoushi.utils.parseAs
@@ -13,6 +15,8 @@ import okhttp3.Headers
 import okhttp3.OkHttpClient
 
 class SmartAnimesExtractor(private val client: OkHttpClient, private val headers: Headers) {
+    private val tag by lazy { javaClass.simpleName }
+
     private val noRedirectClient = client.newBuilder()
         .followRedirects(false)
         .build()
@@ -21,15 +25,18 @@ class SmartAnimesExtractor(private val client: OkHttpClient, private val headers
     private val sendNowExtractor by lazy { SendNowExtractor(client, headers) }
 
     suspend fun videosFromUrl(url: String, name: String): List<Video> {
+        Log.d(tag, "videosFromUrl: $url")
         val content = client.newCall(GET(url, headers)).awaitSuccess().bodyString()
 
         val item = content.substringAfter("var item = ", "")
             .substringBefore(";")
             .parseAs<ItemDto>()
+        Log.d(tag, "Parsed item (id=${item.id}, post=${item.post})")
 
         val options = content.substringAfter("var options = ", "")
             .substringBefore(";")
             .parseAs<OptionsDto>()
+        Log.d(tag, "Parsed options (ajaxurl=${options.soralink_ajaxurl})")
 
         val newHeaders = headers.newBuilder()
             .set("Referer", item.post)
@@ -49,14 +56,27 @@ class SmartAnimesExtractor(private val client: OkHttpClient, private val headers
 
         val sourceUrl =
             noRedirectClient.newCall(POST(options.soralink_ajaxurl, newHeaders, formBody))
-                .awaitSuccess().use { it.header("location") }
-                ?: return emptyList()
+                .await().use { it.header("location") }
+                ?: run {
+                    Log.e(tag, "No redirect location from soralink POST")
+                    return emptyList()
+                }
+        Log.d(tag, "Resolved source url: $sourceUrl")
 
         return when {
-            "drive.google.com" in sourceUrl -> gdriveExtractor.videosFromUrl(sourceUrl)
-            "send.now" in sourceUrl -> sendNowExtractor.videosFromUrl(sourceUrl, name)
+            "drive.google.com" in sourceUrl -> {
+                Log.d(tag, "Delegating to GoogleDrivePlayerExtractor")
+                gdriveExtractor.videosFromUrl(sourceUrl)
+            }
+            "send.now" in sourceUrl -> {
+                Log.d(tag, "Delegating to SendNowExtractor")
+                sendNowExtractor.videosFromUrl(sourceUrl, name)
+            }
 
-            else -> emptyList()
+            else -> {
+                Log.e(tag, "Unknown source host: $sourceUrl")
+                emptyList()
+            }
         }
     }
 

--- a/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SmartAnimesExtractor.kt
+++ b/src/pt/smartanimes/src/eu/kanade/tachiyomi/animeextension/pt/smartanimes/extractors/SmartAnimesExtractor.kt
@@ -12,6 +12,7 @@ import keiyoushi.utils.parseAs
 import kotlinx.serialization.Serializable
 import okhttp3.FormBody
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 
 class SmartAnimesExtractor(private val client: OkHttpClient, private val headers: Headers) {
@@ -25,7 +26,7 @@ class SmartAnimesExtractor(private val client: OkHttpClient, private val headers
     private val sendNowExtractor by lazy { SendNowExtractor(client, headers) }
 
     suspend fun videosFromUrl(url: String, name: String): List<Video> {
-        Log.d(tag, "videosFromUrl: $url")
+        Log.d(tag, "videosFromUrl: ${url.toHttpUrlOrNull()?.host ?: "unknown"}")
         val content = client.newCall(GET(url, headers)).awaitSuccess().bodyString()
 
         val item = content.substringAfter("var item = ", "")
@@ -61,7 +62,7 @@ class SmartAnimesExtractor(private val client: OkHttpClient, private val headers
                     Log.e(tag, "No redirect location from soralink POST")
                     return emptyList()
                 }
-        Log.d(tag, "Resolved source url: $sourceUrl")
+        Log.d(tag, "Resolved source host: ${sourceUrl.toHttpUrlOrNull()?.host ?: "unknown"}")
 
         return when {
             "drive.google.com" in sourceUrl -> {


### PR DESCRIPTION
Closes #576 

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve SmartAnimes streaming extraction reliability by correctly resolving SendNow links behind Cloudflare Turnstile and hardening source resolution flow.

Bug Fixes:
- Restore SendNow video extraction by solving Cloudflare Turnstile challenges and submitting the required form to obtain the stream URL.
- Prevent failures when SmartAnimes soralink responses return redirects without a success status by handling the Location header directly.

Enhancements:
- Align user-agent and client hints with the WebView engine and propagate cookies from WebView to network requests for more robust challenge handling.
- Add logging across SmartAnimes and SendNow extractors to aid in debugging source resolution and failure cases.

Build:
- Bump SmartAnimes extension overrideVersionCode to trigger client updates.