### PR TITLE
AniDB [EN]: No Results Found Hotfix

### DIFF
--- a/src/en/anidb/build.gradle
+++ b/src/en/anidb/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniDB'
     extClass = '.AniDB'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = true
 }
 

--- a/src/en/anidb/src/eu/kanade/tachiyomi/animeextension/en/anidb/AniDB.kt
+++ b/src/en/anidb/src/eu/kanade/tachiyomi/animeextension/en/anidb/AniDB.kt
@@ -372,33 +372,62 @@ class AniDB :
     private fun parseAnimesPage(response: Response): AnimesPage {
         val document = response.asJsoup()
         val animeMap = linkedMapOf<String, SAnime>()
+        val isBrowse = response.request.url.pathSegments.contains("browse")
 
-        // Priority: Seasons
-        document.select("div.overflow-x-auto.snap-x a[href*=/anime/]").forEach { a ->
-            val url = a.absUrl("href")
-            if (url.isNotEmpty()) {
-                animeMap[url] = SAnime.create().apply {
-                    setUrlWithoutDomain(url)
-                    title = a.attr("title").takeIf { it.isNotEmpty() } ?: a.text()
-                    thumbnail_url = a.selectFirst("img")?.absUrl("src")
+        // Priority 1: Slider (Seasons)
+        if (!isBrowse) {
+            document.select("div.overflow-x-auto.snap-x a[href*=/anime/]").forEach { a ->
+                val url = a.absUrl("href").substringBefore("?")
+                if (url.isNotEmpty() && url !in animeMap) {
+                    val titleText = a.attr("title").takeIf { it.isNotEmpty() } ?: a.text()
+                    if (titleText.isNotEmpty()) {
+                        animeMap[url] = SAnime.create().apply {
+                            setUrlWithoutDomain(url)
+                            title = titleText
+                            thumbnail_url = a.selectFirst("img")?.absUrl("src")
+                        }
+                    }
                 }
             }
         }
 
-        // Standard grid / Relations (skips duplicates already added from seasons)
-        document.select(".anime-grid a.anime-card").forEach { card ->
-            val url = card.absUrl("href")
-            if (url.isNotEmpty() && url !in animeMap) {
-                animeMap[url] = SAnime.create().apply {
-                    setUrlWithoutDomain(url)
-                    title = card.selectFirst("p.text-xs, .card-overlay p")?.text()
-                        ?: card.attr("title")
-                    thumbnail_url = card.selectFirst("img")?.absUrl("src")
+        // Priority 2: Grid Cards (Browse results or "You Might Also Like")
+        document.select("a.anime-card").forEach { card ->
+            val url = card.absUrl("href").substringBefore("?")
+            if (url.contains("/anime/") && !url.contains("/episodes") && url !in animeMap) {
+                val titleText = card.selectFirst("p.text-xs, .card-overlay p")?.text()
+                    ?: card.attr("title")
+
+                if (titleText.isNotEmpty()) {
+                    animeMap[url] = SAnime.create().apply {
+                        setUrlWithoutDomain(url)
+                        title = titleText
+                        thumbnail_url = card.selectFirst("img")?.absUrl("src")
+                    }
                 }
             }
         }
 
-        val hasNextPage = document.select("a").any { it.text().contains("Next") }
+        // Slider fallback for Browse pages
+        if (isBrowse && animeMap.isEmpty()) {
+            document.select("div.overflow-x-auto.snap-x a[href*=/anime/]").forEach { a ->
+                val url = a.absUrl("href").substringBefore("?")
+                if (url.isNotEmpty() && url !in animeMap) {
+                    val titleText = a.attr("title").takeIf { it.isNotEmpty() } ?: a.text()
+                    if (titleText.isNotEmpty()) {
+                        animeMap[url] = SAnime.create().apply {
+                            setUrlWithoutDomain(url)
+                            title = titleText
+                            thumbnail_url = a.selectFirst("img")?.absUrl("src")
+                        }
+                    }
+                }
+            }
+        }
+
+        val hasNextPage = document.select("a").any {
+            it.text().contains("Next") && it.attr("href").contains("page=")
+        }
         return AnimesPage(animeMap.values.toList(), hasNextPage)
     }
 

--- a/src/en/anidb/src/eu/kanade/tachiyomi/animeextension/en/anidb/AniDB.kt
+++ b/src/en/anidb/src/eu/kanade/tachiyomi/animeextension/en/anidb/AniDB.kt
@@ -372,55 +372,28 @@ class AniDB :
     private fun parseAnimesPage(response: Response): AnimesPage {
         val document = response.asJsoup()
         val animeMap = linkedMapOf<String, SAnime>()
-        val isBrowse = response.request.url.pathSegments.contains("browse")
 
-        // Priority 1: Slider (Seasons)
-        if (!isBrowse) {
-            document.select("div.overflow-x-auto.snap-x a[href*=/anime/]").forEach { a ->
-                val url = a.absUrl("href").substringBefore("?")
-                if (url.isNotEmpty() && url !in animeMap) {
-                    val titleText = a.attr("title").takeIf { it.isNotEmpty() } ?: a.text()
-                    if (titleText.isNotEmpty()) {
-                        animeMap[url] = SAnime.create().apply {
-                            setUrlWithoutDomain(url)
-                            title = titleText
-                            thumbnail_url = a.selectFirst("img")?.absUrl("src")
-                        }
-                    }
+        // Priority: Seasons
+        document.select("div.overflow-x-auto.snap-x a[href*=/anime/]").forEach { a ->
+            val url = a.absUrl("href")
+            if (url.isNotEmpty()) {
+                animeMap[url] = SAnime.create().apply {
+                    setUrlWithoutDomain(url)
+                    title = a.attr("title").takeIf { it.isNotEmpty() } ?: a.text()
+                    thumbnail_url = a.selectFirst("img")?.absUrl("src")
                 }
             }
         }
 
-        // Priority 2: Grid Cards (Browse results or "You Might Also Like")
-        document.select("a.anime-card").forEach { card ->
-            val url = card.absUrl("href").substringBefore("?")
-            if (url.contains("/anime/") && !url.contains("/episodes") && url !in animeMap) {
-                val titleText = card.selectFirst("p.text-xs, .card-overlay p")?.text()
-                    ?: card.attr("title")
-
-                if (titleText.isNotEmpty()) {
-                    animeMap[url] = SAnime.create().apply {
-                        setUrlWithoutDomain(url)
-                        title = titleText
-                        thumbnail_url = card.selectFirst("img")?.absUrl("src")
-                    }
-                }
-            }
-        }
-
-        // Slider fallback for Browse pages
-        if (isBrowse && animeMap.isEmpty()) {
-            document.select("div.overflow-x-auto.snap-x a[href*=/anime/]").forEach { a ->
-                val url = a.absUrl("href").substringBefore("?")
-                if (url.isNotEmpty() && url !in animeMap) {
-                    val titleText = a.attr("title").takeIf { it.isNotEmpty() } ?: a.text()
-                    if (titleText.isNotEmpty()) {
-                        animeMap[url] = SAnime.create().apply {
-                            setUrlWithoutDomain(url)
-                            title = titleText
-                            thumbnail_url = a.selectFirst("img")?.absUrl("src")
-                        }
-                    }
+        // Standard grid / Relations (skips duplicates already added from seasons)
+        document.select(".anime-grid a.anime-card").forEach { card ->
+            val url = card.absUrl("href")
+            if (url.isNotEmpty() && url !in animeMap) {
+                animeMap[url] = SAnime.create().apply {
+                    setUrlWithoutDomain(url)
+                    title = card.selectFirst("p.text-xs, .card-overlay p")?.text()
+                        ?: card.attr("title")
+                    thumbnail_url = card.selectFirst("img")?.absUrl("src")
                 }
             }
         }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve AniDB search/browse results parsing to correctly populate anime lists and pagination.

New Features:
- Support parsing anime entries from both slider seasons sections and grid card layouts, including browse results and recommendations.

Bug Fixes:
- Fix cases where AniDB search or browse pages returned no results due to incomplete parsing of available anime cards.
- Ensure "Next" page detection only triggers when a valid page parameter is present in the link to avoid incorrect pagination flags.

Enhancements:
- Prioritize slider seasons on non-browse pages and add a slider fallback for browse pages when no grid results are found.
- Increment the AniDB extension version code to ship the parsing and pagination fixes.