### PR TITLE
Update MonosChinos extension for redesign website

### DIFF
--- a/src/es/monoschinos/build.gradle
+++ b/src/es/monoschinos/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MonosChinos'
     extClass = '.MonosChinos'
-    extVersionCode = 53
+    extVersionCode = 54
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -75,7 +75,6 @@ class MonosChinos :
 
     override fun popularAnimeParse(response: Response): AnimesPage {
         val document = response.asJsoup()
-
         val elements = document.select("article a.card-wrap")
         val nextPage = document.selectFirst("a[rel='next']") != null
         val animeList = elements.mapNotNull { element ->
@@ -97,7 +96,6 @@ class MonosChinos :
 
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val document = response.asJsoup()
-
         val episodeItems = document.select("section:has(h2:contains(Últimos capítulos)) article a.card-wrap")
         val animeList = episodeItems.mapNotNull { a ->
             val episodeUrl = a.attr("abs:href")
@@ -106,14 +104,12 @@ class MonosChinos :
             val animeUrl = "/anime/$animeSlugBase-sub-espanol"
 
             val title = a.selectFirst("h3.card-title")?.text()?.trim() ?: return@mapNotNull null
-
             val episodeNumber = a.selectFirst("div.absolute.top-2.5")?.text()
                 ?.replace("EP ", "")?.trim() ?: ""
 
             SAnime.create().apply {
                 this.title = "$title - Episodio $episodeNumber"
                 setUrlWithoutDomain(animeUrl)
-
                 description = a.selectFirst("div.mt-1 span")?.text()?.trim()
                 thumbnail_url = a.selectFirst("img.lazy")?.getImageUrl()
             }
@@ -140,11 +136,8 @@ class MonosChinos :
         val document = response.asJsoup()
         return SAnime.create().apply {
             title = document.selectFirst("h1.font-extrabold")?.text()?.trim() ?: ""
-
             thumbnail_url = document.selectFirst("div.relative[aspect-ratio='2/3'] img.lazy")?.getImageUrl()
-
             description = document.selectFirst(".max-w-\\[640px\\] p.text-white\\/75")?.text()?.trim()
-
             genre = document.select("div.flex.gap-2.flex-wrap a").joinToString { it.text() }
 
             val statusBadge = document.selectFirst("div.absolute.top-3.left-3")
@@ -351,12 +344,17 @@ class MonosChinos :
 
     // ====================== AUXILIARES ======================
 
-    private fun Element.getImageUrl(): String? = when {
-        isValidUrl("data-src") -> attr("abs:data-src")
-        isValidUrl("data-lazy-src") -> attr("abs:data-lazy-src")
-        isValidUrl("srcset") -> attr("abs:srcset").substringBefore(" ")
-        isValidUrl("src") -> attr("abs:src")
-        else -> null
+    
+    private fun Element.getImageUrl(): String? {
+        val candidates = listOf("data-src", "data-lazy-src", "srcset", "src")
+        return candidates.mapNotNull { attr ->
+            when (attr) {
+                "srcset" -> attr("abs:srcset").substringBefore(" ")
+                else -> attr("abs:$attr")
+            }
+        }.firstOrNull { url ->
+            url.isNotBlank() && !url.contains("anime.png")
+        }
     }
 
     private fun Element.isValidUrl(attrName: String): Boolean {

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -108,13 +108,20 @@ class MonosChinos :
                 ?.replace("EP ", "")?.trim() ?: ""
 
             SAnime.create().apply {
-                this.title = "$title - Episodio $episodeNumber"
+                this.title = if (episodeNumber.isNotBlank()) {
+                    "$title - Episodio $episodeNumber"
+                } else {
+                    title
+                }
                 setUrlWithoutDomain(animeUrl)
                 description = a.selectFirst("div.mt-1 span")?.text()?.trim()
                 thumbnail_url = a.selectFirst("img.lazy")?.getImageUrl()
             }
         }
-        return AnimesPage(animeList, false)
+
+        // Restaurar paginación usando el mismo selector que en popularAnimeParse
+        val nextPage = document.selectFirst("a[rel='next']") != null
+        return AnimesPage(animeList, nextPage)
     }
 
     // ====================== BÚSQUEDA ======================
@@ -346,20 +353,14 @@ class MonosChinos :
 
     private fun Element.getImageUrl(): String? {
         val candidates = listOf("data-src", "data-lazy-src", "srcset", "src")
-        return candidates.mapNotNull { attr ->
-            when (attr) {
-                "srcset" -> attr("abs:srcset").substringBefore(" ")
-                else -> attr("abs:$attr")
+        return candidates.mapNotNull { name ->
+            when (name) {
+                "srcset" -> this.attr("abs:srcset").substringBefore(" ")
+                else -> this.attr("abs:$name")
             }
         }.firstOrNull { url ->
             url.isNotBlank() && !url.contains("anime.png")
         }
-    }
-
-    private fun Element.isValidUrl(attrName: String): Boolean {
-        if (!hasAttr(attrName)) return false
-        val url = attr(attrName)
-        return url.isNotBlank() && !url.contains("anime.png")
     }
 
     // ====================== FILTROS ======================

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -25,10 +25,10 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.catchingFlatMapBlocking
 import keiyoushi.utils.getPreferencesLazy
-import keiyoushi.utils.parseAs
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response
+import org.json.JSONObject
 import org.jsoup.nodes.Element
 
 class MonosChinos :
@@ -63,10 +63,6 @@ class MonosChinos :
             "Mp4Upload",
             "LuluStream",
         )
-
-        private val EPISODE_SLUG_REGEX = Regex("-episodio-(\\d+|[\\d.]+)$")
-        private val SUB_ES_REGEX = Regex("-sub-espanol$")
-        private val QUALITY_REGEX = Regex("""(\d+)p""")
     }
 
     // ====================== POPULAR ======================
@@ -75,12 +71,12 @@ class MonosChinos :
 
     override fun popularAnimeParse(response: Response): AnimesPage {
         val document = response.asJsoup()
-        val elements = document.select("li.ficha_efecto a")
-        val nextPage = document.selectFirst(".pagination a:has(span:containsOwn(»))") != null
+        val elements = document.select("article a.card-wrap")
+        val nextPage = document.selectFirst("a[rel='next']") != null
         val animeList = elements.mapNotNull { element ->
             SAnime.create().apply {
-                title = element.selectFirst("h3")?.text() ?: return@mapNotNull null
-                thumbnail_url = element.selectFirst("img")?.getImageUrl()
+                title = element.selectFirst("h3.card-title")?.text()?.trim() ?: return@mapNotNull null
+                thumbnail_url = element.selectFirst("img.lazy")?.getImageUrl()
                 setUrlWithoutDomain(element.attr("abs:href"))
             }
         }
@@ -96,28 +92,25 @@ class MonosChinos :
 
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val document = response.asJsoup()
-        val episodeItems = document.select("ul.row.row-cols-xl-4.row-cols-lg-4.row-cols-md-3.row-cols-2 > li.col.mb-4")
-        val animeList = episodeItems.mapNotNull { item ->
-            val episodeLink = item.selectFirst("a") ?: return@mapNotNull null
-            val episodeUrl = episodeLink.attr("abs:href")
+        val episodeItems = document.select("section:has(h2:contains(Últimos capítulos)) article a.card-wrap")
+        val animeList = episodeItems.mapNotNull { a ->
+            val episodeUrl = a.attr("abs:href")
+            val episodeSlug = episodeUrl.substringAfter("/ver/").substringBefore("-episodio-")
+            if (episodeSlug.isBlank()) return@mapNotNull null
+            val animeUrl = "/anime/${episodeSlug}-sub-espanol"
 
-            val episodeSlug = episodeUrl.substringAfter("/ver/").substringBefore("?")
-            val animeSlugBase = episodeSlug.replace(EPISODE_SLUG_REGEX, "")
-            val animeUrl = "/anime/$animeSlugBase-sub-espanol"
-
-            val animeTitle = item.selectFirst("h2.fs-5")?.text() ?: return@mapNotNull null
-            val genre = item.selectFirst("span.text-muted")?.text() ?: ""
+            val title = a.selectFirst("h3.card-title")?.text()?.trim() ?: return@mapNotNull null
+            val episodeNumber = a.selectFirst("div.absolute.top-2.5")?.text()
+                ?.replace("EP ", "")?.trim() ?: ""
 
             SAnime.create().apply {
-                title = animeTitle
+                this.title = "$title - Episodio $episodeNumber"
                 setUrlWithoutDomain(animeUrl)
-                description = genre
-                thumbnail_url = item.selectFirst("img.lazy")?.getImageUrl()
+                description = a.selectFirst("div.mt-1 span")?.text()?.trim()
+                thumbnail_url = a.selectFirst("img.lazy")?.getImageUrl()
             }
         }
-
-        val nextPage = document.selectFirst(".pagination a:has(span:containsOwn(»))") != null
-        return AnimesPage(animeList, nextPage)
+        return AnimesPage(animeList, false)
     }
 
     // ====================== BÚSQUEDA ======================
@@ -137,20 +130,26 @@ class MonosChinos :
 
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.asJsoup()
-        return SAnime.create().apply {
-            title = document.selectFirst("h1.fs-2.text-capitalize.text-light")?.text() ?: ""
-            description = document.selectFirst("#profile-tab-pane .mb-3 p")?.text()
-            genre = document.select("#profile-tab-pane .badge.bg-secondary").joinToString { it.text() }
-            thumbnail_url = document.selectFirst(".d-none.d-sm-flex img.lazy")?.getImageUrl()
-            status = run {
-                val estadoElement = document.selectFirst(".col:has(.text-muted:contains(Estado)) div.ms-2 div:last-child")
-                when (estadoElement?.text()) {
-                    "Estreno", "En emisión" -> SAnime.ONGOING
-                    "Finalizado" -> SAnime.COMPLETED
-                    else -> SAnime.UNKNOWN
-                }
+        val anime = SAnime.create()
+
+        anime.title = document.selectFirst("h1.font-extrabold")?.text()?.trim() ?: ""
+        anime.thumbnail_url = document.selectFirst("div.relative[aspect-ratio='2/3'] img.lazy")?.getImageUrl()
+        anime.description = document.selectFirst(".max-w-\\[640px\\] p.text-white\\/75")?.text()?.trim()
+        anime.genre = document.select("div.flex.gap-2.flex-wrap a").joinToString { it.text() }
+
+        val statusBadge = document.selectFirst("div.absolute.top-3.left-3")
+        anime.status = if (statusBadge != null) {
+            val statusText = statusBadge.text().trim()
+            when {
+                statusText.contains("Estreno") || statusText.contains("En emisión") -> SAnime.ONGOING
+                statusText.contains("Finalizado") -> SAnime.COMPLETED
+                else -> SAnime.UNKNOWN
             }
+        } else {
+            SAnime.UNKNOWN
         }
+
+        return anime
     }
 
     // ====================== EPISODIOS ======================
@@ -170,7 +169,7 @@ class MonosChinos :
             ?.substringBefore("-episodio-")
             ?: run {
                 val animeSlug = referer.substringAfter("/anime/").substringBefore("?").substringBefore("#")
-                animeSlug.replace(SUB_ES_REGEX, "")
+                animeSlug.replace(Regex("-sub-espanol$"), "")
             }
         if (episodeSlug.isBlank()) return emptyList()
 
@@ -199,17 +198,34 @@ class MonosChinos :
                 .header("Accept", "application/json, text/javascript, */*; q=0.01")
                 .build()
 
-            val json = try {
-                client.newCall(request).execute().parseAs<EpisodesDto>()
+            val responseBody = try {
+                client.newCall(request).execute().use { it.body?.string() ?: "" }
             } catch (_: Exception) {
                 break
             }
 
-            for (obj in json.eps) {
-                val numStr = obj.num.toString()
+            if (responseBody.isBlank()) break
+
+            val json = try {
+                JSONObject(responseBody)
+            } catch (_: Exception) {
+                break
+            }
+
+            val epsArray = try {
+                json.getJSONArray("eps")
+            } catch (_: Exception) {
+                break
+            }
+
+            val perpage = json.optInt("perpage", 0)
+
+            for (i in 0 until epsArray.length()) {
+                val obj = epsArray.getJSONObject(i)
+                val numStr = obj.optString("num", "")
                 if (numStr.isBlank()) continue
 
-                val episodeNumber = numStr.toFloatOrNull() ?: continue
+                val episodeNumber = runCatching { numStr.toFloat() }.getOrNull() ?: continue
 
                 val urlNumber = if (episodeNumber % 1 == 0f) {
                     episodeNumber.toInt().toString()
@@ -217,24 +233,21 @@ class MonosChinos :
                     numStr
                 }
 
-                episodes.add(
-                    SEpisode.create().apply {
-                        name = if (episodeNumber % 1 == 0f) {
-                            "Episodio ${episodeNumber.toInt()}"
-                        } else {
-                            "Episodio $numStr"
-                        }
-                        episode_number = episodeNumber
-                        setUrlWithoutDomain("/ver/$episodeSlug-episodio-$urlNumber")
-                    },
-                )
+                episodes.add(SEpisode.create().apply {
+                    name = if (episodeNumber % 1 == 0f) {
+                        "Episodio ${episodeNumber.toInt()}"
+                    } else {
+                        "Episodio $numStr"
+                    }
+                    episode_number = episodeNumber
+                    setUrlWithoutDomain("/ver/$episodeSlug-episodio-$urlNumber")
+                })
             }
 
-            val perpage = json.perpage?.toInt() ?: 0
-
-            if (perpage == 0 || json.eps.size < perpage) {
+            if (perpage == 0 || epsArray.length() < perpage) {
                 hasMore = false
             } else {
+                Thread.sleep(100)
                 currentPage++
             }
         }
@@ -257,7 +270,7 @@ class MonosChinos :
             } ?: return@mapNotNull null
 
             val serverName = button.attr("data-server").takeIf { it.isNotBlank() }
-                ?: button.text().takeIf { it.isNotBlank() }
+                ?: button.text().trim().takeIf { it.isNotBlank() }
                 ?: ""
 
             serverName to decodedUrl
@@ -333,12 +346,12 @@ class MonosChinos :
         val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
         val server = preferences.getString(PREF_SERVER_KEY, PREF_SERVER_DEFAULT)!!
         return this.sortedWith(
-            compareBy<Video>(
+            compareBy(
                 { it.quality.contains(server, true) },
                 { it.quality.contains(quality) },
-                { QUALITY_REGEX.find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
-            ).reversed(),
-        )
+                { Regex("""(\d+)p""").find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
+            ),
+        ).reversed()
     }
 
     // ====================== AUXILIARES ======================

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -119,7 +119,6 @@ class MonosChinos :
             }
         }
 
-        // Restaurar paginación usando el mismo selector que en popularAnimeParse
         val nextPage = document.selectFirst("a[rel='next']") != null
         return AnimesPage(animeList, nextPage)
     }
@@ -143,8 +142,12 @@ class MonosChinos :
         val document = response.asJsoup()
         return SAnime.create().apply {
             title = document.selectFirst("h1.font-extrabold")?.text()?.trim() ?: ""
-            thumbnail_url = document.selectFirst("div.relative[aspect-ratio='2/3'] img.lazy")?.getImageUrl()
-            description = document.selectFirst(".max-w-\\[640px\\] p.text-white\\/75")?.text()?.trim()
+
+            thumbnail_url = document.selectFirst("div.shrink-0 img.lazy")?.getImageUrl()
+
+            description = document.selectFirst("p[class*=\"max-w-\"]")?.text()?.trim()
+                ?: document.selectFirst("#tab-info p")?.text()?.trim()
+
             genre = document.select("div.flex.gap-2.flex-wrap a").joinToString { it.text() }
 
             val statusBadge = document.selectFirst("div.absolute.top-3.left-3")

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -344,7 +344,6 @@ class MonosChinos :
 
     // ====================== AUXILIARES ======================
 
-    
     private fun Element.getImageUrl(): String? {
         val candidates = listOf("data-src", "data-lazy-src", "srcset", "src")
         return candidates.mapNotNull { attr ->

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -75,7 +75,7 @@ class MonosChinos :
 
     override fun popularAnimeParse(response: Response): AnimesPage {
         val document = response.asJsoup()
-        
+
         val elements = document.select("article a.card-wrap")
         val nextPage = document.selectFirst("a[rel='next']") != null
         val animeList = elements.mapNotNull { element ->
@@ -97,7 +97,7 @@ class MonosChinos :
 
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val document = response.asJsoup()
-        
+
         val episodeItems = document.select("section:has(h2:contains(Últimos capítulos)) article a.card-wrap")
         val animeList = episodeItems.mapNotNull { a ->
             val episodeUrl = a.attr("abs:href")
@@ -106,14 +106,14 @@ class MonosChinos :
             val animeUrl = "/anime/$animeSlugBase-sub-espanol"
 
             val title = a.selectFirst("h3.card-title")?.text()?.trim() ?: return@mapNotNull null
-            
+
             val episodeNumber = a.selectFirst("div.absolute.top-2.5")?.text()
                 ?.replace("EP ", "")?.trim() ?: ""
 
             SAnime.create().apply {
                 this.title = "$title - Episodio $episodeNumber"
                 setUrlWithoutDomain(animeUrl)
-                
+
                 description = a.selectFirst("div.mt-1 span")?.text()?.trim()
                 thumbnail_url = a.selectFirst("img.lazy")?.getImageUrl()
             }
@@ -139,16 +139,14 @@ class MonosChinos :
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.asJsoup()
         return SAnime.create().apply {
-            
             title = document.selectFirst("h1.font-extrabold")?.text()?.trim() ?: ""
-            
+
             thumbnail_url = document.selectFirst("div.relative[aspect-ratio='2/3'] img.lazy")?.getImageUrl()
-            
+
             description = document.selectFirst(".max-w-\\[640px\\] p.text-white\\/75")?.text()?.trim()
-            
+
             genre = document.select("div.flex.gap-2.flex-wrap a").joinToString { it.text() }
 
-            
             val statusBadge = document.selectFirst("div.absolute.top-3.left-3")
             status = if (statusBadge != null) {
                 val statusText = statusBadge.text().trim()

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -25,10 +25,10 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.catchingFlatMapBlocking
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parseAs
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response
-import org.json.JSONObject
 import org.jsoup.nodes.Element
 
 class MonosChinos :
@@ -63,6 +63,10 @@ class MonosChinos :
             "Mp4Upload",
             "LuluStream",
         )
+
+        private val EPISODE_SLUG_REGEX = Regex("-episodio-(\\d+|[\\d.]+)$")
+        private val SUB_ES_REGEX = Regex("-sub-espanol$")
+        private val QUALITY_REGEX = Regex("""(\d+)p""")
     }
 
     // ====================== POPULAR ======================
@@ -71,6 +75,7 @@ class MonosChinos :
 
     override fun popularAnimeParse(response: Response): AnimesPage {
         val document = response.asJsoup()
+        
         val elements = document.select("article a.card-wrap")
         val nextPage = document.selectFirst("a[rel='next']") != null
         val animeList = elements.mapNotNull { element ->
@@ -92,20 +97,23 @@ class MonosChinos :
 
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val document = response.asJsoup()
+        
         val episodeItems = document.select("section:has(h2:contains(Últimos capítulos)) article a.card-wrap")
         val animeList = episodeItems.mapNotNull { a ->
             val episodeUrl = a.attr("abs:href")
-            val episodeSlug = episodeUrl.substringAfter("/ver/").substringBefore("-episodio-")
-            if (episodeSlug.isBlank()) return@mapNotNull null
-            val animeUrl = "/anime/${episodeSlug}-sub-espanol"
+            val episodeSlug = episodeUrl.substringAfter("/ver/").substringBefore("?")
+            val animeSlugBase = episodeSlug.replace(EPISODE_SLUG_REGEX, "")
+            val animeUrl = "/anime/$animeSlugBase-sub-espanol"
 
             val title = a.selectFirst("h3.card-title")?.text()?.trim() ?: return@mapNotNull null
+            
             val episodeNumber = a.selectFirst("div.absolute.top-2.5")?.text()
                 ?.replace("EP ", "")?.trim() ?: ""
 
             SAnime.create().apply {
                 this.title = "$title - Episodio $episodeNumber"
                 setUrlWithoutDomain(animeUrl)
+                
                 description = a.selectFirst("div.mt-1 span")?.text()?.trim()
                 thumbnail_url = a.selectFirst("img.lazy")?.getImageUrl()
             }
@@ -130,26 +138,29 @@ class MonosChinos :
 
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.asJsoup()
-        val anime = SAnime.create()
+        return SAnime.create().apply {
+            
+            title = document.selectFirst("h1.font-extrabold")?.text()?.trim() ?: ""
+            
+            thumbnail_url = document.selectFirst("div.relative[aspect-ratio='2/3'] img.lazy")?.getImageUrl()
+            
+            description = document.selectFirst(".max-w-\\[640px\\] p.text-white\\/75")?.text()?.trim()
+            
+            genre = document.select("div.flex.gap-2.flex-wrap a").joinToString { it.text() }
 
-        anime.title = document.selectFirst("h1.font-extrabold")?.text()?.trim() ?: ""
-        anime.thumbnail_url = document.selectFirst("div.relative[aspect-ratio='2/3'] img.lazy")?.getImageUrl()
-        anime.description = document.selectFirst(".max-w-\\[640px\\] p.text-white\\/75")?.text()?.trim()
-        anime.genre = document.select("div.flex.gap-2.flex-wrap a").joinToString { it.text() }
-
-        val statusBadge = document.selectFirst("div.absolute.top-3.left-3")
-        anime.status = if (statusBadge != null) {
-            val statusText = statusBadge.text().trim()
-            when {
-                statusText.contains("Estreno") || statusText.contains("En emisión") -> SAnime.ONGOING
-                statusText.contains("Finalizado") -> SAnime.COMPLETED
-                else -> SAnime.UNKNOWN
+            
+            val statusBadge = document.selectFirst("div.absolute.top-3.left-3")
+            status = if (statusBadge != null) {
+                val statusText = statusBadge.text().trim()
+                when {
+                    statusText.contains("Estreno") || statusText.contains("En emisión") -> SAnime.ONGOING
+                    statusText.contains("Finalizado") -> SAnime.COMPLETED
+                    else -> SAnime.UNKNOWN
+                }
+            } else {
+                SAnime.UNKNOWN
             }
-        } else {
-            SAnime.UNKNOWN
         }
-
-        return anime
     }
 
     // ====================== EPISODIOS ======================
@@ -169,7 +180,7 @@ class MonosChinos :
             ?.substringBefore("-episodio-")
             ?: run {
                 val animeSlug = referer.substringAfter("/anime/").substringBefore("?").substringBefore("#")
-                animeSlug.replace(Regex("-sub-espanol$"), "")
+                animeSlug.replace(SUB_ES_REGEX, "")
             }
         if (episodeSlug.isBlank()) return emptyList()
 
@@ -198,34 +209,17 @@ class MonosChinos :
                 .header("Accept", "application/json, text/javascript, */*; q=0.01")
                 .build()
 
-            val responseBody = try {
-                client.newCall(request).execute().use { it.body?.string() ?: "" }
-            } catch (_: Exception) {
-                break
-            }
-
-            if (responseBody.isBlank()) break
-
             val json = try {
-                JSONObject(responseBody)
+                client.newCall(request).execute().parseAs<EpisodesDto>()
             } catch (_: Exception) {
                 break
             }
 
-            val epsArray = try {
-                json.getJSONArray("eps")
-            } catch (_: Exception) {
-                break
-            }
-
-            val perpage = json.optInt("perpage", 0)
-
-            for (i in 0 until epsArray.length()) {
-                val obj = epsArray.getJSONObject(i)
-                val numStr = obj.optString("num", "")
+            for (obj in json.eps) {
+                val numStr = obj.num.toString()
                 if (numStr.isBlank()) continue
 
-                val episodeNumber = runCatching { numStr.toFloat() }.getOrNull() ?: continue
+                val episodeNumber = numStr.toFloatOrNull() ?: continue
 
                 val urlNumber = if (episodeNumber % 1 == 0f) {
                     episodeNumber.toInt().toString()
@@ -233,21 +227,24 @@ class MonosChinos :
                     numStr
                 }
 
-                episodes.add(SEpisode.create().apply {
-                    name = if (episodeNumber % 1 == 0f) {
-                        "Episodio ${episodeNumber.toInt()}"
-                    } else {
-                        "Episodio $numStr"
-                    }
-                    episode_number = episodeNumber
-                    setUrlWithoutDomain("/ver/$episodeSlug-episodio-$urlNumber")
-                })
+                episodes.add(
+                    SEpisode.create().apply {
+                        name = if (episodeNumber % 1 == 0f) {
+                            "Episodio ${episodeNumber.toInt()}"
+                        } else {
+                            "Episodio $numStr"
+                        }
+                        episode_number = episodeNumber
+                        setUrlWithoutDomain("/ver/$episodeSlug-episodio-$urlNumber")
+                    },
+                )
             }
 
-            if (perpage == 0 || epsArray.length() < perpage) {
+            val perpage = json.perpage?.toInt() ?: 0
+
+            if (perpage == 0 || json.eps.size < perpage) {
                 hasMore = false
             } else {
-                Thread.sleep(100)
                 currentPage++
             }
         }
@@ -346,12 +343,12 @@ class MonosChinos :
         val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
         val server = preferences.getString(PREF_SERVER_KEY, PREF_SERVER_DEFAULT)!!
         return this.sortedWith(
-            compareBy(
+            compareBy<Video>(
                 { it.quality.contains(server, true) },
                 { it.quality.contains(quality) },
-                { Regex("""(\d+)p""").find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
-            ),
-        ).reversed()
+                { QUALITY_REGEX.find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
+            ).reversed(),
+        )
     }
 
     // ====================== AUXILIARES ======================


### PR DESCRIPTION
## Summary
This PR updates the MonosChinos anime extension to work with the site's redesigned HTML structure. All selectors have been updated, image loading improved, and video extraction remains unchanged and fully functional.

---

## What Changed

### 1. Selectors updated for new site design

**Popular Anime**
- Container: `li.ficha_efecto a` → `article a.card-wrap`
- Title: `h3` → `h3.card-title`
- Thumbnail: `img` → `img.lazy`

**Latest Episodes**
- Container: `ul.row.row-cols-* > li.col.mb-4` → `section:has(h2:contains(Últimos capítulos)) article a.card-wrap`
- Episode number: extracted from `div.absolute.top-2.5` (text like "EP 2")
- Genre: extracted from `div.mt-1 span`
- Pagination: restored using `a[rel='next']` selector

**Anime Details**
- Title: `h1.fs-2.text-capitalize.text-light` → `h1.font-extrabold`
- Thumbnail: `.d-none.d-sm-flex img.lazy` → `div.shrink-0 img.lazy`
- Synopsis: `#profile-tab-pane .mb-3 p` → `p[class*="max-w-"]` with fallback `#tab-info p`
- Genres: `#profile-tab-pane .badge.bg-secondary` → `div.flex.gap-2.flex-wrap a`
- Status: badge in `div.absolute.top-3.left-3` (checks for "Estreno", "En emisión", "Finalizado")

### 2. Image loading improvements
- Rewrote `getImageUrl()` to check multiple attributes in order: `data-src` → `data-lazy-src` → `srcset` → `src`
- Automatically filters out placeholder `anime.png`

### 3. Synopsis extraction fix
- Replaced problematic selector `.max-w-\[640px\] p` (caused `SelectorParseException`) with `p[class*="max-w-"]`
- Added fallback `#tab-info p` for cases where the primary selector fails
- No longer throws parsing exceptions due to escaped brackets or slashes in class names

### 4. Thumbnail extraction fix
- Replaced `div.relative[aspect-ratio='2/3']` (failed because `aspect-ratio` is CSS, not HTML) with `div.shrink-0`
- Now reliably loads cover images for all anime in the details page

### 5. Video extraction unchanged
- All server resolvers and extractors (Voe, StreamWish, Filemoon, DoodStream, LuluStream, etc.) remain untouched
- Sorting and preferences work as before

---

## Testing

- ✅ Popular anime list loads with correct titles and thumbnails
- ✅ Latest episodes section shows episode numbers and genres correctly
- ✅ Search and filtering work
- ✅ Anime details page displays all info correctly (title, synopsis, genres, status, cover)
- ✅ Synopsis now extracts correctly without parsing exceptions
- ✅ Cover images load correctly for all anime in details page
- ✅ Episode list (via AJAX) loads and sorts properly
- ✅ Video players are detected and playback works
- ✅ Server/quality preferences are respected
- ✅ Pagination in latest episodes works correctly

---

## Checklist

- [x] Selectors updated to match current HTML structure
- [x] Images load reliably (no placeholders)
- [x] Synopsis extraction works without exceptions
- [x] Cover images load correctly in details page
- [x] Video extraction remains functional
- [x] Filters and preferences unchanged
- [x] Code formatted consistently with existing codebase
- [x] Removed unused helper functions (`isValidUrl`)

---

## Notes
This PR only restores compatibility with the redesigned website. No new features are added, and the video extraction logic (which was working correctly) has not been modified. The most critical fixes were the synopsis selector (which was throwing `SelectorParseException`) and the thumbnail selector (which failed due to CSS attribute selection).

---
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the MonosChinos Spanish anime extension to match the redesigned website structure and maintain compatibility.

Bug Fixes:
- Restore popular, latest, and detail views by updating selectors for the new MonosChinos site layout.
- Ensure anime status, episode metadata, and thumbnails are correctly parsed from the updated HTML.

Enhancements:
- Improve image URL resolution to handle multiple lazy-loading attributes and skip placeholder images.
- Refine latest updates titles to include episode numbers and clean extracted text for titles and server names.

Build:
- Bump the MonosChinos extension version code to trigger client updates.