### PR TITLE
AnimeiTo [PT]: Fix extractor

### DIFF
--- a/src/pt/animeito/build.gradle
+++ b/src/pt/animeito/build.gradle
@@ -3,12 +3,11 @@ ext {
     extClass = '.AnimeIto'
     themePkg = 'animestream'
     baseUrl = 'https://animesonline.io'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
 }
 
 apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(":lib:playlistutils"))
-    implementation(project(":lib:unpacker"))
 }

--- a/src/pt/animeito/build.gradle
+++ b/src/pt/animeito/build.gradle
@@ -10,4 +10,5 @@ apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(":lib:playlistutils"))
+    implementation(project(":lib:m3u8server"))
 }

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/AnimeIto.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/AnimeIto.kt
@@ -29,7 +29,8 @@ class AnimeIto :
     private val animeitoExtractor by lazy { AnimeItoExtractor(client, headers) }
 
     override suspend fun getVideoList(url: String, name: String): List<Video> = when {
-        "anidrive.click" in url -> animeitoExtractor.videosFromUrl(url)
+        // Embed = googlevideo/blogger MP4; Prime = HLS (.image segments via m3u8server)
+        "anidrive.click" in url -> animeitoExtractor.videosFromUrl(url, name.trim())
         else -> emptyList()
     }
 }

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
@@ -72,7 +72,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
             return videosFromSourceText(script)
         }
 
-        val masterPlaylistUrl = HLS_FILE_REGEX.find(script)?.groupValues?.get(1)
+        val masterPlaylistUrl = extractHlsUrl(script)
         if (masterPlaylistUrl != null) {
             Log.d(tag, "HLS master URL: $masterPlaylistUrl")
             return playlistUtils.extractFromHls(masterPlaylistUrl, videoNameGen = { "Animei.to - $it" })
@@ -118,6 +118,17 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         return null
     }
 
+    private fun extractHlsUrl(script: String): String? = HLS_FILE_REGEX.find(script)
+        ?.groupValues
+        ?.get(1)
+        ?.let(::normalizeStreamUrl)
+
+    private fun normalizeStreamUrl(url: String): String = if (url.startsWith("//")) {
+        "https:$url"
+    } else {
+        url
+    }
+
     private fun isPlayableUrl(url: String): Boolean = url.contains("videoplayback") || url.contains(".m3u8") || url.contains(".mp4")
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -135,36 +146,41 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         val loadHeaders = headers.toMultimap().mapValues { entry -> entry.value.getOrNull(0) ?: "" }
         val jsInterface = PlayerJSInterface(latch) { jsResult = it }
 
-        handler.post {
-            val newView = WebView(applicationContext)
-            webView = newView
-            with(newView.settings) {
-                javaScriptEnabled = true
-                domStorageEnabled = true
-                databaseEnabled = true
-                userAgentString = headers["User-Agent"]
-            }
-            newView.addJavascriptInterface(jsInterface, "Android")
-            newView.webViewClient = object : WebViewClient() {
-                override fun onPageFinished(view: WebView?, loadedUrl: String?) {
-                    Log.d(tag, "WebView page loaded, injecting player script")
-                    view?.evaluateJavascript(PLAYER_SCRIPT) {}
+        try {
+            handler.post {
+                val newView = WebView(applicationContext)
+                webView = newView
+                with(newView.settings) {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    databaseEnabled = true
+                    userAgentString = headers["User-Agent"]
                 }
+                newView.addJavascriptInterface(jsInterface, "Android")
+                newView.webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView?, loadedUrl: String?) {
+                        Log.d(tag, "WebView page loaded, injecting player script")
+                        view?.evaluateJavascript(PLAYER_SCRIPT) {}
+                    }
+                }
+                newView.loadUrl(url, loadHeaders)
             }
-            newView.loadUrl(url, loadHeaders)
-        }
 
-        if (!latch.await(TIMEOUT_SEC, TimeUnit.SECONDS)) {
-            Log.e(tag, "WebView timed out after ${TIMEOUT_SEC}s")
-        }
+            if (!latch.await(TIMEOUT_SEC, TimeUnit.SECONDS)) {
+                Log.e(tag, "WebView timed out after ${TIMEOUT_SEC}s")
+            }
 
-        handler.post {
-            webView?.stopLoading()
-            webView?.destroy()
-            webView = null
+            return parseWebViewResult(jsResult, url)
+        } catch (e: Exception) {
+            Log.e(tag, "WebView extraction failed", e)
+            return emptyList()
+        } finally {
+            val viewToDestroy = webView
+            handler.post {
+                viewToDestroy?.stopLoading()
+                viewToDestroy?.destroy()
+            }
         }
-
-        return parseWebViewResult(jsResult, url)
     }
 
     private fun parseWebViewResult(json: String, pageUrl: String): List<Video> {
@@ -180,11 +196,20 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
             return emptyList()
         }
 
+        if (items.isEmpty()) {
+            Log.w(tag, "WebView JSON array is empty")
+            return emptyList()
+        }
+
         val videoHeaders = buildVideoHeaders(pageUrl)
         val videos = mutableListOf<Video>()
         for (element in items) {
             val item = element.jsonObject
-            val videoUrl = item["url"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: continue
+            val videoUrl = item["url"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+            if (videoUrl == null) {
+                Log.w(tag, "WebView item missing valid 'url' key: $item")
+                continue
+            }
             val label = item["label"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: "Video"
             val type = item["type"]?.jsonPrimitive?.content.orEmpty()
 
@@ -201,6 +226,10 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                     videos += Video(videoUrl, "Animei.to - $label", videoUrl, videoHeaders)
                 }
             }
+        }
+
+        if (videos.isEmpty()) {
+            Log.w(tag, "WebView JSON parsed but no valid entries found (expected keys: url, label, type)")
         }
 
         return videos
@@ -327,15 +356,22 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         private val KEY_SEP_REGEX = Regex("""\],\s*"""")
         private val STRINGS_REGEX = Regex("\"([^\"]*?)\"")
         private val SOURCE_ENTRY_REGEX = Regex(""""file":"([^"]+)","label":"([^"]+)"""")
-        private val HLS_FILE_REGEX = Regex(""""file":"(https://[^"]+\.m3u8[^"]*)"""")
+        private val HLS_FILE_REGEX = Regex(""""file":"((?:https?:)?//[^"]+\.m3u8[^"]*)"""")
 
         private val PLAYER_SCRIPT by lazy {
             """
-            setInterval(function() {
+            var playerIntervalId = setInterval(function() {
+                function deliverResults(results) {
+                    if (results.length > 0 && window.Android && typeof Android.onResult === 'function') {
+                        Android.onResult(JSON.stringify(results));
+                        clearInterval(playerIntervalId);
+                    }
+                }
+
                 try {
                     var config = window.AniDrivePlayerConfig;
                     if (config && config.sources && config.sources.length > 0) {
-                        var results = config.sources.map(function(source) {
+                        deliverResults(config.sources.map(function(source) {
                             var type = source.type || '';
                             if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
                                 type = 'm3u8';
@@ -343,8 +379,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                                 type = 'mp4';
                             }
                             return { url: source.file, label: source.label || '', type: type };
-                        });
-                        Android.onResult(JSON.stringify(results));
+                        }));
                         return;
                     }
 
@@ -352,7 +387,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                     if (player && player.getPlaylistItem) {
                         var item = player.getPlaylistItem();
                         if (item && item.sources && item.sources.length > 0) {
-                            var playlistResults = item.sources.map(function(source) {
+                            deliverResults(item.sources.map(function(source) {
                                 var type = source.type || '';
                                 if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
                                     type = 'm3u8';
@@ -360,8 +395,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                                     type = 'mp4';
                                 }
                                 return { url: source.file, label: source.label || '', type: type };
-                            });
-                            Android.onResult(JSON.stringify(playlistResults));
+                            }));
                             return;
                         }
                     }

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
@@ -1,21 +1,36 @@
 package eu.kanade.tachiyomi.animeextension.pt.animeito.extractors
 
+import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.util.Base64
 import android.util.Log
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.applicationContext
 import keiyoushi.utils.useAsJsoup
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 class AnimeItoExtractor(private val client: OkHttpClient, private val headers: Headers) {
-    private val tag = javaClass.simpleName
+    private val tag by lazy { javaClass.simpleName }
+    private val handler by lazy { Handler(Looper.getMainLooper()) }
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
-    private val arraySepRegex = Regex("""\],\s*\[""")
-    private val keySepRegex = Regex("""\],\s*"""")
-    private val stringsRegex = Regex("\"([^\"]*?)\"")
 
     suspend fun videosFromUrl(url: String): List<Video> {
         val playerDoc = client.newCall(GET(url, headers)).awaitSuccess().useAsJsoup()
@@ -27,31 +42,177 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         } else {
             null
         } ?: run {
-            Log.w(tag, "TextDecoder script not found, falling back to const player")
-            playerDoc.selectFirst("script:containsData(const player)")?.data()
-                ?: return emptyList<Video>().also { Log.e(tag, "No const player script found") }
-        }
-
-        Log.d(tag, "Script type: ${if ("googlevideo" in script) "direct" else "hls"}")
-
-        return if ("googlevideo" in script) {
-            script.substringAfter("sources:").substringBefore("]")
-                .split("{")
-                .drop(1)
-                .map {
-                    val videoUrl = it.substringAfter("file\":\"").substringBefore('"')
-                    val quality = it.substringAfter("label\":\"").substringBefore('"')
-                    Log.d(tag, "Found video: $quality - ${videoUrl.take(80)}...")
-                    Video(videoUrl, "Animei.to - $quality", videoUrl, headers)
+            Log.w(tag, "TextDecoder script not found, falling back to inline player script")
+            playerDoc.selectFirst("script:containsData(AniDrivePlayerConfig)")?.data()
+                ?: playerDoc.selectFirst("script:containsData(const player)")?.data()
+                ?: return videosFromWebView(url).also {
+                    Log.e(tag, "No player script found, WebView fallback returned ${it.size} videos")
                 }
-        } else {
-            val masterPlaylistUrl = script.substringAfter("sources:")
-                .substringAfter("file\":\"")
-                .substringBefore('"')
-            Log.d(tag, "HLS master URL: $masterPlaylistUrl")
-
-            playlistUtils.extractFromHls(masterPlaylistUrl, videoNameGen = { "Animei.to - $it" })
         }
+
+        val videos = extractVideosFromScript(script)
+        if (videos.isNotEmpty()) {
+            return videos
+        }
+
+        Log.w(tag, "No videos extracted from decoded script, falling back to WebView")
+        return videosFromWebView(url)
+    }
+
+    private fun extractVideosFromScript(script: String): List<Video> {
+        val sourcesBlock = extractSourcesBlock(script)
+        if (sourcesBlock != null) {
+            val directVideos = videosFromSourceText(sourcesBlock)
+            if (directVideos.isNotEmpty()) {
+                return directVideos
+            }
+        }
+
+        if ("videoplayback" in script) {
+            return videosFromSourceText(script)
+        }
+
+        val masterPlaylistUrl = HLS_FILE_REGEX.find(script)?.groupValues?.get(1)
+        if (masterPlaylistUrl != null) {
+            Log.d(tag, "HLS master URL: $masterPlaylistUrl")
+            return playlistUtils.extractFromHls(masterPlaylistUrl, videoNameGen = { "Animei.to - $it" })
+        }
+
+        return emptyList()
+    }
+
+    private fun videosFromSourceText(text: String): List<Video> {
+        return SOURCE_ENTRY_REGEX.findAll(text)
+            .mapNotNull { match ->
+                val videoUrl = match.groupValues[1]
+                val quality = match.groupValues[2]
+                if (!isPlayableUrl(videoUrl)) {
+                    return@mapNotNull null
+                }
+                Log.d(tag, "Found video: $quality - ${videoUrl.take(80)}...")
+                Video(videoUrl, "Animei.to - $quality", videoUrl, headers)
+            }
+            .toList()
+    }
+
+    private fun extractSourcesBlock(script: String): String? {
+        val markerIndex = script.indexOf(SOURCES_MARKER)
+        if (markerIndex < 0) {
+            return null
+        }
+
+        val arrayStart = markerIndex + SOURCES_MARKER.length - 1
+        var depth = 0
+        for (index in arrayStart until script.length) {
+            when (script[index]) {
+                '[' -> depth++
+                ']' -> {
+                    depth--
+                    if (depth == 0) {
+                        return script.substring(arrayStart, index + 1)
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun isPlayableUrl(url: String): Boolean = url.contains("videoplayback") || url.contains(".m3u8") || url.contains(".mp4")
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private suspend fun videosFromWebView(url: String): List<Video> = withContext(Dispatchers.IO) {
+        synchronized(WEB_VIEW_LOCK) {
+            videosFromWebViewInternal(url)
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun videosFromWebViewInternal(url: String): List<Video> {
+        val latch = CountDownLatch(1)
+        var webView: WebView? = null
+        var jsResult = ""
+        val loadHeaders = headers.toMultimap().mapValues { entry -> entry.value.getOrNull(0) ?: "" }
+        val jsInterface = PlayerJSInterface(latch) { jsResult = it }
+
+        handler.post {
+            val newView = WebView(applicationContext)
+            webView = newView
+            with(newView.settings) {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                databaseEnabled = true
+                userAgentString = headers["User-Agent"]
+            }
+            newView.addJavascriptInterface(jsInterface, "Android")
+            newView.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, loadedUrl: String?) {
+                    Log.d(tag, "WebView page loaded, injecting player script")
+                    view?.evaluateJavascript(PLAYER_SCRIPT) {}
+                }
+            }
+            newView.loadUrl(url, loadHeaders)
+        }
+
+        if (!latch.await(TIMEOUT_SEC, TimeUnit.SECONDS)) {
+            Log.e(tag, "WebView timed out after ${TIMEOUT_SEC}s")
+        }
+
+        handler.post {
+            webView?.stopLoading()
+            webView?.destroy()
+            webView = null
+        }
+
+        return parseWebViewResult(jsResult, url)
+    }
+
+    private fun parseWebViewResult(json: String, pageUrl: String): List<Video> {
+        if (json.isBlank()) {
+            Log.e(tag, "WebView returned empty player data")
+            return emptyList()
+        }
+
+        val items = try {
+            Json.parseToJsonElement(json).jsonArray
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to parse WebView JSON", e)
+            return emptyList()
+        }
+
+        val videoHeaders = buildVideoHeaders(pageUrl)
+        val videos = mutableListOf<Video>()
+        for (element in items) {
+            val item = element.jsonObject
+            val videoUrl = item["url"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: continue
+            val label = item["label"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: "Video"
+            val type = item["type"]?.jsonPrimitive?.content.orEmpty()
+
+            when {
+                type == "m3u8" || ".m3u8" in videoUrl -> {
+                    videos += playlistUtils.extractFromHls(
+                        videoUrl,
+                        pageUrl,
+                        videoNameGen = { "Animei.to - $it" },
+                    )
+                }
+                else -> {
+                    Log.d(tag, "WebView video: $label - ${videoUrl.take(80)}...")
+                    videos += Video(videoUrl, "Animei.to - $label", videoUrl, videoHeaders)
+                }
+            }
+        }
+
+        return videos
+    }
+
+    private fun buildVideoHeaders(pageUrl: String): Headers {
+        val httpUrl = pageUrl.toHttpUrlOrNull() ?: return headers
+        val siteOrigin = "${httpUrl.scheme}://${httpUrl.host}"
+        return headers.newBuilder()
+            .set("Referer", "$siteOrigin/")
+            .set("Origin", siteOrigin)
+            .build()
     }
 
     private fun decodeTextDecoderScript(script: String): String {
@@ -66,13 +227,13 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
 
         val params = mainContent.substring(funcCallStart + 2, funcCallEnd + 1)
 
-        val array1End = arraySepRegex.find(params)?.range?.first ?: -1
+        val array1End = ARRAY_SEP_REGEX.find(params)?.range?.first ?: -1
         if (array1End < 0) {
             Log.w(tag, "Could not find first array boundary")
             return ""
         }
 
-        val array2End = keySepRegex.find(params)?.range?.first ?: -1
+        val array2End = KEY_SEP_REGEX.find(params)?.range?.first ?: -1
         if (array2End < 0) {
             Log.w(tag, "Could not find second array boundary")
             return ""
@@ -98,33 +259,31 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         }
         val keyStr = params.substring(keyQuoteStart + 1, keyQuoteEnd)
 
-        val strings = stringsRegex
+        val strings = STRINGS_REGEX
             .findAll(firstArrayStr)
             .map { it.groupValues[1] }
             .toList()
 
-        val rawIndexTokens = secondArrayStr
+        val indices = secondArrayStr
             .removeSurrounding("[", "]")
             .split(",")
-        val indices = rawIndexTokens.mapNotNull { token ->
-            val trimmed = token.trim()
-            if (trimmed.isEmpty()) {
-                Log.w(tag, "Skipping empty index token while decoding")
-                return@mapNotNull null
+            .mapNotNull { token ->
+                val trimmed = token.trim()
+                if (trimmed.isEmpty()) {
+                    return@mapNotNull null
+                }
+                trimmed.toIntOrNull() ?: run {
+                    Log.w(tag, "Skipping non-numeric index token while decoding: '$trimmed'")
+                    null
+                }
             }
-            val value = trimmed.toIntOrNull()
-            if (value == null) {
-                Log.w(tag, "Skipping non-numeric index token while decoding: '$trimmed'")
-            }
-            value
-        }
 
         if (indices.isEmpty()) {
             Log.w(tag, "No valid indices found")
             return ""
         }
 
-        val joined = indices.joinToString("") { strings.getOrNull(it) ?: "" }
+        val joined = indices.joinToString("") { index -> strings.getOrNull(index).orEmpty() }
         if (joined.isEmpty()) {
             Log.w(tag, "Joined base64 is empty")
             return ""
@@ -143,5 +302,77 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         }
 
         return String(result, Charsets.UTF_8)
+    }
+
+    private class PlayerJSInterface(
+        private val latch: CountDownLatch,
+        private val callback: (String) -> Unit,
+    ) {
+        private val delivered = AtomicBoolean(false)
+
+        @JavascriptInterface
+        fun onResult(json: String) {
+            if (delivered.compareAndSet(false, true)) {
+                callback(json)
+                latch.countDown()
+            }
+        }
+    }
+
+    companion object {
+        private val WEB_VIEW_LOCK = Any()
+        private const val TIMEOUT_SEC: Long = 15
+        private const val SOURCES_MARKER = "\"sources\":["
+        private val ARRAY_SEP_REGEX = Regex("""\],\s*\[""")
+        private val KEY_SEP_REGEX = Regex("""\],\s*"""")
+        private val STRINGS_REGEX = Regex("\"([^\"]*?)\"")
+        private val SOURCE_ENTRY_REGEX = Regex(""""file":"([^"]+)","label":"([^"]+)"""")
+        private val HLS_FILE_REGEX = Regex(""""file":"(https://[^"]+\.m3u8[^"]*)"""")
+
+        private val PLAYER_SCRIPT by lazy {
+            """
+            setInterval(function() {
+                try {
+                    var config = window.AniDrivePlayerConfig;
+                    if (config && config.sources && config.sources.length > 0) {
+                        var results = config.sources.map(function(source) {
+                            var type = source.type || '';
+                            if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
+                                type = 'm3u8';
+                            } else {
+                                type = 'mp4';
+                            }
+                            return { url: source.file, label: source.label || '', type: type };
+                        });
+                        Android.onResult(JSON.stringify(results));
+                        return;
+                    }
+
+                    var player = jwplayer(0);
+                    if (player && player.getPlaylistItem) {
+                        var item = player.getPlaylistItem();
+                        if (item && item.sources && item.sources.length > 0) {
+                            var playlistResults = item.sources.map(function(source) {
+                                var type = source.type || '';
+                                if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
+                                    type = 'm3u8';
+                                } else {
+                                    type = 'mp4';
+                                }
+                                return { url: source.file, label: source.label || '', type: type };
+                            });
+                            Android.onResult(JSON.stringify(playlistResults));
+                            return;
+                        }
+                    }
+
+                    var playButton = document.querySelector('#player-button-container, .jw-display-icon-container, .jw-icon-display');
+                    if (playButton) {
+                        playButton.click();
+                    }
+                } catch (error) {}
+            }, 2500);
+            """.trimIndent()
+        }
     }
 }

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/extractors/AnimeItoExtractor.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import aniyomi.lib.m3u8server.M3u8Integration
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
@@ -31,66 +32,101 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
     private val tag by lazy { javaClass.simpleName }
     private val handler by lazy { Handler(Looper.getMainLooper()) }
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
+    private val m3u8Integration by lazy { M3u8Integration(client) }
 
-    suspend fun videosFromUrl(url: String): List<Video> {
+    suspend fun videosFromUrl(url: String, serverName: String = ""): List<Video> {
+        val qualityPrefix = qualityPrefix(serverName)
         val playerDoc = client.newCall(GET(url, headers)).awaitSuccess().useAsJsoup()
 
-        val encodedScript = playerDoc.selectFirst("script:containsData(TextDecoder)")?.data()
-        val script = if (encodedScript != null) {
-            Log.d(tag, "TextDecoder script found, length=${encodedScript.length}")
-            decodeTextDecoderScript(encodedScript).takeIf { it.isNotEmpty() }
-        } else {
-            null
-        } ?: run {
-            Log.w(tag, "TextDecoder script not found, falling back to inline player script")
-            playerDoc.selectFirst("script:containsData(AniDrivePlayerConfig)")?.data()
-                ?: playerDoc.selectFirst("script:containsData(const player)")?.data()
-                ?: return videosFromWebView(url).also {
-                    Log.e(tag, "No player script found, WebView fallback returned ${it.size} videos")
-                }
+        // AniDrive embeds multiple TextDecoder scripts (service-worker first, player config later).
+        // Decode each until playable sources are found instead of stopping at the first match.
+        val textDecoderScripts = playerDoc.select("script:containsData(TextDecoder)")
+        for (scriptElement in textDecoderScripts) {
+            val encodedScript = scriptElement.data()
+            Log.d(tag, "Trying TextDecoder script, length=${encodedScript.length}")
+            val decoded = decodeTextDecoderScript(encodedScript)
+            if (decoded.isEmpty()) {
+                continue
+            }
+            val videos = extractVideosFromScript(decoded, url, qualityPrefix)
+            if (videos.isNotEmpty()) {
+                Log.d(tag, "Extracted ${videos.size} videos from TextDecoder script")
+                return finalizeVideos(videos)
+            }
         }
 
-        val videos = extractVideosFromScript(script)
-        if (videos.isNotEmpty()) {
-            return videos
+        Log.w(tag, "No playable TextDecoder script found, falling back to inline player script")
+        val fallbackScript = playerDoc.selectFirst("script:containsData(AniDrivePlayerConfig)")?.data()
+            ?: playerDoc.selectFirst("script:containsData(const player)")?.data()
+
+        if (fallbackScript != null) {
+            val videos = extractVideosFromScript(fallbackScript, url, qualityPrefix)
+            if (videos.isNotEmpty()) {
+                return finalizeVideos(videos)
+            }
         }
 
-        Log.w(tag, "No videos extracted from decoded script, falling back to WebView")
-        return videosFromWebView(url)
+        Log.w(tag, "No videos extracted from scripts, falling back to WebView")
+        return finalizeVideos(videosFromWebView(url, qualityPrefix))
     }
 
-    private fun extractVideosFromScript(script: String): List<Video> {
+    private fun qualityPrefix(serverName: String): String {
+        val trimmed = serverName.trim()
+        return if (trimmed.isEmpty()) "Animei.to" else "Animei.to $trimmed"
+    }
+
+    private fun finalizeVideos(videos: List<Video>): List<Video> {
+        if (videos.isEmpty()) {
+            return emptyList()
+        }
+        // Prime HLS segments are served as .image with an optional PNG prefix before MPEG-TS.
+        return m3u8Integration.processVideoList(videos)
+    }
+
+    private fun extractVideosFromScript(script: String, pageUrl: String, qualityPrefix: String): List<Video> {
         val sourcesBlock = extractSourcesBlock(script)
         if (sourcesBlock != null) {
-            val directVideos = videosFromSourceText(sourcesBlock)
+            val directVideos = videosFromSourceText(sourcesBlock, pageUrl, qualityPrefix)
             if (directVideos.isNotEmpty()) {
                 return directVideos
             }
         }
 
         if ("videoplayback" in script) {
-            return videosFromSourceText(script)
+            return videosFromSourceText(script, pageUrl, qualityPrefix)
         }
 
         val masterPlaylistUrl = extractHlsUrl(script)
         if (masterPlaylistUrl != null) {
             Log.d(tag, "HLS master URL: $masterPlaylistUrl")
-            return playlistUtils.extractFromHls(masterPlaylistUrl, videoNameGen = { "Animei.to - $it" })
+            return playlistUtils.extractFromHls(
+                masterPlaylistUrl,
+                pageUrl,
+                videoNameGen = { "$qualityPrefix - $it" },
+            )
         }
 
         return emptyList()
     }
 
-    private fun videosFromSourceText(text: String): List<Video> {
+    private fun videosFromSourceText(text: String, pageUrl: String, qualityPrefix: String): List<Video> {
+        val videoHeaders = buildVideoHeaders(pageUrl)
         return SOURCE_ENTRY_REGEX.findAll(text)
-            .mapNotNull { match ->
-                val videoUrl = match.groupValues[1]
+            .flatMap { match ->
+                val videoUrl = normalizeStreamUrl(match.groupValues[1])
                 val quality = match.groupValues[2]
                 if (!isPlayableUrl(videoUrl)) {
-                    return@mapNotNull null
+                    return@flatMap emptySequence()
                 }
                 Log.d(tag, "Found video: $quality - ${videoUrl.take(80)}...")
-                Video(videoUrl, "Animei.to - $quality", videoUrl, headers)
+                when {
+                    ".m3u8" in videoUrl -> playlistUtils.extractFromHls(
+                        videoUrl,
+                        pageUrl,
+                        videoNameGen = { "$qualityPrefix - $it" },
+                    ).asSequence()
+                    else -> sequenceOf(Video(videoUrl, "$qualityPrefix - $quality", videoUrl, videoHeaders))
+                }
             }
             .toList()
     }
@@ -132,14 +168,14 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
     private fun isPlayableUrl(url: String): Boolean = url.contains("videoplayback") || url.contains(".m3u8") || url.contains(".mp4")
 
     @SuppressLint("SetJavaScriptEnabled")
-    private suspend fun videosFromWebView(url: String): List<Video> = withContext(Dispatchers.IO) {
+    private suspend fun videosFromWebView(url: String, qualityPrefix: String): List<Video> = withContext(Dispatchers.IO) {
         synchronized(WEB_VIEW_LOCK) {
-            videosFromWebViewInternal(url)
+            videosFromWebViewInternal(url, qualityPrefix)
         }
     }
 
     @SuppressLint("SetJavaScriptEnabled")
-    private fun videosFromWebViewInternal(url: String): List<Video> {
+    private fun videosFromWebViewInternal(url: String, qualityPrefix: String): List<Video> {
         val latch = CountDownLatch(1)
         var webView: WebView? = null
         var jsResult = ""
@@ -170,7 +206,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                 Log.e(tag, "WebView timed out after ${TIMEOUT_SEC}s")
             }
 
-            return parseWebViewResult(jsResult, url)
+            return parseWebViewResult(jsResult, url, qualityPrefix)
         } catch (e: Exception) {
             Log.e(tag, "WebView extraction failed", e)
             return emptyList()
@@ -183,7 +219,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
         }
     }
 
-    private fun parseWebViewResult(json: String, pageUrl: String): List<Video> {
+    private fun parseWebViewResult(json: String, pageUrl: String, qualityPrefix: String): List<Video> {
         if (json.isBlank()) {
             Log.e(tag, "WebView returned empty player data")
             return emptyList()
@@ -214,16 +250,16 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
             val type = item["type"]?.jsonPrimitive?.content.orEmpty()
 
             when {
-                type == "m3u8" || ".m3u8" in videoUrl -> {
+                type == "m3u8" || type == "hls" || ".m3u8" in videoUrl -> {
                     videos += playlistUtils.extractFromHls(
                         videoUrl,
                         pageUrl,
-                        videoNameGen = { "Animei.to - $it" },
+                        videoNameGen = { "$qualityPrefix - $it" },
                     )
                 }
                 else -> {
                     Log.d(tag, "WebView video: $label - ${videoUrl.take(80)}...")
-                    videos += Video(videoUrl, "Animei.to - $label", videoUrl, videoHeaders)
+                    videos += Video(videoUrl, "$qualityPrefix - $label", videoUrl, videoHeaders)
                 }
             }
         }
@@ -373,7 +409,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                     if (config && config.sources && config.sources.length > 0) {
                         deliverResults(config.sources.map(function(source) {
                             var type = source.type || '';
-                            if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
+                            if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || type.indexOf('hls') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
                                 type = 'm3u8';
                             } else {
                                 type = 'mp4';
@@ -389,7 +425,7 @@ class AnimeItoExtractor(private val client: OkHttpClient, private val headers: H
                         if (item && item.sources && item.sources.length > 0) {
                             deliverResults(item.sources.map(function(source) {
                                 var type = source.type || '';
-                                if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
+                                if (type.indexOf('mpegurl') >= 0 || type.indexOf('m3u8') >= 0 || type.indexOf('hls') >= 0 || (source.file || '').indexOf('.m3u8') >= 0) {
                                     type = 'm3u8';
                                 } else {
                                     type = 'mp4';


### PR DESCRIPTION
Closes #750

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve AnimeIto extractor reliability by adding more robust script parsing and a WebView-based fallback for video discovery, and update the PT extension metadata.

Enhancements:
- Add support for extracting videos from AniDrive player config, JWPlayer sources, and HLS playlists with stricter URL validation.
- Introduce a WebView-based fallback with a JS interface to capture player configuration when inline scripts cannot be parsed.
- Refine TextDecoder-based script decoding using shared regex constants and safer index handling.
- Set appropriate video request headers (Referer/Origin) based on the page URL to improve playback compatibility.

Build:
- Bump AnimeIto PT extension overrideVersionCode to 3 and remove the unused unpacker library dependency.