### PR TITLE
MissAV [ALL]: Fix HTTP 403 on video playback (fix #633)

### DIFF
--- a/src/all/missav/build.gradle
+++ b/src/all/missav/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MissAV'
     extClass = '.MissAV'
-    extVersionCode = 25
+    extVersionCode = 26
     isNsfw = true
 }
 
@@ -11,4 +11,5 @@ dependencies {
     implementation(project(':lib:unpacker'))
     implementation(project(':lib:playlistutils'))
     implementation(project(':lib:javcoverfetcher'))
+    implementation(project(':lib:m3u8server'))
 }

--- a/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
+++ b/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.preference.PreferenceScreen
 import aniyomi.lib.javcoverfetcher.JavCoverFetcher
 import aniyomi.lib.javcoverfetcher.JavCoverFetcher.fetchHDCovers
+import aniyomi.lib.m3u8server.M3u8Integration
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -57,6 +58,10 @@ class MissAV :
 
     private var playlistExtractor by LazyMutable {
         PlaylistUtils(client, docHeaders)
+    }
+
+    private val m3u8Integration by lazy {
+        M3u8Integration(client)
     }
 
     override fun popularAnimeRequest(page: Int) = GET("$baseUrl/en/today-hot?page=$page", docHeaders)
@@ -236,6 +241,7 @@ class MissAV :
         val masterPlaylist = playlists.substringAfter("source=\"").substringBefore("\";")
 
         return playlistExtractor.extractFromHls(masterPlaylist, referer = "$baseUrl/")
+            .let(m3u8Integration::processVideoList)
     }
 
     override fun List<Video>.sort(): List<Video> {


### PR DESCRIPTION
Closes #542.

`surrit.com` CDN added Cloudflare WAF. OkHttp passes, but mpv's ffmpeg TLS fingerprint gets blocked with 403. Route HLS playback through the local `m3u8server` proxy so all upstream fetches use OkHttp.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Route MissAV HLS video playback through the local m3u8 proxy to avoid CDN 403 errors and update the extension metadata accordingly.

Bug Fixes:
- Fix HTTP 403 errors on MissAV video playback by proxying HLS streams through OkHttp via the m3u8server integration.

Enhancements:
- Integrate the shared m3u8server library into the MissAV extension for HLS playlist handling.

Build:
- Bump MissAV extension version code and add the m3u8server library dependency in the Gradle configuration.