### PR TITLE
Torrentio(Torrent + Debrid) [ ALL ]:  Update Cinemeta base URL, replace JustWatch with CinemetaV3

### DIFF
--- a/src/all/torrentio/build.gradle
+++ b/src/all/torrentio/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Torrentio (Torrent / Debrid)'
     extClass = '.Torrentio'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = false
 }
 

--- a/src/all/torrentio/build.gradle
+++ b/src/all/torrentio/build.gradle
@@ -4,5 +4,4 @@ ext {
     extVersionCode = 9
     isNsfw = false
 }
-// Temporary comment for Upload APK job
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/all/torrentio/build.gradle
+++ b/src/all/torrentio/build.gradle
@@ -4,5 +4,5 @@ ext {
     extVersionCode = 9
     isNsfw = false
 }
-
+// Temporary comment for Upload APK job
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/CatalogFilters.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/CatalogFilters.kt
@@ -1,0 +1,58 @@
+package eu.kanade.tachiyomi.animeextension.all.torrentio
+
+import eu.kanade.tachiyomi.animesource.model.AnimeFilter
+import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+
+object CatalogFilters {
+
+    fun getFilterList(): AnimeFilterList = AnimeFilterList(
+        TypeFilter(),
+        ServiceFilter(),
+    )
+
+    fun mediaType(filters: AnimeFilterList): List<String> {
+        val typeFilter = filters.filterIsInstance<TypeFilter>().firstOrNull()
+        val selected = typeFilter?.values?.getOrNull(typeFilter.state) ?: "All"
+        return when (selected) {
+            "Movie" -> listOf("movie")
+            "Series" -> listOf("series")
+            else -> listOf("movie", "series")
+        }
+    }
+
+    fun streamingService(filters: AnimeFilterList): String {
+        val networkFilter = filters.filterIsInstance<ServiceFilter>().firstOrNull()
+        return networkFilter?.toCatalogId() ?: "nfx"
+    }
+
+    class TypeFilter : AnimeFilter.Select<String>("Type", arrayOf("All", "Movie", "Series"))
+
+    class ServiceFilter :
+        AnimeFilter.Select<String>(
+            "Platform",
+            arrayOf(
+                "Netflix",
+                "Disney+",
+                "Apple TV+",
+                "Amazon Prime",
+                "HBO Max",
+                "Paramount+",
+                "Hulu",
+                "Peacock",
+                "Crunchyroll",
+            ),
+        ) {
+        fun toCatalogId(): String = when (state) {
+            0 -> "nfx" // Netflix
+            1 -> "dpe" // Disney+
+            2 -> "atp" // Apple TV+
+            3 -> "amp" // Amazon Prime
+            4 -> "hbm" // HBO Max
+            5 -> "pmp" // Paramount+
+            6 -> "hlu" // Hulu
+            7 -> "pcp" // Peacock
+            8 -> "cru" // Crunchyroll
+            else -> "nfx" // Fallback default Netflix
+        }
+    }
+}

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/CatalogFilters.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/CatalogFilters.kt
@@ -5,9 +5,9 @@ import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 
 object CatalogFilters {
 
-    fun getFilterList(): AnimeFilterList = AnimeFilterList(
+    fun getFilterList(contentType: String = "all"): AnimeFilterList = AnimeFilterList(
         TypeFilter(),
-        ServiceFilter(),
+        ServiceFilter(contentType),
     )
 
     fun mediaType(filters: AnimeFilterList): List<String> {
@@ -26,33 +26,58 @@ object CatalogFilters {
     }
 
     class TypeFilter : AnimeFilter.Select<String>("Type", arrayOf("All", "Movie", "Series"))
+    class ServiceFilter(
+        contentType: String = "all",
+    ) : AnimeFilter.Select<String>(
+        "Platform",
+        when (contentType) {
+            "anime" -> {
 
-    class ServiceFilter :
-        AnimeFilter.Select<String>(
-            "Platform",
-            arrayOf(
-                "Netflix",
-                "Disney+",
-                "Apple TV+",
-                "Amazon Prime",
-                "HBO Max",
-                "Paramount+",
-                "Hulu",
-                "Peacock",
-                "Crunchyroll",
-            ),
-        ) {
-        fun toCatalogId(): String = when (state) {
-            0 -> "nfx" // Netflix
-            1 -> "dpe" // Disney+
-            2 -> "atp" // Apple TV+
-            3 -> "amp" // Amazon Prime
-            4 -> "hbm" // HBO Max
-            5 -> "pmp" // Paramount+
-            6 -> "hlu" // Hulu
-            7 -> "pcp" // Peacock
-            8 -> "cru" // Crunchyroll
-            else -> "nfx" // Fallback default Netflix
+                arrayOf("Crunchyroll")
+            }
+            "all" -> {
+                arrayOf(
+                    "Netflix",
+                    "Disney+",
+                    "Apple TV+",
+                    "Amazon Prime",
+                    "HBO Max",
+                    "Paramount+",
+                    "Hulu",
+                    "Peacock",
+                    "Crunchyroll",
+                )
+            }
+            else -> {
+                arrayOf(
+                    "Netflix",
+                    "Disney+",
+                    "Apple TV+",
+                    "Amazon Prime",
+                    "HBO Max",
+                    "Paramount+",
+                    "Hulu",
+                    "Peacock",
+                )
+            }
+        },
+    ) {
+        fun toCatalogId(): String {
+            // Get the actual selected service name
+            val selectedService = values.getOrNull(state) ?: return "nfx"
+
+            return when (selectedService) {
+                "Netflix" -> "nfx"
+                "Disney+" -> "dpe"
+                "Apple TV+" -> "atp"
+                "Amazon Prime" -> "amp"
+                "HBO Max" -> "hbm"
+                "Paramount+" -> "pmp"
+                "Hulu" -> "hlu"
+                "Peacock" -> "pcp"
+                "Crunchyroll" -> "cru"
+                else -> "nfx"
+            }
         }
     }
 }

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -16,6 +16,10 @@ import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.CinemetaSearchRespon
 import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.EpisodeList
 import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.EpisodeVideo
 import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.StreamDataTorrent
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.TheMovieDatabaseResponse
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.TmdbDiscoverPlusMeta
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.TmdbDiscoverPlusResponse
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.TmdbResult
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -32,11 +36,13 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Locale
 
 class Torrentio :
@@ -49,7 +55,7 @@ class Torrentio :
 
     override val lang = "all"
 
-    override val supportsLatest = false
+    override val supportsLatest = true
 
     private val json: Json by injectLazy()
 
@@ -57,37 +63,61 @@ class Torrentio :
 
     private val cinemetaUrl = "https://v3-cinemeta.strem.io"
     private val streamingCatalogUrl = "https://7a82163c306e-stremio-netflix-catalog-addon.baby-beamup.club"
+    private val tmdbUrl = "https://api.themoviedb.org"
+    private val tmdbDiscoverPlusUrl = "https://tmdb-discover-plus.elfhosted.com/t5mDdzCuoL" // rate limited do not abuse
     private val handler by lazy { Handler(Looper.getMainLooper()) }
 
+    // ============================== Related =====================================
+    override suspend fun fetchRelatedAnimeList(anime: SAnime): List<SAnime> = emptyList()
+
     // ============================== Popular =====================================
+
     override suspend fun getPopularAnime(page: Int): AnimesPage {
         if (page > 1) return AnimesPage(emptyList(), false)
 
+        val contentType = getContentType()
+        val service = getStreamingServiceForContentType(contentType)
+
         val results = coroutineScope {
-            val movies = async { fetchStreamingCatalog("movie", DEFAULT_STREAMING_SERVICE) }
-            val series = async { fetchStreamingCatalog("series", DEFAULT_STREAMING_SERVICE) }
+            val movies = async { fetchStreamingCatalog("movie", service) }
+            val series = async { fetchStreamingCatalog("series", service) }
             movies.await() + series.await()
         }
 
         return AnimesPage(results.map { it.toSAnime() }, false)
     }
-
-    override fun popularAnimeRequest(page: Int): Request = GET("$streamingCatalogUrl/catalog/movie/$DEFAULT_STREAMING_SERVICE.json")
-
-    override fun popularAnimeParse(response: Response): AnimesPage {
-        val url = response.request.url.toString()
-        val type = if (url.contains("/movie/")) "movie" else "series"
-
-        val results = runBlocking {
-            fetchStreamingCatalog(type, DEFAULT_STREAMING_SERVICE)
-        }
-        return AnimesPage(results.map { it.toSAnime() }, false)
+    override fun popularAnimeRequest(page: Int): Request {
+        TODO("Not yet implemented") // hmm naah
     }
 
-    //  =============================== Latest ===============================
-    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/")
+    override fun popularAnimeParse(response: Response): AnimesPage {
+        TODO("Not yet implemented") // i wont
+    }
+    // =============================== Latest ===============================
 
-    override fun latestUpdatesParse(response: Response) = AnimesPage(emptyList(), false)
+    override fun latestUpdatesRequest(page: Int): Request {
+        val contentType = getContentType()
+
+        val url = when (contentType) {
+            "anime" -> buildTmdbAnimeDiscoverUrl(page)
+            else -> buildTmdbTrendingUrl("tv", page)
+        }
+
+        return GET(url)
+    }
+
+    override fun latestUpdatesParse(response: Response): AnimesPage {
+        val url = response.request.url
+        val page = url.queryParameter("page")?.toIntOrNull() ?: 1
+        val contentType = getContentType()
+
+        return runBlocking {
+            when (contentType) {
+                "anime" -> fetchTmdbAnime(page)
+                else -> fetchTrendingMoviesAndTV(page)
+            }
+        }
+    }
 
     // =========================== Search ====================================
     override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
@@ -110,12 +140,14 @@ class Torrentio :
 
         val trimmedQuery = query.trim()
         val types = CatalogFilters.mediaType(filters)
-        val network = CatalogFilters.streamingService(filters)
+        val contentType = getContentType()
 
         if (trimmedQuery.isBlank()) {
+            val effectiveNetwork = resolveEffectiveNetwork(contentType, filters)
+
             val results = coroutineScope {
                 types.map { type ->
-                    async { fetchStreamingCatalog(type, network) }
+                    async { fetchStreamingCatalog(type, effectiveNetwork) }
                 }.awaitAll().flatten()
             }
             return AnimesPage(results.distinctBy { it.id }.map { it.toSAnime() }, false)
@@ -123,12 +155,11 @@ class Torrentio :
 
         val results = coroutineScope {
             types.map { type ->
-                async { fetchCatalog(type, trimmedQuery) }
+                async { searchCinemeta(type, trimmedQuery) }
             }.awaitAll().flatten()
         }
 
         val distinctResults = results.distinctBy { it.id }.map { it.toSAnime() }
-
         return AnimesPage(distinctResults, false)
     }
 
@@ -138,34 +169,37 @@ class Torrentio :
             return GET("$cinemetaUrl/meta/movie/$id.json")
         }
 
-        val types = CatalogFilters.mediaType(filters)
-        val network = CatalogFilters.streamingService(filters)
-        val type = types.firstOrNull() ?: "movie"
         val trimmedQuery = query.trim()
 
-        return if (trimmedQuery.isBlank()) {
-            GET("$streamingCatalogUrl/catalog/$type/$network.json")
-        } else {
-            GET("$cinemetaUrl/catalog/$type/top/search=$trimmedQuery.json")
+        if (trimmedQuery.isBlank()) {
+            val types = CatalogFilters.mediaType(filters)
+            val contentType = getContentType()
+            val effectiveNetwork = resolveEffectiveNetwork(contentType, filters)
+            val type = types.firstOrNull() ?: "movie"
+            return GET("$streamingCatalogUrl/catalog/$type/$effectiveNetwork.json")
         }
+
+        val types = CatalogFilters.mediaType(filters)
+        val type = types.firstOrNull() ?: "movie"
+        return GET("$cinemetaUrl/catalog/$type/top/search=$trimmedQuery.json")
     }
 
     override fun searchAnimeParse(response: Response): AnimesPage {
         val responseString = response.body.string()
-        var url = response.request.url.toString()
+        val url = response.request.url.toString()
 
         if (url.contains("/meta/")) {
             val detail = json.decodeFromString<CinemetaMetaDetailResponse>(responseString)
-            val meta = detail.meta
+            val meta = detail.meta ?: return AnimesPage(emptyList(), false)
             val type = if (url.contains("/movie/")) "movie" else "series"
-            val imdbId = meta?.id.orEmpty()
+            val id = meta.id.orEmpty()
 
             val anime = SAnime.create().apply {
-                url = "$imdbId,$type"
-                title = meta?.name.orEmpty()
-                thumbnail_url = meta?.poster.orEmpty()
-                description = meta?.description.orEmpty()
-                genre = meta?.genres?.joinToString().orEmpty()
+                this.url = "$id,$type"
+                title = meta.name.orEmpty()
+                thumbnail_url = meta.poster.orEmpty()
+                description = meta.description.orEmpty()
+                genre = meta.genres?.joinToString().orEmpty()
             }
             return AnimesPage(listOf(anime), false)
         }
@@ -175,117 +209,243 @@ class Torrentio :
         return AnimesPage(results.map { it.toSAnime() }, false)
     }
 
+    private fun resolveEffectiveNetwork(contentType: String, filters: AnimeFilterList): String = when (contentType) {
+        "anime" -> "cru"
+        else -> CatalogFilters.streamingService(filters)
+    }
+
     // =============================== Filters =======================================
 
-    override fun getFilterList(): AnimeFilterList = CatalogFilters.getFilterList()
+    override fun getFilterList(): AnimeFilterList {
+        val contentType = getContentType()
+        return CatalogFilters.getFilterList(contentType)
+    }
 
-    // ===========================  Details  ====================================
+    // =========================== Details ====================================
 
     override fun animeDetailsParse(response: Response): SAnime {
         val responseString = response.body.string()
-        val detail = json.decodeFromString<CinemetaMetaDetailResponse>(responseString)
-        val meta = detail.meta ?: return SAnime.create()
+        val url = response.request.url.toString()
 
-        var url = response.request.url.toString()
+        // Try to parse as TmdbDiscoverPlusResponse first
+        val detail = runCatching {
+            json.decodeFromString<TmdbDiscoverPlusResponse>(responseString)
+        }.getOrNull()
+
+        val meta = detail?.meta
+
+        if (meta == null) {
+            val cinemetaDetail = runCatching {
+                json.decodeFromString<CinemetaMetaDetailResponse>(responseString)
+            }.getOrNull()
+            val cinemetaMeta = cinemetaDetail?.meta ?: return SAnime.create()
+
+            return SAnime.create().apply {
+                val id = cinemetaMeta.id.orEmpty()
+                val type = if (url.contains("/movie/")) "movie" else "series"
+                this.url = "$id,$type"
+                title = cinemetaMeta.name.orEmpty()
+                thumbnail_url = cinemetaMeta.poster.orEmpty()
+                description = cinemetaMeta.description.orEmpty()
+                genre = cinemetaMeta.genres?.joinToString().orEmpty()
+                author = cinemetaMeta.director?.joinToString().orEmpty()
+                artist = cinemetaMeta.cast?.take(4)?.joinToString().orEmpty()
+                status = mapStatus(cinemetaMeta.status, cinemetaMeta.released)
+            }
+        }
+
         val type = if (url.contains("/movie/")) "movie" else "series"
-        val imdbId = meta.id.orEmpty()
+        val id = meta.imdbId ?: meta.imdb_id ?: meta.id.orEmpty()
 
         return SAnime.create().apply {
-            url = "$imdbId,$type"
+            this.url = "$id,$type"
             title = meta.name.orEmpty()
             thumbnail_url = meta.poster.orEmpty()
             description = meta.description.orEmpty()
             genre = meta.genres?.joinToString().orEmpty()
-            author = meta.director?.joinToString().orEmpty()
+            author = meta.writer ?: meta.director ?: ""
             artist = meta.cast?.take(4)?.joinToString().orEmpty()
             status = mapStatus(meta.status, meta.released)
         }
     }
 
     override suspend fun getAnimeDetails(anime: SAnime): SAnime {
-        val parts = anime.url.split(",")
-        val imdbId = parts[0]
+        val originalUrl = anime.url
+        val parts = originalUrl.split(",")
+        val id = parts[0]
         val type = parts.getOrNull(1)?.lowercase()?.ifBlank { "movie" } ?: "movie"
 
-        val detail = fetchMetaDetail(type, imdbId)
+        val isTmdbId = id.toIntOrNull() != null
 
-        if (detail != null) {
-            anime.title = detail.name ?: anime.title
-            if (!detail.poster.isNullOrBlank()) {
-                anime.thumbnail_url = detail.poster
+        val meta = if (isTmdbId) {
+            fetchMetaDetailViaDiscoverPlus(type, id)
+        } else {
+            fetchMetaDetail(type, id)?.let { cinemetaMeta ->
+
+                cinemetaMeta.toDiscoverPlusMeta()
             }
-            anime.description = detail.description ?: anime.description
-            anime.genre = detail.genres?.joinToString() ?: anime.genre
-            anime.author = detail.writer?.joinToString() ?: detail.writer?.joinToString()
-            anime.artist = detail.cast?.take(4)?.joinToString() ?: anime.artist
-            anime.status = mapStatus(detail.status, detail.released)
+        }
+
+        if (meta != null) {
+            val imdbId = meta.imdbId ?: meta.imdb_id
+
+            anime.title = meta.name ?: anime.title
+            if (!meta.poster.isNullOrBlank()) {
+                anime.thumbnail_url = meta.poster
+            }
+            anime.description = meta.description ?: anime.description
+            anime.genre = meta.genres?.joinToString() ?: anime.genre
+            anime.author = meta.writer ?: meta.director ?: anime.author
+            anime.artist = meta.cast?.take(4)?.joinToString() ?: anime.artist
+            anime.status = mapStatus(meta.status, meta.released)
+
+            if (!imdbId.isNullOrBlank()) {
+                val newUrl = "$imdbId,$type"
+                anime.url = newUrl
+            } else {
+            }
+        } else {
         }
 
         return anime
     }
 
     // ============================== Episodes ==============================
+    override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
+        val resolvedAnime = if (anime.url.split(",")[0].toIntOrNull() != null) {
+            getAnimeDetails(anime)
+        } else {
+            anime
+        }
+        return super.getEpisodeList(resolvedAnime)
+    }
+
     override fun episodeListRequest(anime: SAnime): Request {
         val parts = anime.url.split(",")
-        val type = parts[1].lowercase()
-        val imdbId = parts[0]
-        return GET("$cinemetaUrl/meta/$type/$imdbId.json")
+        val type = parts.getOrNull(1)?.lowercase() ?: "movie"
+        val id = parts[0]
+
+        if (id.toIntOrNull() != null) {
+            return GET("$tmdbDiscoverPlusUrl/meta/$type/tmdb:$id.json")
+        }
+
+        return GET("$cinemetaUrl/meta/$type/$id.json")
     }
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val responseString = response.body.string()
-        val episodeList = json.decodeFromString<EpisodeList>(responseString)
+        val url = response.request.url.toString()
+
+        if (url.contains("tmdb-discover-plus")) {
+            val discoverPlusResponse = runCatching {
+                json.decodeFromString<TmdbDiscoverPlusResponse>(responseString)
+            }.getOrNull()
+
+            if (discoverPlusResponse != null) {
+                return parseEpisodeListFromTmdbDiscoverPlus(discoverPlusResponse)
+            }
+        }
+
+        val episodeList = runCatching {
+            json.decodeFromString<EpisodeList>(responseString)
+        }.getOrNull()
+
+        if (episodeList == null) {
+            return emptyList()
+        }
 
         return when (episodeList.meta?.type) {
-            "series" -> {
-                val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
-                val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
-                val now = System.currentTimeMillis()
-
-                episodeList.meta.videos
-                    .orEmpty()
-                    .filter { video ->
-                        if (hideSeasonZero) video.season != 0 else true
-                    }
-                    .mapNotNull { video ->
-                        val releaseTime = (video.firstAired ?: video.released)
-                            ?.let(::parseDate) ?: Long.MAX_VALUE
-
-                        val isReleased = releaseTime <= now
-                        if (!showUpcoming && !isReleased) {
-                            return@mapNotNull null
-                        }
-
-                        val episode = SEpisode.create().apply {
-                            episode_number = "${video.season}.${video.number}".toFloat()
-                            url = "/stream/series/${video.id}.json"
-                            date_upload = if (releaseTime == Long.MAX_VALUE) 0L else releaseTime
-                            name = "S${video.season}:E${video.number} - ${video.name.orEmpty()}"
-                            scanlator = if (!isReleased) "Upcoming" else ""
-                        }
-
-                        video to episode
-                    }
-                    .sortedWith(
-                        compareByDescending<Pair<EpisodeVideo, SEpisode>> { (video, _) -> video.season!! > 0 }
-                            .thenByDescending { (video, _) -> video.season }
-                            .thenByDescending { (video, _) -> video.number },
-                    )
-                    .map { (_, episode) -> episode }
+            "series" -> buildSeriesEpisodes(
+                videos = episodeList.meta.videos.orEmpty(),
+                episodeUrl = { videoId -> "/stream/series/$videoId.json" },
+            )
+            "movie" -> {
+                listOf(singleMovieEpisode("/stream/movie/${episodeList.meta.id}.json"))
             }
 
-            "movie" -> {
-                listOf(
-                    SEpisode.create().apply {
-                        episode_number = 1f
-                        url = "/stream/movie/${episodeList.meta.id}.json"
-                        name = "Movie"
-                    },
+            else -> {
+                emptyList()
+            }
+        }
+    }
+
+    private fun parseEpisodeListFromTmdbDiscoverPlus(response: TmdbDiscoverPlusResponse): List<SEpisode> {
+        val meta = response.meta ?: return emptyList()
+        val type = meta.type ?: "movie"
+
+        return when (type) {
+            "series" -> {
+                val videos = meta.videos.orEmpty()
+
+                if (videos.isEmpty()) {
+                    val imdbId = meta.imdbId ?: meta.imdb_id ?: meta.id.orEmpty()
+                    return listOf(
+                        SEpisode.create().apply {
+                            episode_number = 1f
+                            this.url = "/stream/series/$imdbId.json"
+                            name = "Series - ${meta.name.orEmpty()}"
+                        },
+                    )
+                }
+
+                buildSeriesEpisodes(
+                    videos = videos,
+                    episodeUrl = { videoId -> "/stream/series/$videoId.json" },
                 )
             }
-
-            else -> emptyList()
+            "movie" -> {
+                val imdbId = meta.imdbId ?: meta.imdb_id ?: meta.id.orEmpty()
+                listOf(singleMovieEpisode("/stream/movie/$imdbId.json"))
+            }
+            else -> {
+                emptyList()
+            }
         }
+    }
+
+    private fun buildSeriesEpisodes(
+        videos: List<EpisodeVideo>,
+        episodeUrl: (String) -> String,
+    ): List<SEpisode> {
+        val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
+        val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
+        val now = System.currentTimeMillis()
+
+        return videos
+            .filter { video ->
+                if (hideSeasonZero) video.season != 0 else true
+            }
+            .mapNotNull { video ->
+                val releaseTime = (video.firstAired ?: video.released)
+                    ?.let(::parseDate) ?: Long.MAX_VALUE
+
+                val isReleased = releaseTime <= now
+                if (!showUpcoming && !isReleased) {
+                    return@mapNotNull null
+                }
+
+                val episode = SEpisode.create().apply {
+                    episode_number = "${video.season}.${video.number}".toFloat()
+                    this.url = episodeUrl(video.id.orEmpty())
+                    date_upload = if (releaseTime == Long.MAX_VALUE) 0L else releaseTime
+                    name = "S${video.season}:E${video.number} - ${video.name.orEmpty()}"
+                    scanlator = if (!isReleased) "Upcoming" else ""
+                }
+
+                video to episode
+            }
+            .sortedWith(
+                compareByDescending<Pair<EpisodeVideo, SEpisode>> { (video, _) -> video.season!! > 0 }
+                    .thenByDescending { (video, _) -> video.season }
+                    .thenByDescending { (video, _) -> video.number },
+            )
+            .map { (_, episode) -> episode }
+    }
+
+    private fun singleMovieEpisode(url: String): SEpisode = SEpisode.create().apply {
+        episode_number = 1f
+        this.url = url
+        name = "Movie"
     }
 
     private fun parseDate(dateStr: String): Long = runCatching { DATE_FORMATTER.parse(dateStr)?.time }
@@ -331,6 +491,7 @@ class Torrentio :
             }
             append(episode.url)
         }.removeSuffix("|")
+
         return GET(mainURL)
     }
 
@@ -392,7 +553,163 @@ class Torrentio :
         )
     }
 
+    // ============================ TMDB Helpers ==============================
+
+    private fun buildTmdbAnimeDiscoverUrl(page: Int): HttpUrl {
+        val (weekStart, weekEnd) = getWeeklyDates()
+        return tmdbUrl.toHttpUrl().newBuilder()
+            .addPathSegment("3")
+            .addPathSegment("discover")
+            .addPathSegment("tv")
+            .addQueryParameter("api_key", getTmdbApiKey())
+            .addQueryParameter("with_genres", "16,10765,10759")
+            .addQueryParameter("with_original_language", "ja")
+            .addQueryParameter("with_origin_country", "JP")
+            .addQueryParameter("air_date.gte", weekStart)
+            .addQueryParameter("air_date.lte", weekEnd)
+            .addQueryParameter("sort_by", "popularity.desc")
+            .addQueryParameter("page", page.toString())
+            .build()
+    }
+
+    private fun buildTmdbTrendingUrl(mediaType: String, page: Int): HttpUrl = tmdbUrl.toHttpUrl().newBuilder()
+        .addPathSegment("3")
+        .addPathSegment("trending")
+        .addPathSegment(mediaType)
+        .addPathSegment("week")
+        .addQueryParameter("api_key", getTmdbApiKey())
+        .addQueryParameter("page", page.toString())
+        .build()
+
+    private suspend fun fetchTmdbAnime(page: Int): AnimesPage {
+        val url = buildTmdbAnimeDiscoverUrl(page)
+
+        return try {
+            val response = client.newCall(GET(url)).awaitSuccess()
+            val body = response.body.string()
+            val discoverResponse = json.decodeFromString<TheMovieDatabaseResponse>(body)
+
+            val animeList = discoverResponse.results.map { result ->
+                SAnime.create().apply {
+                    this.url = "${result.id},series"
+                    title = result.name ?: "Unknown"
+                    thumbnail_url = buildImageUrl(result.poster_path)
+                    description = result.overview ?: ""
+                    genre = result.genre_ids?.joinToString() ?: ""
+                    status = mapStatusFromDate(result.first_air_date)
+                }
+            }
+
+            AnimesPage(
+                animeList,
+                discoverResponse.page < discoverResponse.total_pages,
+            )
+        } catch (e: Exception) {
+            AnimesPage(emptyList(), false)
+        }
+    }
+
+    private suspend fun fetchTrendingMoviesAndTV(page: Int): AnimesPage = try {
+        val results = coroutineScope {
+            val tvDeferred = async {
+                val url = buildTmdbTrendingUrl("tv", page)
+                val response = client.newCall(GET(url)).awaitSuccess()
+                json.decodeFromString<TheMovieDatabaseResponse>(response.body.string())
+            }
+
+            val movieDeferred = async {
+                val url = buildTmdbTrendingUrl("movie", page)
+                val response = client.newCall(GET(url)).awaitSuccess()
+                json.decodeFromString<TheMovieDatabaseResponse>(response.body.string())
+            }
+
+            val tvResults = tvDeferred.await()
+            val movieResults = movieDeferred.await()
+
+            val combined = mutableListOf<TmdbResult>()
+            combined.addAll(tvResults.results)
+            combined.addAll(movieResults.results)
+            combined.sortByDescending { it.popularity ?: 0.0 }
+
+            combined to (tvResults.total_pages > page || movieResults.total_pages > page)
+        }
+
+        val (combinedResults, hasNextPage) = results
+
+        val animeList = combinedResults.map { result ->
+            SAnime.create().apply {
+                val isTv = result.first_air_date != null
+                this.url = "${result.id},${if (isTv) "series" else "movie"}"
+                title = if (isTv) result.name ?: "Unknown" else result.title ?: "Unknown"
+                thumbnail_url = buildImageUrl(result.poster_path)
+                description = result.overview ?: ""
+                genre = result.genre_ids?.joinToString() ?: ""
+                status = if (isTv) {
+                    mapStatusFromDate(result.first_air_date)
+                } else {
+                    SAnime.COMPLETED
+                }
+            }
+        }
+
+        AnimesPage(animeList, hasNextPage)
+    } catch (e: Exception) {
+        AnimesPage(emptyList(), false)
+    }
+
+    private fun getWeeklyDates(offsetWeeks: Int = 0): Pair<String, String> {
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+        val calendar = Calendar.getInstance()
+        calendar.add(Calendar.DAY_OF_MONTH, -offsetWeeks * 7)
+
+        val dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK) - 1
+
+        val diffToMonday = calendar.get(Calendar.DAY_OF_MONTH) - dayOfWeek + (if (dayOfWeek == 0) -6 else 1)
+        calendar.set(Calendar.DAY_OF_MONTH, diffToMonday)
+        val monday = calendar.time
+
+        val sundayCalendar = calendar.clone() as Calendar
+        sundayCalendar.add(Calendar.DAY_OF_MONTH, 6)
+        val sunday = sundayCalendar.time
+
+        return dateFormat.format(monday) to dateFormat.format(sunday)
+    }
+
+    private fun buildImageUrl(path: String?): String = if (!path.isNullOrBlank()) {
+        "https://image.tmdb.org/t/p/w500$path"
+    } else {
+        ""
+    }
+
+    private fun mapStatusFromDate(date: String?): Int {
+        if (date == null) return SAnime.UNKNOWN
+        return try {
+            val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val releaseDate = dateFormat.parse(date)
+            val now = System.currentTimeMillis()
+
+            if (releaseDate != null && releaseDate.time > now) {
+                SAnime.ONGOING
+            } else {
+                SAnime.COMPLETED
+            }
+        } catch (e: Exception) {
+            SAnime.UNKNOWN
+        }
+    }
+
+    private fun getTmdbApiKey(): String = PREF_TMDB_DEFAULT
+
     // ============================ Helper Methods ==============================
+
+    private fun getContentType(): String = preferences.getString(PREF_CONTENT_TYPE_KEY, PREF_CONTENT_TYPE_DEFAULT) ?: PREF_CONTENT_TYPE_DEFAULT
+
+    private fun getStreamingServiceForContentType(contentType: String): String = when (contentType) {
+        "anime" -> "cru"
+        else -> DEFAULT_STREAMING_SERVICE
+    }
+
     private suspend fun fetchStreamingCatalog(mediaType: String, streamingServiceId: String): List<CinemetaMeta> {
         val url = "$streamingCatalogUrl/catalog/$mediaType/$streamingServiceId.json"
         return runCatching {
@@ -402,16 +719,46 @@ class Torrentio :
     }
 
     private suspend fun searchAnimeByIdParse(imdbId: String): AnimesPage {
-        val movieMeta = fetchMetaDetail("movie", imdbId)
-        val meta = movieMeta ?: fetchMetaDetail("series", imdbId)
-        val type = if (movieMeta != null) "movie" else "series"
+        val isTmdbId = imdbId.toIntOrNull() != null
+
+        var meta: TmdbDiscoverPlusMeta? = null
+        var type = "movie"
+
+        if (isTmdbId) {
+            meta = fetchMetaDetailViaDiscoverPlus("movie", imdbId)
+            type = "movie"
+
+            if (meta == null) {
+                meta = fetchMetaDetailViaDiscoverPlus("series", imdbId)
+                type = "series"
+            }
+        } else {
+            var cinemetaMeta = fetchMetaDetail("movie", imdbId)
+            type = "movie"
+
+            if (cinemetaMeta == null) {
+                cinemetaMeta = fetchMetaDetail("series", imdbId)
+                type = "series"
+            }
+
+            meta = cinemetaMeta?.let { cm ->
+
+                cm.toDiscoverPlusMeta()
+            }
+        }
+
+        if (meta == null) {
+            return AnimesPage(emptyList(), false)
+        }
+
+        val finalId = meta.imdbId ?: meta.imdb_id ?: imdbId
 
         val anime = SAnime.create().apply {
-            url = "$imdbId,$type"
-            title = meta?.name.orEmpty()
-            thumbnail_url = meta?.poster.orEmpty()
-            description = meta?.description.orEmpty()
-            genre = meta?.genres?.joinToString().orEmpty()
+            this.url = "$finalId,$type"
+            title = meta.name.orEmpty()
+            thumbnail_url = meta.poster.orEmpty()
+            description = meta.description.orEmpty()
+            genre = meta.genres?.joinToString().orEmpty()
         }
 
         return AnimesPage(listOf(anime), false)
@@ -427,11 +774,72 @@ class Torrentio :
         }.getOrNull()
     }
 
+    private suspend fun fetchMetaDetailViaDiscoverPlus(type: String, id: String): TmdbDiscoverPlusMeta? {
+        // If it's already a tt ID, use cinemeta directly
+        if (id.startsWith("tt")) {
+            return fetchMetaDetail(type, id)?.let { meta ->
+                meta.toDiscoverPlusMeta()
+            }
+        }
+
+        val url = "$tmdbDiscoverPlusUrl/meta/$type/tmdb:$id.json"
+
+        return try {
+            val response = client.newCall(GET(url)).awaitSuccess()
+            val body = response.body.string()
+            val detail = json.decodeFromString<TmdbDiscoverPlusResponse>(body)
+            detail.meta?.apply {
+                val imdb = this.imdbId ?: this.imdb_id
+                if (!imdb.isNullOrBlank()) {
+                    this.imdbId = imdb
+                    this.imdb_id = imdb
+                } else {
+                }
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private suspend fun searchCinemeta(type: String, query: String): List<CinemetaMeta> {
+        val trimmed = query.trim()
+        if (trimmed.length < 2) return emptyList()
+
+        val url = cinemetaUrl.toHttpUrl().newBuilder()
+            .addPathSegment("catalog")
+            .addPathSegment(type)
+            .addPathSegment("top")
+            .addPathSegment("search=$trimmed.json")
+            .build()
+
+        return runCatching {
+            val response = client.newCall(GET(url)).awaitSuccess()
+            val body = response.body.string()
+            json.decodeFromString<CinemetaSearchResponse>(body).metas.orEmpty()
+        }.getOrDefault(emptyList())
+    }
+
     private fun CinemetaMeta.toSAnime(): SAnime = SAnime.create().apply {
-        url = "${imdbId ?: id.orEmpty()},${type.orEmpty()}"
+        url = "${id.orEmpty()},${type.orEmpty()}"
         title = name.orEmpty()
         thumbnail_url = poster.orEmpty()
     }
+
+    private fun CinemetaMetaDetail.toDiscoverPlusMeta(): TmdbDiscoverPlusMeta = TmdbDiscoverPlusMeta(
+        id = id,
+        imdbId = id,
+        imdb_id = id,
+        type = type,
+        name = name,
+        poster = poster,
+        description = description,
+        genres = genres,
+        cast = cast,
+        director = director?.joinToString(),
+        writer = writer?.joinToString(),
+        released = released,
+        status = status,
+    )
 
     private fun mapStatus(status: String?, released: String?): Int {
         if (status != null) {
@@ -444,24 +852,6 @@ class Torrentio :
 
         val releaseTime = released?.let(::parseDate) ?: return SAnime.UNKNOWN
         return if (releaseTime > System.currentTimeMillis()) SAnime.ONGOING else SAnime.COMPLETED
-    }
-
-    private suspend fun fetchCatalog(type: String, query: String): List<CinemetaMeta> {
-        val trimmed = query.trim()
-
-        if (trimmed.length < 2) return emptyList()
-
-        val url = cinemetaUrl.toHttpUrl().newBuilder()
-            .addPathSegment("catalog")
-            .addPathSegment(type)
-            .addPathSegment("top")
-            .addPathSegment("search=$trimmed.json")
-            .build()
-
-        return runCatching {
-            val response = client.newCall(GET(url)).awaitSuccess()
-            json.decodeFromString<CinemetaSearchResponse>(response.body.string()).metas.orEmpty()
-        }.getOrDefault(emptyList())
     }
 
     private fun fetchTrackers(): String {
@@ -478,15 +868,13 @@ class Torrentio :
     // ============================ Preferences ==============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        // Debrid provider
         ListPreference(screen.context).apply {
-            key = PREF_DEBRID_KEY
-            title = "Debrid Provider"
-            entries = PREF_DEBRID_ENTRIES
-            entryValues = PREF_DEBRID_VALUES
-            setDefaultValue("none")
-            summary =
-                "Choose 'None' for Torrent. If you select a Debrid provider, enter your token key. No token key is needed if 'None' is selected."
+            key = PREF_CONTENT_TYPE_KEY
+            title = "Content Type"
+            entries = PREF_CONTENT_TYPE_ENTRIES
+            entryValues = PREF_CONTENT_TYPE_VALUES
+            setDefaultValue(PREF_CONTENT_TYPE_DEFAULT)
+            summary = "Filter content: %s"
 
             setOnPreferenceChangeListener { _, newValue ->
                 val selected = newValue as String
@@ -496,7 +884,22 @@ class Torrentio :
             }
         }.also(screen::addPreference)
 
-        // Token
+        ListPreference(screen.context).apply {
+            key = PREF_DEBRID_KEY
+            title = "Debrid Provider"
+            entries = PREF_DEBRID_ENTRIES
+            entryValues = PREF_DEBRID_VALUES
+            setDefaultValue("none")
+            summary = "Choose 'None' for Torrent. If you select a Debrid provider, enter your token key."
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val selected = newValue as String
+                val index = findIndexOfValue(selected)
+                val entry = entryValues[index] as String
+                preferences.edit().putString(key, entry).commit()
+            }
+        }.also(screen::addPreference)
+
         EditTextPreference(screen.context).apply {
             key = PREF_TOKEN_KEY
             title = "Token"
@@ -512,7 +915,6 @@ class Torrentio :
             }
         }.also(screen::addPreference)
 
-        // Provider
         MultiSelectListPreference(screen.context).apply {
             key = PREF_PROVIDER_KEY
             title = "Enable/Disable Providers"
@@ -526,7 +928,6 @@ class Torrentio :
             }
         }.also(screen::addPreference)
 
-        // Exclude Qualities
         MultiSelectListPreference(screen.context).apply {
             key = PREF_QUALITY_KEY
             title = "Exclude Qualities/Resolutions"
@@ -540,7 +941,6 @@ class Torrentio :
             }
         }.also(screen::addPreference)
 
-        // Priority foreign language
         MultiSelectListPreference(screen.context).apply {
             key = PREF_LANG_KEY
             title = "Priority foreign language"
@@ -554,7 +954,6 @@ class Torrentio :
             }
         }.also(screen::addPreference)
 
-        // Sorting
         ListPreference(screen.context).apply {
             key = PREF_SORT_KEY
             title = "Sorting"
@@ -605,22 +1004,25 @@ class Torrentio :
             setOnPreferenceChangeListener { _, newValue ->
                 preferences.edit().putBoolean(key, newValue as Boolean).commit()
             }
-            summary = "Codec: (HEVC / x265)  & AV1. High-quality video with less data usage."
+            summary = "Codec: (HEVC / x265) & AV1. High-quality video with less data usage."
         }.also(screen::addPreference)
     }
 
     companion object {
         const val PREFIX_SEARCH = "id:"
+        const val DEFAULT_STREAMING_SERVICE = "nfx"
 
-        // Popular source (Streaming Catalogs addon)
-        private const val DEFAULT_STREAMING_SERVICE = "nfx"
+        private const val PREF_CONTENT_TYPE_KEY = "content_type"
+        private const val PREF_CONTENT_TYPE_DEFAULT = "all"
+        private val PREF_CONTENT_TYPE_ENTRIES = arrayOf("All Content", "Anime Only (Crunchyroll)", "Movies & TV")
+        private val PREF_CONTENT_TYPE_VALUES = arrayOf("all", "anime", "movies_tv")
 
-        // Token
+        private const val PREF_TMDB_DEFAULT = "ea021b3b0775c8531592713ab727f254" // ignore this ive got keys to play with
+
         private const val PREF_TOKEN_KEY = "token"
         private const val PREF_TOKEN_DEFAULT = ""
         private const val PREF_TOKEN_SUMMARY = "Exclusive to Debrid providers; not intended for Torrents."
 
-        // Debrid
         private const val PREF_DEBRID_KEY = "debrid_provider"
         private val PREF_DEBRID_ENTRIES = arrayOf(
             "None",
@@ -643,229 +1045,57 @@ class Torrentio :
             "torbox",
         )
 
-        // Sort
         private const val PREF_SORT_KEY = "sorting_link"
-        private val PREF_SORT_ENTRIES = arrayOf(
-            "By quality then seeders",
-            "By quality then size",
-            "By seeders",
-            "By size",
-        )
-        private val PREF_SORT_VALUES = arrayOf(
-            "quality",
-            "qualitysize",
-            "seeders",
-            "size",
+        private val PREF_SORT_ENTRIES = arrayOf("By quality then seeders", "By quality then size", "By seeders", "By size")
+        private val PREF_SORT_VALUES = arrayOf("quality", "qualitysize", "seeders", "size")
 
-        )
-
-        // Provider
         private const val PREF_PROVIDER_KEY = "provider_selection"
         private val PREF_PROVIDERS = arrayOf(
-            "YTS",
-            "EZTV",
-            "RARBG",
-            "1337x",
-            "ThePirateBay",
-            "KickassTorrents",
-            "TorrentGalaxy",
-            "MagnetDL",
-            "HorribleSubs",
-            "NyaaSi",
-            "TokyoTosho",
-            "AniDex",
-            "nekoBT",
-            "🇷🇺 Rutor",
-            "🇷🇺 Rutracker",
-            "🇵🇹 Comando",
-            "🇵🇹 BluDV",
-            "🇫🇷 Torrent9",
-            "🇮🇹 ilCorSaRoNero",
-            "🇪🇸 MejorTorrent",
-            "🇪🇸 Wolfmax4k",
-            "🇲🇽 Cinecalidad",
-            "🇵🇱 BestTorrents",
+            "YTS", "EZTV", "RARBG", "1337x", "ThePirateBay", "KickassTorrents", "TorrentGalaxy", "MagnetDL",
+            "HorribleSubs", "NyaaSi", "TokyoTosho", "AniDex", "nekoBT", "🇷🇺 Rutor", "🇷🇺 Rutracker", "🇵🇹 Comando",
+            "🇵🇹 BluDV", "🇫🇷 Torrent9", "🇮🇹 ilCorSaRoNero", "🇪🇸 MejorTorrent", "🇪🇸 Wolfmax4k", "🇲🇽 Cinecalidad", "🇵🇱 BestTorrents",
         )
-
         private val PREF_PROVIDERS_VALUE = arrayOf(
-            "yts",
-            "eztv",
-            "rarbg",
-            "1337x",
-            "thepiratebay",
-            "kickasstorrents",
-            "torrentgalaxy",
-            "magnetdl",
-            "horriblesubs",
-            "nyaasi",
-            "tokyotosho",
-            "anidex",
-            "nekobt",
-            "rutor",
-            "rutracker",
-            "comando",
-            "bludv",
-            "torrent9",
-            "ilcorsaronero",
-            "mejortorrent",
-            "wolfmax4k",
-            "cinecalidad",
-            "besttorrents",
+            "yts", "eztv", "rarbg", "1337x", "thepiratebay", "kickasstorrents", "torrentgalaxy", "magnetdl",
+            "horriblesubs", "nyaasi", "tokyotosho", "anidex", "nekobt", "rutor", "rutracker", "comando",
+            "bludv", "torrent9", "ilcorsaronero", "mejortorrent", "wolfmax4k", "cinecalidad", "besttorrents",
         )
-
         private val PREF_DEFAULT_PROVIDERS_VALUE = arrayOf(
-            "yts",
-            "eztv",
-            "rarbg",
-            "1337x",
-            "thepiratebay",
-            "kickasstorrents",
-            "torrentgalaxy",
-            "magnetdl",
-            "horriblesubs",
-            "nyaasi",
-            "tokyotosho",
-            "anidex",
-            "nekobt",
+            "yts", "eztv", "rarbg", "1337x", "thepiratebay", "kickasstorrents", "torrentgalaxy", "magnetdl",
+            "horriblesubs", "nyaasi", "tokyotosho", "anidex", "nekobt",
         )
         private val PREF_PROVIDERS_DEFAULT = PREF_DEFAULT_PROVIDERS_VALUE.toSet()
 
-        // / Qualities/Resolutions
         private const val PREF_QUALITY_KEY = "quality_selection"
         private val PREF_QUALITY = arrayOf(
-            "BluRay REMUX",
-            "HDR/HDR10+/Dolby Vision",
-            "Dolby Vision",
-            "Dolby Vision + HDR",
-            "3D",
-            "Non 3D (DO NOT SELECT IF NOT SURE)",
-            "4k",
-            "1080p",
-            "720p",
-            "480p",
-            "Other (DVDRip/HDRip/BDRip...)",
-            "Screener",
-            "Cam",
-            "Unknown",
+            "BluRay REMUX", "HDR/HDR10+/Dolby Vision", "Dolby Vision", "Dolby Vision + HDR", "3D",
+            "Non 3D (DO NOT SELECT IF NOT SURE)", "4k", "1080p", "720p", "480p", "Other (DVDRip/HDRip/BDRip...)",
+            "Screener", "Cam", "Unknown",
         )
-
         private val PREF_QUALITY_VALUE = arrayOf(
-            "brremux",
-            "hdrall",
-            "dolbyvision",
-            "dolbyvisionwithhdr",
-            "threed",
-            "nonthreed",
-            "4k",
-            "1080p",
-            "720p",
-            "480p",
-            "other",
-            "scr",
-            "cam",
-            "unknown",
+            "brremux", "hdrall", "dolbyvision", "dolbyvisionwithhdr", "threed", "nonthreed",
+            "4k", "1080p", "720p", "480p", "other", "scr", "cam", "unknown",
         )
-
-        private val PREF_DEFAULT_QUALITY_VALUE = arrayOf(
-            "720p",
-            "480p",
-            "other",
-            "scr",
-            "cam",
-            "unknown",
-        )
-
+        private val PREF_DEFAULT_QUALITY_VALUE = arrayOf("720p", "480p", "other", "scr", "cam", "unknown")
         private val PREF_QUALITY_DEFAULT = PREF_DEFAULT_QUALITY_VALUE.toSet()
 
-        // Languages
         private const val PREF_LANG_KEY = "lang_selection"
         private val PREF_LANG = arrayOf(
-            "🇯🇵 Japanese",
-            "🇷🇺 Russian",
-            "🇮🇹 Italian",
-            "🇵🇹 Portuguese",
-            "🇪🇸 Spanish",
-            "🇲🇽 Latino",
-            "🇰🇷 Korean",
-            "🇨🇳 Chinese",
-            "🇹🇼 Taiwanese",
-            "🇫🇷 French",
-            "🇩🇪 German",
-            "🇳🇱 Dutch",
-            "🇮🇳 Hindi",
-            "🇮🇳 Telugu",
-            "🇮🇳 Tamil",
-            "🇵🇱 Polish",
-            "🇱🇹 Lithuanian",
-            "🇱🇻 Latvian",
-            "🇪🇪 Estonian",
-            "🇨🇿 Czech",
-            "🇸🇰 Slovakian",
-            "🇸🇮 Slovenian",
-            "🇭🇺 Hungarian",
-            "🇷🇴 Romanian",
-            "🇧🇬 Bulgarian",
-            "🇷🇸 Serbian",
-            "🇭🇷 Croatian",
-            "🇺🇦 Ukrainian",
-            "🇬🇷 Greek",
-            "🇩🇰 Danish",
-            "🇫🇮 Finnish",
-            "🇸🇪 Swedish",
-            "🇳🇴 Norwegian",
-            "🇹🇷 Turkish",
-            "🇸🇦 Arabic",
-            "🇮🇷 Persian",
-            "🇮🇱 Hebrew",
-            "🇻🇳 Vietnamese",
-            "🇮🇩 Indonesian",
-            "🇲🇾 Malay",
-            "🇹🇭 Thai",
+            "🇯🇵 Japanese", "🇷🇺 Russian", "🇮🇹 Italian", "🇵🇹 Portuguese", "🇪🇸 Spanish", "🇲🇽 Latino",
+            "🇰🇷 Korean", "🇨🇳 Chinese", "🇹🇼 Taiwanese", "🇫🇷 French", "🇩🇪 German", "🇳🇱 Dutch",
+            "🇮🇳 Hindi", "🇮🇳 Telugu", "🇮🇳 Tamil", "🇵🇱 Polish", "🇱🇹 Lithuanian", "🇱🇻 Latvian",
+            "🇪🇪 Estonian", "🇨🇿 Czech", "🇸🇰 Slovakian", "🇸🇮 Slovenian", "🇭🇺 Hungarian", "🇷🇴 Romanian",
+            "🇧🇬 Bulgarian", "🇷🇸 Serbian", "🇭🇷 Croatian", "🇺🇦 Ukrainian", "🇬🇷 Greek", "🇩🇰 Danish",
+            "🇫🇮 Finnish", "🇸🇪 Swedish", "🇳🇴 Norwegian", "🇹🇷 Turkish", "🇸🇦 Arabic", "🇮🇷 Persian",
+            "🇮🇱 Hebrew", "🇻🇳 Vietnamese", "🇮🇩 Indonesian", "🇲🇾 Malay", "🇹🇭 Thai",
         )
         private val PREF_LANG_VALUE = arrayOf(
-            "japanese",
-            "russian",
-            "italian",
-            "portuguese",
-            "spanish",
-            "latino",
-            "korean",
-            "chinese",
-            "taiwanese",
-            "french",
-            "german",
-            "dutch",
-            "hindi",
-            "telugu",
-            "tamil",
-            "polish",
-            "lithuanian",
-            "latvian",
-            "estonian",
-            "czech",
-            "slovakian",
-            "slovenian",
-            "hungarian",
-            "romanian",
-            "bulgarian",
-            "serbian",
-            "croatian",
-            "ukrainian",
-            "greek",
-            "danish",
-            "finnish",
-            "swedish",
-            "norwegian",
-            "turkish",
-            "arabic",
-            "persian",
-            "hebrew",
-            "vietnamese",
-            "indonesian",
-            "malay",
-            "thai",
+            "japanese", "russian", "italian", "portuguese", "spanish", "latino", "korean", "chinese",
+            "taiwanese", "french", "german", "dutch", "hindi", "telugu", "tamil", "polish", "lithuanian",
+            "latvian", "estonian", "czech", "slovakian", "slovenian", "hungarian", "romanian", "bulgarian",
+            "serbian", "croatian", "ukrainian", "greek", "danish", "finnish", "swedish", "norwegian",
+            "turkish", "arabic", "persian", "hebrew", "vietnamese", "indonesian", "malay", "thai",
         )
-
         private val PREF_LANG_DEFAULT = setOf<String>()
 
         private const val UPCOMING_EP_KEY = "upcoming_ep"

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -106,12 +106,11 @@ class Torrentio :
         val url = response.request.url
         val page = url.queryParameter("page")?.toIntOrNull() ?: 1
         val contentType = getContentType()
+        val body = response.body.string()
 
-        return runBlocking {
-            when (contentType) {
-                "anime" -> fetchTmdbAnime(page)
-                else -> fetchTrendingMoviesAndTV(page)
-            }
+        return when (contentType) {
+            "anime" -> parseTmdbAnimeDiscover(body)
+            else -> runBlocking { fetchTrendingMoviesAndTV(body, page) }
         }
     }
 
@@ -389,10 +388,12 @@ class Torrentio :
                     episodeUrl = { videoId -> "/stream/series/$videoId.json" },
                 )
             }
+
             "movie" -> {
                 val imdbId = meta.imdbId ?: meta.imdb_id ?: meta.id.orEmpty()
                 listOf(singleMovieEpisode("/stream/movie/$imdbId.json"))
             }
+
             else -> {
                 emptyList()
             }
@@ -589,41 +590,31 @@ class Torrentio :
         .addQueryParameter("page", page.toString())
         .build()
 
-    private suspend fun fetchTmdbAnime(page: Int): AnimesPage {
-        val url = buildTmdbAnimeDiscoverUrl(page)
+    private fun parseTmdbAnimeDiscover(body: String): AnimesPage = try {
+        val discoverResponse = json.decodeFromString<TheMovieDatabaseResponse>(body)
 
-        return try {
-            val response = client.newCall(GET(url)).awaitSuccess()
-            val body = response.body.string()
-            val discoverResponse = json.decodeFromString<TheMovieDatabaseResponse>(body)
-
-            val animeList = discoverResponse.results.map { result ->
-                SAnime.create().apply {
-                    this.url = "${result.id},series"
-                    title = result.name ?: "Unknown"
-                    thumbnail_url = buildImageUrl(result.poster_path)
-                    description = result.overview ?: ""
-                    genre = result.genre_ids?.joinToString() ?: ""
-                    status = mapStatusFromDate(result.first_air_date)
-                }
+        val animeList = discoverResponse.results.map { result ->
+            SAnime.create().apply {
+                this.url = "${result.id},series"
+                title = result.name ?: "Unknown"
+                thumbnail_url = buildImageUrl(result.poster_path)
+                description = result.overview ?: ""
+                genre = result.genre_ids?.joinToString() ?: ""
+                status = mapStatusFromDate(result.first_air_date)
             }
-
-            AnimesPage(
-                animeList,
-                discoverResponse.page < discoverResponse.total_pages,
-            )
-        } catch (e: Exception) {
-            AnimesPage(emptyList(), false)
         }
+
+        AnimesPage(
+            animeList,
+            discoverResponse.page < discoverResponse.total_pages,
+        )
+    } catch (e: Exception) {
+        AnimesPage(emptyList(), false)
     }
 
-    private suspend fun fetchTrendingMoviesAndTV(page: Int): AnimesPage = try {
+    private suspend fun fetchTrendingMoviesAndTV(tvBody: String, page: Int): AnimesPage = try {
         val results = coroutineScope {
-            val tvDeferred = async {
-                val url = buildTmdbTrendingUrl("tv", page)
-                val response = client.newCall(GET(url)).awaitSuccess()
-                json.decodeFromString<TheMovieDatabaseResponse>(response.body.string())
-            }
+            val tvResults = json.decodeFromString<TheMovieDatabaseResponse>(tvBody)
 
             val movieDeferred = async {
                 val url = buildTmdbTrendingUrl("movie", page)
@@ -631,7 +622,6 @@ class Torrentio :
                 json.decodeFromString<TheMovieDatabaseResponse>(response.body.string())
             }
 
-            val tvResults = tvDeferred.await()
             val movieResults = movieDeferred.await()
 
             val combined = mutableListOf<TmdbResult>()
@@ -917,7 +907,6 @@ class Torrentio :
             setOnPreferenceChangeListener { _, newValue ->
                 runCatching {
                     val value = (newValue as String).trim().ifBlank { PREF_TOKEN_DEFAULT }
-                    Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                     preferences.edit().putString(key, value).commit()
                 }.getOrDefault(false)
             }

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -8,9 +8,13 @@ import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.animeextension.all.torrentio.Torrentio.Companion.DEFAULT_STREAMING_SERVICE
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.CinemetaMeta
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.CinemetaMetaDetail
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.CinemetaMetaDetailResponse
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.CinemetaSearchResponse
 import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.EpisodeList
-import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.GetPopularTitlesResponse
-import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.GetUrlTitleDetailsResponse
+import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.EpisodeVideo
 import eu.kanade.tachiyomi.animeextension.all.torrentio.dto.StreamDataTorrent
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -23,7 +27,10 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.applicationContext
 import keiyoushi.utils.getPreferencesLazy
-import keiyoushi.utils.toJsonBody
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -48,150 +55,41 @@ class Torrentio :
 
     private val preferences by getPreferencesLazy()
 
+    private val cinemetaUrl = "https://v3-cinemeta.strem.io"
+    private val streamingCatalogUrl = "https://7a82163c306e-stremio-netflix-catalog-addon.baby-beamup.club"
     private val handler by lazy { Handler(Looper.getMainLooper()) }
 
-    // ============================== JustWatch API Request ===================
-    private fun makeGraphQLRequest(query: String, variables: String): Request {
-        val requestBody = """
-        {"query": "${query.replace("\n", "")}", "variables": $variables}
-        """.trimIndent().toJsonBody()
+    // ============================== Popular =====================================
+    override suspend fun getPopularAnime(page: Int): AnimesPage {
+        if (page > 1) return AnimesPage(emptyList(), false)
 
-        val request = Request.Builder()
-            .url("https://apis.justwatch.com/graphql")
-            .post(requestBody)
-            .build()
+        val results = coroutineScope {
+            val movies = async { fetchStreamingCatalog("movie", DEFAULT_STREAMING_SERVICE) }
+            val series = async { fetchStreamingCatalog("series", DEFAULT_STREAMING_SERVICE) }
+            movies.await() + series.await()
+        }
 
-        return request
+        return AnimesPage(results.map { it.toSAnime() }, false)
     }
 
-    // ============================== JustWatch Api Query ======================
-    private fun justWatchQuery(): String = $$"""
-            query GetPopularTitles(
-              $country: Country!,
-              $first: Int!,
-              $language: Language!,
-              $offset: Int,
-              $searchQuery: String,
-              $packages: [String!]!,
-              $objectTypes: [ObjectType!]!,
-              $popularTitlesSortBy: PopularTitlesSorting!,
-              $releaseYear: IntFilter
-            ) {
-              popularTitles(
-                country: $country
-                first: $first
-                offset: $offset
-                sortBy: $popularTitlesSortBy
-                filter: {
-                  objectTypes: $objectTypes,
-                  searchQuery: $searchQuery,
-                  packages: $packages,
-                  genres: [],
-                  excludeGenres: [],
-                  releaseYear: $releaseYear
-                }
-              ) {
-                edges {
-                  node {
-                    id
-                    objectType
-                    content(country: $country, language: $language) {
-                      fullPath
-                      title
-                      shortDescription
-                      externalIds {
-                        imdbId
-                      }
-                      posterUrl
-                      genres {
-                        translation(language: $language)
-                      }
-                      credits {
-                        name
-                        role
-                      }
-                    }
-                  }
-                }
-                pageInfo {
-                  hasPreviousPage
-                  hasNextPage
-                }
-              }
-            }
-    """.trimIndent()
-
-    private fun parseSearchJson(jsonLine: String?): AnimesPage {
-        val jsonData = jsonLine ?: return AnimesPage(emptyList(), false)
-        val popularTitlesResponse = json.decodeFromString<GetPopularTitlesResponse>(jsonData)
-
-        val edges = popularTitlesResponse.data?.popularTitles?.edges.orEmpty()
-        val hasNextPage = popularTitlesResponse.data?.popularTitles?.pageInfo?.hasNextPage ?: false
-
-        val metaList = edges
-            .mapNotNull { edge ->
-                val node = edge.node ?: return@mapNotNull null
-                val content = node.content ?: return@mapNotNull null
-
-                SAnime.create().apply {
-                    url = "${content.externalIds?.imdbId ?: ""},${if (node.objectType == "SHOW") "series" else node.objectType ?: ""},${content.fullPath ?: ""}"
-                    title = content.title ?: ""
-                    thumbnail_url = "https://images.justwatch.com${content.posterUrl?.replace("{profile}", "s276")?.replace("{format}", "webp")}"
-                    description = content.shortDescription ?: ""
-                    val genresList = content.genres?.mapNotNull { it.translation }.orEmpty()
-                    genre = genresList.joinToString()
-
-                    val directors = content.credits?.filter { it.role == "DIRECTOR" }?.mapNotNull { it.name }
-                    author = directors?.joinToString()
-                    val actors = content.credits?.filter { it.role == "ACTOR" }?.take(4)?.mapNotNull { it.name }
-                    artist = actors?.joinToString()
-                    initialized = true
-                }
-            }
-
-        return AnimesPage(metaList, hasNextPage)
-    }
-
-    // ============================== Popular ===============================
-    override fun popularAnimeRequest(page: Int): Request {
-        val country = preferences.getString(PREF_REGION_KEY, PREF_REGION_DEFAULT)
-        val language = preferences.getString(PREF_JW_LANG_KEY, PREF_JW_LANG_DEFAULT)
-        val perPage = 40
-        val packages = ""
-        val year = 0
-        val objectTypes = ""
-        val variables = """
-            {
-              "first": $perPage,
-              "offset": ${(page - 1) * perPage},
-              "platform": "WEB",
-              "country": "$country",
-              "language": "$language",
-              "searchQuery": "",
-              "packages": [$packages],
-              "objectTypes": [$objectTypes],
-              "popularTitlesSortBy": "TRENDING",
-              "releaseYear": {
-                "min": $year,
-                "max": $year
-              }
-            }
-        """.trimIndent()
-
-        return makeGraphQLRequest(justWatchQuery(), variables)
-    }
+    override fun popularAnimeRequest(page: Int): Request = GET("$streamingCatalogUrl/catalog/movie/$DEFAULT_STREAMING_SERVICE.json")
 
     override fun popularAnimeParse(response: Response): AnimesPage {
-        val jsonData = response.body.string()
-        return parseSearchJson(jsonData)
+        val url = response.request.url.toString()
+        val type = if (url.contains("/movie/")) "movie" else "series"
+
+        val results = runBlocking {
+            fetchStreamingCatalog(type, DEFAULT_STREAMING_SERVICE)
+        }
+        return AnimesPage(results.map { it.toSAnime() }, false)
     }
 
-    // =============================== Latest ===============================
-    override fun latestUpdatesRequest(page: Int) = throw UnsupportedOperationException()
+    //  =============================== Latest ===============================
+    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/")
 
-    override fun latestUpdatesParse(response: Response) = throw UnsupportedOperationException()
+    override fun latestUpdatesParse(response: Response) = AnimesPage(emptyList(), false)
 
-    // =============================== Search ===============================
+    // =========================== Search ====================================
     override suspend fun getSearchAnime(page: Int, query: String, filters: AnimeFilterList): AnimesPage {
         if (query.startsWith("https://")) {
             val url = query.toHttpUrl()
@@ -205,103 +103,123 @@ class Torrentio :
 
         if (query.startsWith(PREFIX_SEARCH)) {
             val id = query.removePrefix(PREFIX_SEARCH)
-            return client.newCall(GET("$baseUrl/anime/$id"))
-                .awaitSuccess()
-                .use(::searchAnimeByIdParse)
+            return searchAnimeByIdParse(id)
         }
 
-        return super.getSearchAnime(page, query, filters)
-    }
+        if (page > 1) return AnimesPage(emptyList(), false)
 
-    private fun searchAnimeByIdParse(response: Response): AnimesPage {
-        val details = animeDetailsParse(response)
-        return AnimesPage(listOf(details), false)
+        val trimmedQuery = query.trim()
+        val types = CatalogFilters.mediaType(filters)
+        val network = CatalogFilters.streamingService(filters)
+
+        if (trimmedQuery.isBlank()) {
+            val results = coroutineScope {
+                types.map { type ->
+                    async { fetchStreamingCatalog(type, network) }
+                }.awaitAll().flatten()
+            }
+            return AnimesPage(results.distinctBy { it.id }.map { it.toSAnime() }, false)
+        }
+
+        val results = coroutineScope {
+            types.map { type ->
+                async { fetchCatalog(type, trimmedQuery) }
+            }.awaitAll().flatten()
+        }
+
+        val distinctResults = results.distinctBy { it.id }.map { it.toSAnime() }
+
+        return AnimesPage(distinctResults, false)
     }
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
-        val country = preferences.getString(PREF_REGION_KEY, PREF_REGION_DEFAULT)
-        val language = preferences.getString(PREF_JW_LANG_KEY, PREF_JW_LANG_DEFAULT)
-        val perPage = 40
-        val packages = ""
-        val year = 0
-        val objectTypes = ""
-        val variables = """
-            {
-              "first": $perPage,
-              "offset": ${(page - 1) * perPage},
-              "platform": "WEB",
-              "country": "$country",
-              "language": "$language",
-              "searchQuery": "${query.replace(Regex("[^A-Za-z0-9 ]"), "").trim()}",
-              "packages": [$packages],
-              "objectTypes": [$objectTypes],
-              "popularTitlesSortBy": "TRENDING",
-              "releaseYear": {
-                "min": $year,
-                "max": $year
-              }
-            }
-        """.trimIndent()
+        if (query.startsWith(PREFIX_SEARCH)) {
+            val id = query.removePrefix(PREFIX_SEARCH)
+            return GET("$cinemetaUrl/meta/movie/$id.json")
+        }
 
-        return makeGraphQLRequest(justWatchQuery(), variables)
+        val types = CatalogFilters.mediaType(filters)
+        val network = CatalogFilters.streamingService(filters)
+        val type = types.firstOrNull() ?: "movie"
+        val trimmedQuery = query.trim()
+
+        return if (trimmedQuery.isBlank()) {
+            GET("$streamingCatalogUrl/catalog/$type/$network.json")
+        } else {
+            GET("$cinemetaUrl/catalog/$type/top/search=$trimmedQuery.json")
+        }
     }
 
-    override fun searchAnimeParse(response: Response) = popularAnimeParse(response)
+    override fun searchAnimeParse(response: Response): AnimesPage {
+        val responseString = response.body.string()
+        var url = response.request.url.toString()
 
-    // =========================== Anime Details ============================
+        if (url.contains("/meta/")) {
+            val detail = json.decodeFromString<CinemetaMetaDetailResponse>(responseString)
+            val meta = detail.meta
+            val type = if (url.contains("/movie/")) "movie" else "series"
+            val imdbId = meta?.id.orEmpty()
 
-    override fun animeDetailsParse(response: Response): SAnime = throw UnsupportedOperationException()
+            val anime = SAnime.create().apply {
+                url = "$imdbId,$type"
+                title = meta?.name.orEmpty()
+                thumbnail_url = meta?.poster.orEmpty()
+                description = meta?.description.orEmpty()
+                genre = meta?.genres?.joinToString().orEmpty()
+            }
+            return AnimesPage(listOf(anime), false)
+        }
 
-    // override suspend fun getAnimeDetails(anime: SAnime): SAnime = throw UnsupportedOperationException()
+        val searchResponse = json.decodeFromString<CinemetaSearchResponse>(responseString)
+        val results = searchResponse.metas.orEmpty()
+        return AnimesPage(results.map { it.toSAnime() }, false)
+    }
+
+    // =============================== Filters =======================================
+
+    override fun getFilterList(): AnimeFilterList = CatalogFilters.getFilterList()
+
+    // ===========================  Details  ====================================
+
+    override fun animeDetailsParse(response: Response): SAnime {
+        val responseString = response.body.string()
+        val detail = json.decodeFromString<CinemetaMetaDetailResponse>(responseString)
+        val meta = detail.meta ?: return SAnime.create()
+
+        var url = response.request.url.toString()
+        val type = if (url.contains("/movie/")) "movie" else "series"
+        val imdbId = meta.id.orEmpty()
+
+        return SAnime.create().apply {
+            url = "$imdbId,$type"
+            title = meta.name.orEmpty()
+            thumbnail_url = meta.poster.orEmpty()
+            description = meta.description.orEmpty()
+            genre = meta.genres?.joinToString().orEmpty()
+            author = meta.director?.joinToString().orEmpty()
+            artist = meta.cast?.take(4)?.joinToString().orEmpty()
+            status = mapStatus(meta.status, meta.released)
+        }
+    }
 
     override suspend fun getAnimeDetails(anime: SAnime): SAnime {
-        val query = $$"""
-            query GetUrlTitleDetails($fullPath: String!, $country: Country!, $language: Language!) {
-              urlV2(fullPath: $fullPath) {
-                node {
-                  ...TitleDetails
-                }
-              }
+        val parts = anime.url.split(",")
+        val imdbId = parts[0]
+        val type = parts.getOrNull(1)?.lowercase()?.ifBlank { "movie" } ?: "movie"
+
+        val detail = fetchMetaDetail(type, imdbId)
+
+        if (detail != null) {
+            anime.title = detail.name ?: anime.title
+            if (!detail.poster.isNullOrBlank()) {
+                anime.thumbnail_url = detail.poster
             }
-
-            fragment TitleDetails on Node {
-              ... on MovieOrShowOrSeason {
-                id
-                objectType
-                content(country: $country, language: $language) {
-                  title
-                  shortDescription
-                  externalIds {
-                    imdbId
-                  }
-                  posterUrl
-                  genres {
-                    translation(language: $language)
-                  }
-                }
-              }
-            }
-        """.trimIndent()
-
-        val country = preferences.getString(PREF_REGION_KEY, PREF_REGION_DEFAULT)
-        val language = preferences.getString(PREF_JW_LANG_KEY, PREF_JW_LANG_DEFAULT)
-        val variables = """
-            {
-              "fullPath": "${anime.url.split(',').last()}",
-              "country": "$country",
-              "language": "$language"
-            }
-        """.trimIndent()
-
-        val content = runCatching {
-            json.decodeFromString<GetUrlTitleDetailsResponse>(client.newCall(makeGraphQLRequest(query, variables)).execute().body.string())
-        }.getOrNull()?.data?.urlV2?.node?.content
-
-        anime.title = content?.title ?: ""
-        anime.thumbnail_url = "https://images.justwatch.com${content?.posterUrl?.replace("{profile}", "s718")?.replace("{format}", "webp")}"
-        anime.description = content?.shortDescription ?: ""
-        val genresList = content?.genres?.mapNotNull { it.translation }.orEmpty()
-        anime.genre = genresList.joinToString()
+            anime.description = detail.description ?: anime.description
+            anime.genre = detail.genres?.joinToString() ?: anime.genre
+            anime.author = detail.writer?.joinToString() ?: detail.writer?.joinToString()
+            anime.artist = detail.cast?.take(4)?.joinToString() ?: anime.artist
+            anime.status = mapStatus(detail.status, detail.released)
+        }
 
         return anime
     }
@@ -311,58 +229,65 @@ class Torrentio :
         val parts = anime.url.split(",")
         val type = parts[1].lowercase()
         val imdbId = parts[0]
-        return GET("https://cinemeta-live.strem.io/meta/$type/$imdbId.json")
+        return GET("$cinemetaUrl/meta/$type/$imdbId.json")
     }
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val responseString = response.body.string()
         val episodeList = json.decodeFromString<EpisodeList>(responseString)
+
         return when (episodeList.meta?.type) {
             "series" -> {
-                episodeList.meta.videos
-                    ?.let { videos ->
-                        val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
-                        val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
-                        val now = System.currentTimeMillis()
+                val showUpcoming = preferences.getBoolean(UPCOMING_EP_KEY, UPCOMING_EP_DEFAULT)
+                val hideSeasonZero = preferences.getBoolean(HIDE_SEASON_ZERO_KEY, HIDE_SEASON_ZERO_DEFAULT)
+                val now = System.currentTimeMillis()
 
-                        videos.filter { video ->
-                            val isNotSeasonZero = !hideSeasonZero || video.season != 0
-                            isNotSeasonZero && (showUpcoming || (video.released?.let { parseDate(it) } ?: 0L) <= now)
-                        }
+                episodeList.meta.videos
+                    .orEmpty()
+                    .filter { video ->
+                        if (hideSeasonZero) video.season != 0 else true
                     }
-                    ?.map { video ->
-                        SEpisode.create().apply {
+                    .mapNotNull { video ->
+                        val releaseTime = (video.firstAired ?: video.released)
+                            ?.let(::parseDate) ?: Long.MAX_VALUE
+
+                        val isReleased = releaseTime <= now
+                        if (!showUpcoming && !isReleased) {
+                            return@mapNotNull null
+                        }
+
+                        val episode = SEpisode.create().apply {
                             episode_number = "${video.season}.${video.number}".toFloat()
                             url = "/stream/series/${video.id}.json"
-                            date_upload = video.released?.let { parseDate(it) } ?: 0L
-                            name = "S${video.season.toString().trim()}:E${video.number} - ${video.title}"
-                            scanlator = (video.released?.let { parseDate(it) } ?: 0L)
-                                .takeIf { it > System.currentTimeMillis() }
-                                ?.let { "Upcoming" }
-                                ?: ""
+                            date_upload = if (releaseTime == Long.MAX_VALUE) 0L else releaseTime
+                            name = "S${video.season}:E${video.number} - ${video.name.orEmpty()}"
+                            scanlator = if (!isReleased) "Upcoming" else ""
                         }
+
+                        video to episode
                     }
-                    ?.sortedWith(
-                        compareBy<SEpisode> { it.name.substringAfter("S").substringBefore(":").toInt() }
-                            .thenBy { it.name.substringAfter("E").substringBefore(" -").toInt() },
+                    .sortedWith(
+                        compareByDescending<Pair<EpisodeVideo, SEpisode>> { (video, _) -> video.season!! > 0 }
+                            .thenByDescending { (video, _) -> video.season }
+                            .thenByDescending { (video, _) -> video.number },
                     )
-                    .orEmpty().reversed()
+                    .map { (_, episode) -> episode }
             }
 
             "movie" -> {
-                // Handle movie response
                 listOf(
                     SEpisode.create().apply {
-                        episode_number = 1.0F
+                        episode_number = 1f
                         url = "/stream/movie/${episodeList.meta.id}.json"
                         name = "Movie"
                     },
-                ).reversed()
+                )
             }
 
             else -> emptyList()
         }
     }
+
     private fun parseDate(dateStr: String): Long = runCatching { DATE_FORMATTER.parse(dateStr)?.time }
         .getOrNull() ?: 0L
 
@@ -467,6 +392,78 @@ class Torrentio :
         )
     }
 
+    // ============================ Helper Methods ==============================
+    private suspend fun fetchStreamingCatalog(mediaType: String, streamingServiceId: String): List<CinemetaMeta> {
+        val url = "$streamingCatalogUrl/catalog/$mediaType/$streamingServiceId.json"
+        return runCatching {
+            val response = client.newCall(GET(url)).awaitSuccess()
+            json.decodeFromString<CinemetaSearchResponse>(response.body.string()).metas.orEmpty()
+        }.getOrDefault(emptyList())
+    }
+
+    private suspend fun searchAnimeByIdParse(imdbId: String): AnimesPage {
+        val movieMeta = fetchMetaDetail("movie", imdbId)
+        val meta = movieMeta ?: fetchMetaDetail("series", imdbId)
+        val type = if (movieMeta != null) "movie" else "series"
+
+        val anime = SAnime.create().apply {
+            url = "$imdbId,$type"
+            title = meta?.name.orEmpty()
+            thumbnail_url = meta?.poster.orEmpty()
+            description = meta?.description.orEmpty()
+            genre = meta?.genres?.joinToString().orEmpty()
+        }
+
+        return AnimesPage(listOf(anime), false)
+    }
+
+    private suspend fun fetchMetaDetail(type: String, imdbId: String): CinemetaMetaDetail? {
+        val url = "$cinemetaUrl/meta/$type/$imdbId.json"
+
+        return runCatching {
+            val response = client.newCall(GET(url)).awaitSuccess()
+            val body = response.body.string()
+            json.decodeFromString<CinemetaMetaDetailResponse>(body).meta
+        }.getOrNull()
+    }
+
+    private fun CinemetaMeta.toSAnime(): SAnime = SAnime.create().apply {
+        url = "${imdbId ?: id.orEmpty()},${type.orEmpty()}"
+        title = name.orEmpty()
+        thumbnail_url = poster.orEmpty()
+    }
+
+    private fun mapStatus(status: String?, released: String?): Int {
+        if (status != null) {
+            return when (status.trim().lowercase()) {
+                "continuing" -> SAnime.ONGOING
+                "ended" -> SAnime.COMPLETED
+                else -> SAnime.UNKNOWN
+            }
+        }
+
+        val releaseTime = released?.let(::parseDate) ?: return SAnime.UNKNOWN
+        return if (releaseTime > System.currentTimeMillis()) SAnime.ONGOING else SAnime.COMPLETED
+    }
+
+    private suspend fun fetchCatalog(type: String, query: String): List<CinemetaMeta> {
+        val trimmed = query.trim()
+
+        if (trimmed.length < 2) return emptyList()
+
+        val url = cinemetaUrl.toHttpUrl().newBuilder()
+            .addPathSegment("catalog")
+            .addPathSegment(type)
+            .addPathSegment("top")
+            .addPathSegment("search=$trimmed.json")
+            .build()
+
+        return runCatching {
+            val response = client.newCall(GET(url)).awaitSuccess()
+            json.decodeFromString<CinemetaSearchResponse>(response.body.string()).metas.orEmpty()
+        }.getOrDefault(emptyList())
+    }
+
     private fun fetchTrackers(): String {
         val request = Request.Builder()
             .url("https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt")
@@ -478,6 +475,8 @@ class Torrentio :
         }
     }
 
+    // ============================ Preferences ==============================
+
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         // Debrid provider
         ListPreference(screen.context).apply {
@@ -486,7 +485,8 @@ class Torrentio :
             entries = PREF_DEBRID_ENTRIES
             entryValues = PREF_DEBRID_VALUES
             setDefaultValue("none")
-            summary = "Choose 'None' for Torrent. If you select a Debrid provider, enter your token key. No token key is needed if 'None' is selected."
+            summary =
+                "Choose 'None' for Torrent. If you select a Debrid provider, enter your token key. No token key is needed if 'None' is selected."
 
             setOnPreferenceChangeListener { _, newValue ->
                 val selected = newValue as String
@@ -584,6 +584,9 @@ class Torrentio :
             key = HIDE_SEASON_ZERO_KEY
             title = "Hide Season 0 Episodes"
             setDefaultValue(HIDE_SEASON_ZERO_DEFAULT)
+            setOnPreferenceChangeListener { _, newValue ->
+                preferences.edit().putBoolean(key, newValue as Boolean).commit()
+            }
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
@@ -604,45 +607,13 @@ class Torrentio :
             }
             summary = "Codec: (HEVC / x265)  & AV1. High-quality video with less data usage."
         }.also(screen::addPreference)
-
-        // JustWatch Settings
-
-        // Region
-        ListPreference(screen.context).apply {
-            key = PREF_REGION_KEY
-            title = "Catalogue Region"
-            entries = PREF_REGION_ENTRIES
-            entryValues = PREF_REGION_VALUES
-            setDefaultValue(PREF_REGION_DEFAULT)
-            summary = "Region based catalogue recommendation."
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
-        }.also(screen::addPreference)
-
-        // Poster and Titles Language
-        ListPreference(screen.context).apply {
-            key = PREF_JW_LANG_KEY
-            title = "Poster and Titles Language"
-            entries = PREF_JW_LANG_ENTRIES
-            entryValues = PREF_JW_LANG_VALUES
-            setDefaultValue(PREF_JW_LANG_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
-        }.also(screen::addPreference)
     }
 
     companion object {
         const val PREFIX_SEARCH = "id:"
+
+        // Popular source (Streaming Catalogs addon)
+        private const val DEFAULT_STREAMING_SERVICE = "nfx"
 
         // Token
         private const val PREF_TOKEN_KEY = "token"
@@ -806,7 +777,7 @@ class Torrentio :
 
         private val PREF_QUALITY_DEFAULT = PREF_DEFAULT_QUALITY_VALUE.toSet()
 
-        // Qualities/Resolutions
+        // Languages
         private const val PREF_LANG_KEY = "lang_selection"
         private val PREF_LANG = arrayOf(
             "🇯🇵 Japanese",
@@ -819,7 +790,6 @@ class Torrentio :
             "🇨🇳 Chinese",
             "🇹🇼 Taiwanese",
             "🇫🇷 French",
-
             "🇩🇪 German",
             "🇳🇱 Dutch",
             "🇮🇳 Hindi",
@@ -830,7 +800,6 @@ class Torrentio :
             "🇱🇻 Latvian",
             "🇪🇪 Estonian",
             "🇨🇿 Czech",
-
             "🇸🇰 Slovakian",
             "🇸🇮 Slovenian",
             "🇭🇺 Hungarian",
@@ -841,7 +810,6 @@ class Torrentio :
             "🇺🇦 Ukrainian",
             "🇬🇷 Greek",
             "🇩🇰 Danish",
-
             "🇫🇮 Finnish",
             "🇸🇪 Swedish",
             "🇳🇴 Norwegian",
@@ -852,7 +820,6 @@ class Torrentio :
             "🇻🇳 Vietnamese",
             "🇮🇩 Indonesian",
             "🇲🇾 Malay",
-
             "🇹🇭 Thai",
         )
         private val PREF_LANG_VALUE = arrayOf(
@@ -866,7 +833,6 @@ class Torrentio :
             "chinese",
             "taiwanese",
             "french",
-
             "german",
             "dutch",
             "hindi",
@@ -877,7 +843,6 @@ class Torrentio :
             "latvian",
             "estonian",
             "czech",
-
             "slovakian",
             "slovenian",
             "hungarian",
@@ -888,7 +853,6 @@ class Torrentio :
             "ukrainian",
             "greek",
             "danish",
-
             "finnish",
             "swedish",
             "norwegian",
@@ -899,9 +863,7 @@ class Torrentio :
             "vietnamese",
             "indonesian",
             "malay",
-
             "thai",
-
         )
 
         private val PREF_LANG_DEFAULT = setOf<String>()
@@ -921,27 +883,5 @@ class Torrentio :
         private val DATE_FORMATTER by lazy {
             SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
         }
-
-        // JustWatch settings
-        // Region
-        private const val PREF_REGION_KEY = "jw_region"
-        private val PREF_REGION_ENTRIES = arrayOf(
-            "Albania", "Algeria", "Androrra", "Angola", "Antigua and Barbuda", "Argentina", "Australia", "Austria", "Azerbaijan", "Bahamas", "Bahrain", "Barbados", "Belarus", "Belgium", "Belize", "Bermuda", "Bolivia", "Bosnia and Herzegovina", "Brazil", "Bulgaria", "Burkina Faso", "Cameroon", "Canada", "Cape Verde", "Chad", "Chile", "Colombia", "Costa Rica", "Croatia", "Cuba", "Cyprus", "Czech Republic", "DR Congo", "Denmark", "Dominican Republic", "Ecuador", "Egypt", "El Salvador", "Equatorial Guinea", "Estonia", "Fiji", "Finland", "France", "French Guiana", "French Polynesia", "Germany", "Ghana", "Gibraltar", "Greece", "Guatemala", "Guernsey", "Guyana", "Honduras", "Hong Kong", "Hungary", "Iceland", "India", "Indonesia", "Iraq", "Ireland", "Israel", "Italy", "Ivory Coast", "Jamaica", "Japan", "Jordan", "Kenya", "Kosovo", "Kuwait", "Latvia", "Lebanon", "Libya", "Liechtenstein", "Lithuania", "Luxembourg", "Macedonia", "Madagascar", "Malawi", "Malaysia", "Mali", "Malta", "Mauritius", "Mexico", "Moldova", "Monaco", "Montenegro", "Morocco", "Mozambique", "Netherlands", "New Zealand", "Nicaragua", "Niger", "Nigeria", "Norway", "Oman", "Pakistan", "Palestine", "Panama", "Papua New Guinea", "Paraguay", "Peru", "Philippines", "Poland", "Portugal", "Qatar", "Romania", "Russia", "Saint Lucia", "San Marino", "Saudi Arabia", "Senegal", "Serbia", "Seychelles", "Singapore", "Slovakia", "Slovenia", "South Africa", "South Korea", "Spain", "Sweden", "Switzerland", "Taiwan", "Tanzania", "Thailand", "Trinidad and Tobago", "Tunisia", "Turkey", "Turks and Caicos Islands", "Uganda", "Ukraine", "United Arab Emirates", "United Kingdom", "United States", "Uruguay", "Vatican City", "Venezuela", "Yemen", "Zambia", "Zimbabwe",
-        )
-        private val PREF_REGION_VALUES = arrayOf(
-            "AL", "DZ", "AD", "AO", "AG", "AR", "AU", "AT", "AZ", "BS", "BH", "BB", "BY", "BE", "BZ", "BM", "BO", "BA", "BR", "BG", "BF", "CM", "CA", "CV", "TD", "CL", "CO", "CR", "HR", "CU", "CY", "CZ", "CD", "DK", "DO", "EC", "EG", "SV", "GQ", "EE", "FJ", "FI", "FR", "GF", "PF", "DE", "GH", "GI", "GR", "GT", "GG", "GY", "HN", "HK", "HU", "IS", "IN", "ID", "IQ", "IE", "IL", "IT", "CI", "JM", "JP", "JO", "KE", "XK", "KW", "LV", "LB", "LY", "LI", "LT", "LU", "MK", "MG", "MW", "MY", "ML", "MT", "MU", "MX", "MD", "MC", "ME", "MA", "MZ", "NL", "NZ", "NI", "NE", "NG", "NO", "OM", "PK", "PS", "PA", "PG", "PY", "PE", "PH", "PL", "PT", "QA", "RO", "RU", "LC", "SM", "SA", "SN", "RS", "SC", "SG", "SK", "SI", "ZA", "KR", "ES", "SE", "CH", "TW", "TZ", "TH", "TT", "TN", "TR", "TC", "UG", "UA", "AE", "UK", "US", "UY", "VA", "VE", "YE", "ZM", "ZW",
-        )
-        private const val PREF_REGION_DEFAULT = "US"
-
-        // JustWatch language in Poster, Titles
-        private const val PREF_JW_LANG_KEY = "jw_lang"
-        private val PREF_JW_LANG_ENTRIES = arrayOf(
-            "Arabic", "Azerbaijani", "Belarusian", "Bulgarian", "Bosnian", "Catalan", "Czech", "German", "Greek", "English", "English (U.S.A.)", "Spanish", "Spanish (Spain)", "Spanish (Latinamerican)", "Estonian", "Finnish", "French", "French (Canada)", "Hebrew", "Croatian", "Hungarian", "Icelandic", "Italian", "Japanese", "Korean", "Lithuanian", "Latvian", "Macedonian", "Maltese", "Polish", "Portuguese", "Portuguese (Portugal)", "Portuguese (Brazil)", "Romanian", "Russian", "Slovakian", "Slovenian", "Albanian", "Serbian", "Swedish", "Swahili", "Turkish", "Ukrainian", "Urdu", "Chinese",
-        )
-        private val PREF_JW_LANG_VALUES = arrayOf(
-            "ar", "az", "be", "bg", "bs", "ca", "cs", "de", "el", "en", "en-US", "es", "es-ES", "es-LA", "et", "fi", "fr", "fr-CA", "he", "hr", "hu", "is", "it", "ja", "ko", "lt", "lv", "mk", "mt", "pl", "pt", "pt-PT", "pt-BR", "ro", "ru", "sk", "sl", "sq", "sr", "sv", "sw", "tr", "uk", "ur", "zh",
-
-        )
-        private const val PREF_JW_LANG_DEFAULT = "en"
     }
 }

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -86,13 +86,9 @@ class Torrentio :
 
         return AnimesPage(results.map { it.toSAnime() }, false)
     }
-    override fun popularAnimeRequest(page: Int): Request {
-        TODO("Not yet implemented") // hmm naah
-    }
+    override fun popularAnimeRequest(page: Int): Request = throw UnsupportedOperationException("Use getPopularAnime instead")
 
-    override fun popularAnimeParse(response: Response): AnimesPage {
-        TODO("Not yet implemented") // i wont
-    }
+    override fun popularAnimeParse(response: Response): AnimesPage = throw UnsupportedOperationException("Use getPopularAnime instead")
     // =============================== Latest ===============================
 
     override fun latestUpdatesRequest(page: Int): Request {
@@ -435,9 +431,9 @@ class Torrentio :
                 video to episode
             }
             .sortedWith(
-                compareByDescending<Pair<EpisodeVideo, SEpisode>> { (video, _) -> video.season!! > 0 }
-                    .thenByDescending { (video, _) -> video.season }
-                    .thenByDescending { (video, _) -> video.number },
+                compareByDescending<Pair<EpisodeVideo, SEpisode>> { (video, _) -> (video.season ?: 0) > 0 }
+                    .thenByDescending { (video, _) -> video.season ?: 0 }
+                    .thenByDescending { (video, _) -> video.number ?: 0 },
             )
             .map { (_, episode) -> episode }
     }
@@ -448,8 +444,20 @@ class Torrentio :
         name = "Movie"
     }
 
-    private fun parseDate(dateStr: String): Long = runCatching { DATE_FORMATTER.parse(dateStr)?.time }
-        .getOrNull() ?: 0L
+    private fun parseDate(dateStr: String): Long {
+        val trimmed = dateStr.trim()
+        if (trimmed.isEmpty()) return 0L
+
+        runCatching { DATE_FORMATTER.parse(trimmed)?.time }
+            .getOrNull()
+            ?.let { return it }
+
+        runCatching { SIMPLE_DATE_FORMATTER.parse(trimmed)?.time }
+            .getOrNull()
+            ?.let { return it }
+
+        return 0L
+    }
 
     // ============================ Video Links =============================
 
@@ -699,7 +707,7 @@ class Torrentio :
         }
     }
 
-    private fun getTmdbApiKey(): String = PREF_TMDB_DEFAULT
+    private fun getTmdbApiKey(): String = preferences.getString(PREF_TMDB_API_KEY, null)?.takeIf { it.isNotBlank() } ?: PREF_TMDB_DEFAULT
 
     // ============================ Helper Methods ==============================
 
@@ -915,6 +923,19 @@ class Torrentio :
             }
         }.also(screen::addPreference)
 
+        EditTextPreference(screen.context).apply {
+            key = PREF_TMDB_API_KEY
+            title = "TMDB API Key"
+            summary = "Optional: provide your own TMDB API key. Leave blank to use the bundled default key."
+
+            setOnPreferenceChangeListener { _, newValue ->
+                runCatching {
+                    val value = (newValue as String).trim()
+                    preferences.edit().putString(key, value).commit()
+                }.getOrDefault(false)
+            }
+        }.also(screen::addPreference)
+
         MultiSelectListPreference(screen.context).apply {
             key = PREF_PROVIDER_KEY
             title = "Enable/Disable Providers"
@@ -1016,8 +1037,8 @@ class Torrentio :
         private const val PREF_CONTENT_TYPE_DEFAULT = "all"
         private val PREF_CONTENT_TYPE_ENTRIES = arrayOf("All Content", "Anime Only (Crunchyroll)", "Movies & TV")
         private val PREF_CONTENT_TYPE_VALUES = arrayOf("all", "anime", "movies_tv")
-
-        private const val PREF_TMDB_DEFAULT = "ea021b3b0775c8531592713ab727f254" // ignore this ive got keys to play with
+        private const val PREF_TMDB_DEFAULT = "ea021b3b0775c8531592713ab727f254"
+        private const val PREF_TMDB_API_KEY = "tmdb_api_key"
 
         private const val PREF_TOKEN_KEY = "token"
         private const val PREF_TOKEN_DEFAULT = ""
@@ -1112,6 +1133,10 @@ class Torrentio :
 
         private val DATE_FORMATTER by lazy {
             SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
+        }
+
+        private val SIMPLE_DATE_FORMATTER by lazy {
+            SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
         }
     }
 }

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/dto/CinemetaDto.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/dto/CinemetaDto.kt
@@ -1,0 +1,43 @@
+package eu.kanade.tachiyomi.animeextension.all.torrentio.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CinemetaSearchResponse(
+    val query: String? = null,
+    val metas: List<CinemetaMeta>? = null,
+)
+
+@Serializable
+data class CinemetaMeta(
+    val id: String? = null,
+    @SerialName("imdb_id") val imdbId: String? = null,
+    val type: String? = null,
+    val name: String? = null,
+    val poster: String? = null,
+    val background: String? = null,
+    val releaseInfo: String? = null,
+)
+
+@Serializable
+data class CinemetaMetaDetailResponse(
+    val meta: CinemetaMetaDetail? = null,
+)
+
+@Serializable
+data class CinemetaMetaDetail(
+    val id: String? = null,
+    val type: String? = null,
+    val name: String? = null,
+    val poster: String? = null,
+    val background: String? = null,
+    val description: String? = null,
+    val genres: List<String>? = null,
+    val cast: List<String>? = null,
+    val director: List<String>? = null,
+    val writer: List<String>? = null,
+    val imdbRating: String? = null,
+    val status: String? = null,
+    val released: String? = null,
+)

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/dto/TheMovieDatabaseDto.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/dto/TheMovieDatabaseDto.kt
@@ -1,0 +1,61 @@
+package eu.kanade.tachiyomi.animeextension.all.torrentio.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TheMovieDatabaseResponse(
+    val page: Int,
+    val results: List<TmdbResult>,
+    val total_results: Int,
+    val total_pages: Int,
+)
+
+@Serializable
+data class TmdbResult(
+    val id: Int,
+    val name: String? = null,
+    val title: String? = null,
+    val original_name: String? = null,
+    val original_title: String? = null,
+    val poster_path: String? = null,
+    val backdrop_path: String? = null,
+    val origin_country: List<String>? = null,
+    val original_language: String? = null,
+    val first_air_date: String? = null,
+    val release_date: String? = null,
+    val overview: String? = null,
+    val genre_ids: List<Int>? = null,
+    val vote_average: Double? = null,
+    val vote_count: Int? = null,
+    val popularity: Double? = null,
+    val adult: Boolean? = null,
+    val media_type: String? = null,
+)
+// TmdbDiscoverPlusResponse.kt
+
+@Serializable
+data class TmdbDiscoverPlusResponse(
+    val meta: TmdbDiscoverPlusMeta? = null,
+    val cacheMaxAge: Int? = null,
+    val staleRevalidate: Int? = null,
+    val staleError: Int? = null,
+)
+
+@Serializable
+data class TmdbDiscoverPlusMeta(
+    val id: String? = null,
+    val tmdbId: Int? = null,
+    var imdbId: String? = null,
+    var imdb_id: String? = null,
+    val type: String? = null,
+    val name: String? = null,
+    val poster: String? = null,
+    val description: String? = null,
+    val genres: List<String>? = null,
+    val cast: List<String>? = null,
+    val director: String? = null,
+    val writer: String? = null,
+    val released: String? = null,
+    val status: String? = null,
+    val videos: List<EpisodeVideo>? = null,
+)

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/dto/TorrentioDto.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/dto/TorrentioDto.kt
@@ -2,80 +2,6 @@ package eu.kanade.tachiyomi.animeextension.all.torrentio.dto
 
 import kotlinx.serialization.Serializable
 
-@Serializable
-class GetPopularTitlesResponse(
-    val data: PopularTitlesData? = null,
-)
-
-@Serializable
-class PopularTitlesData(
-    val popularTitles: PopularTitles? = null,
-)
-
-@Serializable
-class PopularTitles(
-    val edges: List<PopularTitlesEdge>? = null,
-    val pageInfo: PageInfo? = null,
-)
-
-@Serializable
-class PopularTitlesEdge(
-    val node: PopularTitleNode? = null,
-)
-
-@Serializable
-class PopularTitleNode(
-    val objectType: String? = null,
-    val content: Content? = null,
-)
-
-@Serializable
-class Content(
-    val fullPath: String? = null,
-    val title: String? = null,
-    val shortDescription: String? = null,
-    val externalIds: ExternalIds? = null,
-    val posterUrl: String? = null,
-    val genres: List<Genre>? = null,
-    val credits: List<Credit>? = null,
-)
-
-@Serializable
-class ExternalIds(
-    val imdbId: String? = null,
-)
-
-@Serializable
-class Genre(
-    val translation: String? = null,
-)
-
-@Serializable
-class Credit(
-    val name: String? = null,
-    val role: String? = null,
-)
-
-@Serializable
-class PageInfo(
-    val hasNextPage: Boolean = false,
-)
-
-@Serializable
-class GetUrlTitleDetailsResponse(
-    val data: UrlV2Data? = null,
-)
-
-@Serializable
-class UrlV2Data(
-    val urlV2: UrlV2? = null,
-)
-
-@Serializable
-class UrlV2(
-    val node: PopularTitleNode? = null,
-)
-
 // Stream Data For Torrent
 @Serializable
 class StreamDataTorrent(
@@ -110,6 +36,7 @@ class EpisodeVideo(
     val id: String? = null,
     val season: Int? = null,
     val number: Int? = null,
+    val name: String? = null,
+    val firstAired: String? = null,
     val released: String? = null,
-    val title: String? = null,
 )


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Switch Torrentio from JustWatch to Cinemeta v3/TMDB-based metadata and catalogs, enabling latest updates and richer filtering while updating supporting DTOs and preferences.

New Features:
- Add TMDB-backed latest updates support, including anime-focused discovery and general trending movies/TV.
- Introduce Cinemeta v3-based search, catalog browsing, and metadata resolution for movies and series.
- Add configurable content-type filtering (all, anime-only via Crunchyroll, or movies & TV) and per-platform catalog filters (Netflix, Disney+, etc.).
- Allow users to set a custom TMDB API key in extension preferences.

Bug Fixes:
- Ensure episode and details fetching works for both IMDb-style and TMDB numeric IDs by normalizing IDs through Cinemeta and Discover+.

Enhancements:
- Replace JustWatch GraphQL integration with new Cinemeta/TMDB/Discover+ APIs for popular, search, details, and episodes.
- Improve episode generation for series and movies, including better upcoming-episode handling and TMDB/Discover+ fallback logic.
- Refine episode date parsing and status mapping to more accurately label ongoing vs completed shows.
- Simplify and tighten preference descriptions and behavior for provider, quality, language, and upcoming/season-0 options.

Build:
- Bump Torrentio extension versionCode to 9.