### PR TITLE
AllAnime [EN]: Fix Stream Encryption

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AllAnime'
     extClass = '.AllAnime'
-    extVersionCode = 57
+    extVersionCode = 58
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -261,7 +261,7 @@ class AllAnime :
     // ============================ Video Links =============================
 
     private val keyManager by lazy {
-        AllAnimeKeyManager(client, headers, preferences, preferences.siteUrl)
+        AllAnimeKeyManager(client, headers, preferences, preferences.siteUrl, apiUrl)
     }
 
     override fun videoListRequest(episode: SEpisode): Request = throw UnsupportedOperationException()
@@ -280,6 +280,7 @@ class AllAnime :
                 put("version", 1)
                 put("sha256Hash", STREAM_HASH)
             }
+            put("k", ANIME_LANE)
             put("aaReq", keyManager.aaReq(material))
         }
 
@@ -289,7 +290,10 @@ class AllAnime :
             addQueryParameter("extensions", extensions.toJsonString())
         }.build()
 
-        return GET(url, headers)
+        // The build the token was minted for; the server rejects a mismatch with AA_CRYPTO_BUILD_MISMATCH.
+        val streamHeaders = headers.newBuilder().set("x-build-id", material.buildId).build()
+
+        return GET(url, streamHeaders)
     }
 
     private val allAnimeExtractor by lazy { AllAnimeExtractor(client, headers) }
@@ -507,10 +511,16 @@ class AllAnime :
     private suspend fun fetchSourceUrls(episode: SEpisode): List<SourceUrl> {
         val encryptionChangedError = Exception("AllAnime changed its stream encryption; update the extension")
         var lastError: Throwable? = null
-        var maskHealed = false
+        var buildHealed = false
 
         repeat(MAX_KEY_ATTEMPTS) { attempt ->
-            val material = keyManager.material(forceRefresh = attempt > 0)
+            // Obtaining material can itself fail transiently; letting that escape would spend the
+            // whole retry budget on the first attempt.
+            val material = runCatching { keyManager.material(forceRefresh = attempt > 0) }
+                .getOrElse {
+                    lastError = it
+                    return@repeat
+                }
 
             // Keep the real request error so it's surfaced instead of the generic crypto message.
             val responseBody = runCatching {
@@ -543,9 +553,11 @@ class AllAnime :
                 // not a network fault; record it so the surfaced error reflects this attempt.
                 lastError = encryptionChangedError
 
-                // Only a server-side crypto rejection means the mask likely rotated; heal once.
-                if (attempt >= 1 && !maskHealed && keyManager.isCryptoError(responseBody)) {
-                    maskHealed = keyManager.healMask()
+                // The bootstrap accepted this build but the streams API did not, so only a rescrape
+                // can help; force one on the next attempt.
+                if (attempt >= 1 && !buildHealed && keyManager.isCryptoError(responseBody)) {
+                    keyManager.invalidateBuild()
+                    buildHealed = true
                 }
             }
             keyManager.invalidate()

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -440,15 +440,20 @@ class AllAnime :
         val quality = preferences.quality
         val subPref = preferences.subPref
 
+        // Reversed comparator, not reversed list: keeps the sort stable, so equal-key entries stay
+        // in extractor order (highest bitrate first).
         return pList.sortedWith(
-            compareBy(
+            compareBy<Pair<Video, Float>>(
                 { if (prefServer == "site_default") it.second else it.first.quality.contains(prefServer, true) },
                 { it.first.quality.contains(quality, true) },
                 { it.first.quality.contains(subPref, true) },
-            ),
-        ).reversed()
-            .map { t -> t.first }
+                { it.first.quality.resolution() },
+            ).reversed(),
+        ).map { t -> t.first }
     }
+
+    // First match, not the largest: names can end in a bitrate ("Ak - 1080 5 mb/s").
+    private fun String.resolution(): Int = RESOLUTION_REGEX.find(this)?.value?.toIntOrNull() ?: 0
 
     private fun buildPost(dataObject: JsonObject): Request {
         val payload = dataObject.toJsonString().toJsonBody()
@@ -642,6 +647,8 @@ class AllAnime :
         private const val PREF_SUB_DEFAULT = "sub"
 
         private const val MAX_KEY_ATTEMPTS = 3
+
+        private val RESOLUTION_REGEX = Regex("""\d{3,4}""")
 
         // XOR keys indexed by source-URL prefix type: '--'=3  '#-'=2  '##'=1  '-#'=4  '#'=0
         private val XOR_KEYS = arrayOf(

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -620,7 +620,7 @@ class AllAnime :
         private val PREF_HOSTER_ENTRY_VALUES = INTERAL_HOSTER_NAMES.map {
             it.lowercase()
         }.toTypedArray()
-        private val PREF_HOSTER_DEFAULT = setOf("default", "ac", "ak", "kir", "luf-mp4", "si-hls", "s-mp4", "ac-hls")
+        private val PREF_HOSTER_DEFAULT = setOf("default", "ac", "ak", "kir", "si-hls", "s-mp4", "ac-hls")
 
         private const val PREF_ALT_HOSTER_KEY = "alt_hoster_selection"
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeBundle.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeBundle.kt
@@ -1,0 +1,179 @@
+package eu.kanade.tachiyomi.animeextension.en.allanime
+
+/**
+ * Recovers the two per-build crypto inputs — `buildId` and the four mask seeds — from mkissa's
+ * obfuscated JS chunk.
+ *
+ * `buildId` is a plain literal. The seeds are not: each is two concatenated calls into a string
+ * table, reached through alias functions that offset the index, and the table is rotated at load
+ * time by an amount only the bundle's own checksum loop knows. Rather than emulate that loop,
+ * [parse] resolves the lookup chain for every possible rotation and keeps the one whose results
+ * all have the seed shape.
+ */
+object AllAnimeBundle {
+
+    class BuildInfo(val buildId: String, val seeds: List<String>)
+
+    fun parse(js: String): BuildInfo? {
+        val buildId = BUILD_ID_REGEX.find(js)?.groupValues?.get(1) ?: return null
+        val seeds = extractSeeds(js) ?: return null
+        return BuildInfo(buildId, seeds)
+    }
+
+    private class Base(val table: String, val offset: Int)
+    private class Alias(val base: String, val argIndex: Int, val delta: Int)
+
+    private fun extractSeeds(js: String): List<String>? {
+        val tables = readTables(js)
+        val bases = BASE_DECODER_REGEX.findAll(js).associate { m ->
+            m.groupValues[1] to Base(m.groupValues[4], fold(m.groupValues[3]))
+        }
+        val aliases = buildMap {
+            // A seed may call a base decoder directly rather than through an alias; treating each
+            // base as its own identity alias lets one lookup path handle both spellings.
+            bases.keys.forEach { put(it, Alias(it, 0, 0)) }
+            ALIAS_DECODER_REGEX.findAll(js).forEach { m ->
+                val (name, firstParam, _, callee, arg, delta) = m.destructured
+                if (callee !in bases) return@forEach
+                // The alias forwards exactly one of its two parameters; which one tells us where
+                // the real table index sits in the call. Deeper chains are not handled.
+                put(name, Alias(callee, if (arg == firstParam) 0 else 1, if (delta.isEmpty()) 0 else fold(delta)))
+            }
+        }
+
+        // Normally there is exactly one such array, but scan every candidate so an unrelated
+        // lookalike earlier in the chunk cannot poison the parse.
+        for (match in SEED_ARRAY_REGEX.findAll(js)) {
+            val calls = CALL_REGEX.findAll(match.groupValues[1]).map(MatchResult::value).toList()
+            if (calls.size != AllAnimeCrypto.SEED_COUNT * 2) continue
+
+            // Every decoder ultimately indexes the same table, so any of them bounds the search.
+            val table = CALL_REGEX.find(calls.first())
+                ?.let { aliases[it.groupValues[1]] }
+                ?.let { tables[bases[it.base]?.table] }
+                ?: continue
+
+            val matches = table.indices.mapNotNull { rotation ->
+                seedsAt(calls, rotation, tables, bases, aliases)
+            }
+            // A wrong rotation matching the seed shape by chance is vanishingly unlikely, but
+            // would silently yield a bad mask — so require the answer to be unambiguous.
+            matches.singleOrNull()?.let { return it }
+        }
+        return null
+    }
+
+    private fun seedsAt(
+        calls: List<String>,
+        rotation: Int,
+        tables: Map<String, List<String>>,
+        bases: Map<String, Base>,
+        aliases: Map<String, Alias>,
+    ): List<String>? {
+        val seeds = calls.chunked(2).mapNotNull { (first, second) ->
+            val a = resolve(first, rotation, tables, bases, aliases) ?: return@mapNotNull null
+            val b = resolve(second, rotation, tables, bases, aliases) ?: return@mapNotNull null
+            (a + b).takeIf(SEED_REGEX::matches)
+        }
+        return seeds.takeIf { it.size == AllAnimeCrypto.SEED_COUNT }
+    }
+
+    private fun resolve(
+        call: String,
+        rotation: Int,
+        tables: Map<String, List<String>>,
+        bases: Map<String, Base>,
+        aliases: Map<String, Alias>,
+    ): String? {
+        val match = CALL_REGEX.matchEntire(call) ?: return null
+        val alias = aliases[match.groupValues[1]] ?: return null
+        val base = bases[alias.base] ?: return null
+        val table = tables[base.table]?.takeIf { it.isNotEmpty() } ?: return null
+
+        val args = listOfNotNull(
+            match.groupValues[2].toIntOrNull(),
+            match.groupValues[3].toIntOrNull(),
+        )
+        val arg = args.getOrNull(alias.argIndex) ?: return null
+
+        val index = arg + alias.delta - base.offset + rotation
+        return table[((index % table.size) + table.size) % table.size]
+    }
+
+    private fun readTables(js: String): Map<String, List<String>> = buildMap {
+        for (match in TABLE_HEAD_REGEX.findAll(js)) {
+            readStringArray(js, match.range.last)?.let { put(match.groupValues[1], it) }
+        }
+    }
+
+    /** Whitelist parser: returns null rather than a partial array if anything unexpected appears. */
+    private fun readStringArray(js: String, open: Int): List<String>? {
+        val items = mutableListOf<String>()
+        var i = open + 1
+        while (i < js.length) {
+            when (val c = js[i]) {
+                ']' -> return items
+                ',', ' ' -> i++
+                '"', '\'' -> {
+                    val sb = StringBuilder()
+                    i++
+                    while (i < js.length && js[i] != c) {
+                        if (js[i] == '\\') {
+                            sb.append(js[i + 1])
+                            i += 2
+                        } else {
+                            sb.append(js[i])
+                            i++
+                        }
+                    }
+                    if (i >= js.length) return null
+                    i++
+                    items.add(sb.toString())
+                }
+                else -> return null
+            }
+        }
+        return null
+    }
+
+    /** Folds the `2935+-1459*2` arithmetic the obfuscator hides every integer behind. */
+    private fun fold(expression: String): Int {
+        var total = 0
+        for (term in TERM_REGEX.findAll(expression.replace(" ", "")).map(MatchResult::value)) {
+            var sign = 1
+            var body = term
+            while (body.startsWith('+') || body.startsWith('-')) {
+                if (body.startsWith('-')) sign = -sign
+                body = body.substring(1)
+            }
+            var value = 1
+            for (factor in body.split('*')) value *= factor.toIntOrNull() ?: return 0
+            total += sign * value
+        }
+        return total
+    }
+
+    private val BUILD_ID_REGEX = Regex("""!==\s*["']string["']\s*\?\s*["'](\d+)["']\s*:\s*["']["']""")
+
+    private val TABLE_HEAD_REGEX = Regex("""function (\w+)\(\)\s*\{\s*(?:const|let|var)\s+\w+\s*=\s*\[""")
+
+    // Subtracts a constant from its argument and indexes the string table with the result.
+    private val BASE_DECODER_REGEX = Regex("""function (\w+)\((\w+)(?:,\w+)*\)\{return \2=\2-\(?([-\d+*\s]+?)\)?,(\w+)\(\)\[\2\]\}""")
+
+    // Forwards one of its two parameters to a base decoder, optionally shifting it. Kept to
+    // exactly two parameters on purpose: the argIndex logic above only distinguishes first
+    // from second.
+    private val ALIAS_DECODER_REGEX = Regex("""function (\w+)\((\w+),(\w+)\)\{return (\w+)\((\w+)((?:[-+][\d+*\s-]+)?)\)\}""")
+
+    private const val CALL_PATTERN = """(\w+)\(\s*(-?\d+)\s*(?:,\s*(-?\d+)\s*)?\)"""
+    private val CALL_REGEX = Regex(CALL_PATTERN)
+
+    // Four elements, each two concatenated lookups — the shape is what tells this array apart
+    // from every other array literal in the chunk.
+    private val SEED_ARRAY_REGEX = Regex("""=\[((?:$CALL_PATTERN\+$CALL_PATTERN,){3}$CALL_PATTERN\+$CALL_PATTERN)]""")
+
+    // 8 bytes of base64. Discriminating enough that only the true rotation produces four of them.
+    private val SEED_REGEX = Regex("""[A-Za-z0-9+/]{11}=""")
+
+    private val TERM_REGEX = Regex("""[-+]?[^-+]+""")
+}

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeBundle.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeBundle.kt
@@ -136,7 +136,10 @@ object AllAnimeBundle {
         return null
     }
 
-    /** Folds the `2935+-1459*2` arithmetic the obfuscator hides every integer behind. */
+    /**
+     * Folds the `2935+-1459*2` arithmetic the obfuscator hides every integer behind. Signs stack,
+     * so `- -732` is a subtraction of a negative and must come out positive.
+     */
     private fun fold(expression: String): Int {
         var total = 0
         for (term in TERM_REGEX.findAll(expression.replace(" ", "")).map(MatchResult::value)) {
@@ -175,5 +178,6 @@ object AllAnimeBundle {
     // 8 bytes of base64. Discriminating enough that only the true rotation produces four of them.
     private val SEED_REGEX = Regex("""[A-Za-z0-9+/]{11}=""")
 
-    private val TERM_REGEX = Regex("""[-+]?[^-+]+""")
+    // Leading signs are matched greedily, not one at a time: `fold` counts them to get the sign.
+    private val TERM_REGEX = Regex("""[-+]*[^-+]+""")
 }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeBundle.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeBundle.kt
@@ -1,14 +1,9 @@
 package eu.kanade.tachiyomi.animeextension.en.allanime
 
 /**
- * Recovers the two per-build crypto inputs — `buildId` and the four mask seeds — from mkissa's
- * obfuscated JS chunk.
- *
- * `buildId` is a plain literal. The seeds are not: each is two concatenated calls into a string
- * table, reached through alias functions that offset the index, and the table is rotated at load
- * time by an amount only the bundle's own checksum loop knows. Rather than emulate that loop,
- * [parse] resolves the lookup chain for every possible rotation and keeps the one whose results
- * all have the seed shape.
+ * Recovers `buildId` and the four mask seeds from the obfuscated JS chunk. The seeds are lookups
+ * into a string table rotated at load time by an amount only the bundle's checksum loop knows, so
+ * [parse] tries every rotation and keeps the one whose results all have the seed shape.
  */
 object AllAnimeBundle {
 
@@ -29,25 +24,20 @@ object AllAnimeBundle {
             m.groupValues[1] to Base(m.groupValues[4], fold(m.groupValues[3]))
         }
         val aliases = buildMap {
-            // A seed may call a base decoder directly rather than through an alias; treating each
-            // base as its own identity alias lets one lookup path handle both spellings.
+            // A seed may call a base decoder directly, so each base is its own identity alias.
             bases.keys.forEach { put(it, Alias(it, 0, 0)) }
             ALIAS_DECODER_REGEX.findAll(js).forEach { m ->
                 val (name, firstParam, _, callee, arg, delta) = m.destructured
                 if (callee !in bases) return@forEach
-                // The alias forwards exactly one of its two parameters; which one tells us where
-                // the real table index sits in the call. Deeper chains are not handled.
+                // Which parameter the alias forwards tells us where the table index sits.
                 put(name, Alias(callee, if (arg == firstParam) 0 else 1, if (delta.isEmpty()) 0 else fold(delta)))
             }
         }
 
-        // Normally there is exactly one such array, but scan every candidate so an unrelated
-        // lookalike earlier in the chunk cannot poison the parse.
         for (match in SEED_ARRAY_REGEX.findAll(js)) {
             val calls = CALL_REGEX.findAll(match.groupValues[1]).map(MatchResult::value).toList()
             if (calls.size != AllAnimeCrypto.SEED_COUNT * 2) continue
 
-            // Every decoder ultimately indexes the same table, so any of them bounds the search.
             val table = CALL_REGEX.find(calls.first())
                 ?.let { aliases[it.groupValues[1]] }
                 ?.let { tables[bases[it.base]?.table] }
@@ -56,8 +46,7 @@ object AllAnimeBundle {
             val matches = table.indices.mapNotNull { rotation ->
                 seedsAt(calls, rotation, tables, bases, aliases)
             }
-            // A wrong rotation matching the seed shape by chance is vanishingly unlikely, but
-            // would silently yield a bad mask — so require the answer to be unambiguous.
+            // A chance match would silently yield a bad mask, so require an unambiguous answer.
             matches.singleOrNull()?.let { return it }
         }
         return null
@@ -136,10 +125,7 @@ object AllAnimeBundle {
         return null
     }
 
-    /**
-     * Folds the `2935+-1459*2` arithmetic the obfuscator hides every integer behind. Signs stack,
-     * so `- -732` is a subtraction of a negative and must come out positive.
-     */
+    /** Folds the `2935+-1459*2` arithmetic every integer is hidden behind; signs stack. */
     private fun fold(expression: String): Int {
         var total = 0
         for (term in TERM_REGEX.findAll(expression.replace(" ", "")).map(MatchResult::value)) {
@@ -160,24 +146,18 @@ object AllAnimeBundle {
 
     private val TABLE_HEAD_REGEX = Regex("""function (\w+)\(\)\s*\{\s*(?:const|let|var)\s+\w+\s*=\s*\[""")
 
-    // Subtracts a constant from its argument and indexes the string table with the result.
     private val BASE_DECODER_REGEX = Regex("""function (\w+)\((\w+)(?:,\w+)*\)\{return \2=\2-\(?([-\d+*\s]+?)\)?,(\w+)\(\)\[\2\]\}""")
 
-    // Forwards one of its two parameters to a base decoder, optionally shifting it. Kept to
-    // exactly two parameters on purpose: the argIndex logic above only distinguishes first
-    // from second.
+    // Two parameters exactly: the argIndex logic only distinguishes first from second.
     private val ALIAS_DECODER_REGEX = Regex("""function (\w+)\((\w+),(\w+)\)\{return (\w+)\((\w+)((?:[-+][\d+*\s-]+)?)\)\}""")
 
     private const val CALL_PATTERN = """(\w+)\(\s*(-?\d+)\s*(?:,\s*(-?\d+)\s*)?\)"""
     private val CALL_REGEX = Regex(CALL_PATTERN)
 
-    // Four elements, each two concatenated lookups — the shape is what tells this array apart
-    // from every other array literal in the chunk.
     private val SEED_ARRAY_REGEX = Regex("""=\[((?:$CALL_PATTERN\+$CALL_PATTERN,){3}$CALL_PATTERN\+$CALL_PATTERN)]""")
 
-    // 8 bytes of base64. Discriminating enough that only the true rotation produces four of them.
     private val SEED_REGEX = Regex("""[A-Za-z0-9+/]{11}=""")
 
-    // Leading signs are matched greedily, not one at a time: `fold` counts them to get the sign.
+    // Leading signs matched greedily; `fold` counts them.
     private val TERM_REGEX = Regex("""[-+]*[^-+]+""")
 }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeCrypto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeCrypto.kt
@@ -10,11 +10,8 @@ import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
 /**
- * Stateless primitives for AllAnime's "aaReq" scheme (wire layout
- * `[0x01] + iv(12) + AES-GCM(ciphertext‖tag)`). Both the request token and the response payload
- * are keyed with `clientMask XOR partB`; the mask itself is folded out of the JS build's
- * `buildId` and four base64 seeds ([deriveMask]), and `partB` comes from the crypto bootstrap
- * endpoint, which is in turn gated by an HMAC token ([bootToken]).
+ * Stateless primitives for the "aaReq" scheme, wire layout `[0x01] + iv(12) + AES-GCM(ct‖tag)`.
+ * Request token and response payload are both keyed with `clientMask XOR partB`.
  */
 object AllAnimeCrypto {
 
@@ -30,21 +27,16 @@ object AllAnimeCrypto {
     const val SEED_COUNT = 4
     private const val SEED_SIZE = KEY_SIZE / SEED_COUNT
 
-    // Wire layout: [version(1)] + iv(12) + ciphertext‖tag.
     private const val IV_SIZE = 12
     private const val HEADER_SIZE = 1 + IV_SIZE
 
-    // aaReq time bucket: the token is valid for its rounded-down 5-minute window.
     private const val WINDOW_MS = 5 * 60 * 1000L
 
-    // The server derives partB from a 3-day epoch and keeps the previous one alive for a day.
+    // The server derives partB from a 3-day epoch and keeps the previous alive for a day.
     private const val EPOCH_WINDOW_MS = 3 * 24 * 60 * 60 * 1000L
     private const val EPOCH_GRACE_MS = 24 * 60 * 60 * 1000L
 
-    /**
-     * The 32-byte client mask, obfuscated in the bundle as `seeds XOR f(buildId) XOR f(position)`.
-     * Both inputs change on every site rebuild, so they are scraped rather than baked in.
-     */
+    /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild. */
     fun deriveMask(buildId: String, seeds: List<String>): ByteArray? {
         if (buildId.isEmpty() || seeds.size != SEED_COUNT) return null
 
@@ -76,7 +68,7 @@ object AllAnimeCrypto {
         return SecretKeySpec(keyBytes, KEY_TYPE)
     }
 
-    /** `x-aa-boot`, the token the bootstrap endpoint checks before handing out `partB`. */
+    /** `x-aa-boot`, checked by the bootstrap endpoint before it hands out `partB`. */
     fun bootToken(
         mask: ByteArray,
         buildId: String,
@@ -94,22 +86,14 @@ object AllAnimeCrypto {
         return hmac(inner, message).toHex()
     }
 
-    /**
-     * Ordered oldest first, because during the grace window the *previous* epoch is the one the
-     * server is still minting `partB` for; the new one only goes live once the grace expires.
-     * Only the server knows which side of that boundary it is on, so both are tried in turn.
-     */
+    /** Oldest first: during the grace window the server still mints `partB` for the previous. */
     fun epochCandidates(now: Long = System.currentTimeMillis()): List<Long> {
         val current = now / EPOCH_WINDOW_MS
         val inGrace = now - current * EPOCH_WINDOW_MS < EPOCH_GRACE_MS && current > 0
         return if (inGrace) listOf(current - 1, current) else listOf(current)
     }
 
-    /**
-     * Neighbouring epochs to fall back on once every normal candidate is rejected. The epoch is
-     * derived from the device clock, so a clock off by more than the grace window would otherwise
-     * fail permanently with an error pointing at the bundle parser instead.
-     */
+    /** Fallback for a device clock off by more than the grace window. */
     fun skewedEpochCandidates(now: Long = System.currentTimeMillis()): List<Long> {
         val current = now / EPOCH_WINDOW_MS
         return listOf(current + 1, current - 1).filter { it > 0 } - epochCandidates(now).toSet()
@@ -118,8 +102,7 @@ object AllAnimeCrypto {
     fun buildAaReq(key: SecretKeySpec, epoch: Long, buildId: String, queryHash: String, lane: String): String {
         val ts = System.currentTimeMillis() / WINDOW_MS * WINDOW_MS
 
-        // Deriving the IV rather than randomising it is required: the server recomputes the same
-        // one to decrypt. Reuse is inert because the plaintext is fixed within a `ts` bucket.
+        // Derived, not random: the server recomputes the same one to decrypt.
         val iv = MessageDigest.getInstance(HASH_ALGO)
             .digest("$epoch:$buildId:$queryHash:$ts:$lane".toByteArray(Charsets.UTF_8))
             .copyOfRange(0, IV_SIZE)
@@ -146,7 +129,6 @@ object AllAnimeCrypto {
         val iv = blob.sliceArray(1 until HEADER_SIZE)
         val encryptedData = blob.sliceArray(HEADER_SIZE until blob.size)
 
-        // The GCM tag guarantees only the correct key yields output, so trying both is safe.
         for (key in listOf(materialKey, legacyKey(version))) {
             runCatching {
                 val cipher = Cipher.getInstance(CIPHER_ALGO)

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeCrypto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeCrypto.kt
@@ -1,67 +1,153 @@
 package eu.kanade.tachiyomi.animeextension.en.allanime
 
 import android.util.Base64
+import keiyoushi.utils.toHex
 import keiyoushi.utils.toJsonString
 import java.security.MessageDigest
 import javax.crypto.Cipher
+import javax.crypto.Mac
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
 /**
- * Stateless AES-GCM primitives for AllAnime's "aaReq" scheme (wire layout
- * `[0x01] + iv(12) + AES-GCM(ciphertext‖tag)`). Request token keyed with `clientMask XOR partB`;
- * response payload with the legacy static key, falling back to the mask key.
+ * Stateless primitives for AllAnime's "aaReq" scheme (wire layout
+ * `[0x01] + iv(12) + AES-GCM(ciphertext‖tag)`). Both the request token and the response payload
+ * are keyed with `clientMask XOR partB`; the mask itself is folded out of the JS build's
+ * `buildId` and four base64 seeds ([deriveMask]), and `partB` comes from the crypto bootstrap
+ * endpoint, which is in turn gated by an HMAC token ([bootToken]).
  */
 object AllAnimeCrypto {
 
     private const val TAG_LENGTH = 128
     private const val HASH_ALGO = "SHA-256"
+    private const val HMAC_ALGO = "HmacSHA256"
     private const val KEY_TYPE = "AES"
     private const val CIPHER_ALGO = "AES/GCM/NoPadding"
 
     private const val LEGACY_SECRET = "Xot36i3lK3"
 
+    private const val KEY_SIZE = 32
+    const val SEED_COUNT = 4
+    private const val SEED_SIZE = KEY_SIZE / SEED_COUNT
+
+    // Wire layout: [version(1)] + iv(12) + ciphertext‖tag.
+    private const val IV_SIZE = 12
+    private const val HEADER_SIZE = 1 + IV_SIZE
+
     // aaReq time bucket: the token is valid for its rounded-down 5-minute window.
     private const val WINDOW_MS = 5 * 60 * 1000L
 
+    // The server derives partB from a 3-day epoch and keeps the previous one alive for a day.
+    private const val EPOCH_WINDOW_MS = 3 * 24 * 60 * 60 * 1000L
+    private const val EPOCH_GRACE_MS = 24 * 60 * 60 * 1000L
+
+    /**
+     * The 32-byte client mask, obfuscated in the bundle as `seeds XOR f(buildId) XOR f(position)`.
+     * Both inputs change on every site rebuild, so they are scraped rather than baked in.
+     */
+    fun deriveMask(buildId: String, seeds: List<String>): ByteArray? {
+        if (buildId.isEmpty() || seeds.size != SEED_COUNT) return null
+
+        val stream = ByteArray(KEY_SIZE) { i ->
+            (buildId[i % buildId.length].code xor ((i * 17 + 31) and 0xFF)).toByte()
+        }
+
+        val mask = ByteArray(KEY_SIZE)
+        seeds.forEachIndexed { index, seed ->
+            val bytes = runCatching { Base64.decode(seed, Base64.DEFAULT) }.getOrNull() ?: return null
+            if (bytes.size < SEED_SIZE) return null
+
+            val base = index * SEED_SIZE
+            for (offset in 0 until SEED_SIZE) {
+                mask[base + offset] = (
+                    (bytes[offset].toInt() and 0xFF) xor
+                        (stream[base + offset].toInt() and 0xFF) xor
+                        ((index * 41 + offset * 7) and 0xFF)
+                    ).toByte()
+            }
+        }
+        return mask
+    }
+
     fun deriveKey(mask: ByteArray, partB: ByteArray): SecretKeySpec {
-        val keyBytes = ByteArray(32) { i ->
+        val keyBytes = ByteArray(KEY_SIZE) { i ->
             ((partB[i].toInt() and 0xFF) xor (mask[i % mask.size].toInt() and 0xFF)).toByte()
         }
         return SecretKeySpec(keyBytes, KEY_TYPE)
     }
 
-    fun buildAaReq(key: SecretKeySpec, epoch: Long, buildId: String, queryHash: String): String {
+    /** `x-aa-boot`, the token the bootstrap endpoint checks before handing out `partB`. */
+    fun bootToken(
+        mask: ByteArray,
+        buildId: String,
+        epoch: Long,
+        keyGroup: String,
+        refererHost: String,
+        lane: String,
+    ): String {
+        val inner = hmac(mask, "aa-boot:$buildId")
+        val message = buildString {
+            append(buildId).append(':').append(keyGroup).append(':')
+            append(refererHost).append(':').append(epoch)
+            if (lane.isNotEmpty()) append(':').append(lane)
+        }
+        return hmac(inner, message).toHex()
+    }
+
+    /**
+     * Ordered oldest first, because during the grace window the *previous* epoch is the one the
+     * server is still minting `partB` for; the new one only goes live once the grace expires.
+     * Only the server knows which side of that boundary it is on, so both are tried in turn.
+     */
+    fun epochCandidates(now: Long = System.currentTimeMillis()): List<Long> {
+        val current = now / EPOCH_WINDOW_MS
+        val inGrace = now - current * EPOCH_WINDOW_MS < EPOCH_GRACE_MS && current > 0
+        return if (inGrace) listOf(current - 1, current) else listOf(current)
+    }
+
+    /**
+     * Neighbouring epochs to fall back on once every normal candidate is rejected. The epoch is
+     * derived from the device clock, so a clock off by more than the grace window would otherwise
+     * fail permanently with an error pointing at the bundle parser instead.
+     */
+    fun skewedEpochCandidates(now: Long = System.currentTimeMillis()): List<Long> {
+        val current = now / EPOCH_WINDOW_MS
+        return listOf(current + 1, current - 1).filter { it > 0 } - epochCandidates(now).toSet()
+    }
+
+    fun buildAaReq(key: SecretKeySpec, epoch: Long, buildId: String, queryHash: String, lane: String): String {
         val ts = System.currentTimeMillis() / WINDOW_MS * WINDOW_MS
 
+        // Deriving the IV rather than randomising it is required: the server recomputes the same
+        // one to decrypt. Reuse is inert because the plaintext is fixed within a `ts` bucket.
         val iv = MessageDigest.getInstance(HASH_ALGO)
-            .digest("$epoch:$buildId:$queryHash:$ts".toByteArray(Charsets.UTF_8))
-            .copyOfRange(0, 12)
+            .digest("$epoch:$buildId:$queryHash:$ts:$lane".toByteArray(Charsets.UTF_8))
+            .copyOfRange(0, IV_SIZE)
 
-        val payload = AaReqPayload(v = 1, ts = ts, epoch = epoch, buildId = buildId, qh = queryHash).toJsonString()
+        val payload = AaReqPayload(v = 1, ts = ts, epoch = epoch, buildId = buildId, qh = queryHash, k = lane).toJsonString()
 
         val cipher = Cipher.getInstance(CIPHER_ALGO)
         cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH, iv))
         val ciphertext = cipher.doFinal(payload.toByteArray(Charsets.UTF_8))
 
-        val blob = ByteArray(13 + ciphertext.size)
+        val blob = ByteArray(HEADER_SIZE + ciphertext.size)
         blob[0] = 1
-        System.arraycopy(iv, 0, blob, 1, 12)
-        System.arraycopy(ciphertext, 0, blob, 13, ciphertext.size)
+        System.arraycopy(iv, 0, blob, 1, IV_SIZE)
+        System.arraycopy(ciphertext, 0, blob, HEADER_SIZE, ciphertext.size)
 
         return Base64.encodeToString(blob, Base64.NO_WRAP)
     }
 
     fun decrypt(base64Payload: String, materialKey: SecretKeySpec): String? {
         val blob = runCatching { Base64.decode(base64Payload, Base64.DEFAULT) }.getOrNull() ?: return null
-        if (blob.size < 13) return null
+        if (blob.size < HEADER_SIZE) return null
 
         val version = blob[0].toInt() and 0xFF
-        val iv = blob.sliceArray(1 until 13)
-        val encryptedData = blob.sliceArray(13 until blob.size)
+        val iv = blob.sliceArray(1 until HEADER_SIZE)
+        val encryptedData = blob.sliceArray(HEADER_SIZE until blob.size)
 
         // The GCM tag guarantees only the correct key yields output, so trying both is safe.
-        for (key in listOf(legacyKey(version), materialKey)) {
+        for (key in listOf(materialKey, legacyKey(version))) {
             runCatching {
                 val cipher = Cipher.getInstance(CIPHER_ALGO)
                 cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH, iv))
@@ -71,14 +157,14 @@ object AllAnimeCrypto {
         return null
     }
 
+    private fun hmac(key: ByteArray, message: String): ByteArray = Mac.getInstance(HMAC_ALGO).run {
+        init(SecretKeySpec(key, HMAC_ALGO))
+        doFinal(message.toByteArray(Charsets.UTF_8))
+    }
+
     private fun legacyKey(version: Int): SecretKeySpec {
         val bytes = MessageDigest.getInstance(HASH_ALGO)
             .digest("$LEGACY_SECRET:v$version".toByteArray(Charsets.UTF_8))
         return SecretKeySpec(bytes, KEY_TYPE)
     }
-
-    fun hexToBytesOrNull(hex: String): ByteArray? = runCatching {
-        require(hex.isNotEmpty() && hex.length % 2 == 0)
-        ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
-    }.getOrNull()
 }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeDto.kt
@@ -166,10 +166,13 @@ class AaApiError(
     }
 }
 
+// Response of `/client-crypto/v1/bootstrap`. `k` echoes back the content lane the partB is
+// scoped to; a mismatch means the server answered for a different lane than we asked for.
 @Serializable
 class AaCryptoBootstrap(
     val epoch: Long,
     val partB: String,
+    val k: String? = null,
 )
 
 @Serializable
@@ -179,6 +182,7 @@ class AaReqPayload(
     private val epoch: Long,
     private val buildId: String,
     private val qh: String,
+    private val k: String,
 )
 
 @Serializable

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeKeyManager.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeKeyManager.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.animeextension.en.allanime
 import android.content.SharedPreferences
 import android.util.Base64
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.bodyString
 import keiyoushi.utils.delegate
@@ -10,24 +11,30 @@ import keiyoushi.utils.parseAs
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import javax.crypto.spec.SecretKeySpec
 
 /**
- * Owns the "aaReq" key material: fetches partB + epoch from the mkissa page's `window.__aaCrypto`
- * and derives the AES-GCM key with the client mask, cached until the epoch rotates. The mask is
- * extracted from the live JS bundle ([resolveMask]) and re-extracted when it rotates.
+ * Owns the "aaReq" key material.
+ *
+ * The build's `buildId` and mask seeds are scraped from the live JS bundle ([resolveBuild]) and
+ * cached in preferences; together they fold into the 32-byte client mask. That mask signs the
+ * `x-aa-boot` token for the crypto bootstrap endpoint, which returns the per-epoch `partB`; the
+ * AES-GCM key is `mask XOR partB`.
  */
 class AllAnimeKeyManager(
     private val client: OkHttpClient,
     private val headers: Headers,
     preferences: SharedPreferences,
     private val siteUrl: String,
+    private val apiUrl: String,
 ) {
 
     class Material(
         val key: SecretKeySpec,
         val epoch: Long,
+        val buildId: String,
         val expiresAt: Long,
         val fetchedAt: Long,
     )
@@ -36,11 +43,9 @@ class AllAnimeKeyManager(
     private var cachedMaterial: Material? = null
     private val materialMutex = Mutex()
 
-    @Volatile
-    private var appEntryUrl: String? = null
-
-    private var storedMaskHex by preferences.delegate(PREF_MASK_KEY, "")
-    private val maskMutex = Mutex()
+    // Both halves live in one preference so a concurrent write can never pair one build's id
+    // with another's seeds.
+    private var storedBuild by preferences.delegate(PREF_BUILD_KEY, "")
 
     suspend fun material(forceRefresh: Boolean = false): Material {
         val enteredAt = System.currentTimeMillis()
@@ -54,32 +59,31 @@ class AllAnimeKeyManager(
                 if (it.fetchedAt > enteredAt || (!forceRefresh && !it.isExpired())) return@withLock it
             }
 
-            val html = client.newCall(GET("$siteUrl/", headers))
-                .awaitSuccess().bodyString()
+            val handshake = handshake() ?: throw Exception(MATERIAL_ERROR)
 
-            APP_ENTRY_REGEX.find(html)?.groupValues?.get(1)?.let { appEntryUrl = it }
+            val partB = runCatching { Base64.decode(handshake.bootstrap.partB, Base64.DEFAULT) }
+                .getOrElse { throw Exception(MATERIAL_ERROR) }
+            require(partB.size >= 32) { MATERIAL_ERROR }
 
-            val json = AA_CRYPTO_REGEX.find(html)?.groupValues?.get(1)
-                ?: throw Exception("Unable to obtain AllAnime crypto material")
+            // Persisted only now that the server has accepted this build, so a bad parse cannot
+            // overwrite a working one and wedge every later launch.
+            storedBuild = handshake.build.serialize()
 
-            val bootstrap = json.parseAs<AaCryptoBootstrap>()
-            val partB = runCatching { Base64.decode(bootstrap.partB, Base64.DEFAULT) }
-                .getOrElse { throw Exception("AllAnime crypto material changed; update the extension") }
-            require(partB.size >= 32) { "AllAnime crypto material changed; update the extension" }
-
-            // Fixed TTL, not the bootstrap's switchAt: that can already be in the past while the
-            // epoch is live, which would refetch the slow mkissa page every playback.
+            // Fixed TTL rather than the bootstrap's switchAt: that boundary can already be in the
+            // past while the epoch is live, which would refetch on every playback. Real rotations
+            // are caught by the AA_CRYPTO_STALE retry, so this is a performance knob only.
             val now = System.currentTimeMillis()
             Material(
-                key = AllAnimeCrypto.deriveKey(mask(), partB),
-                epoch = bootstrap.epoch,
+                key = AllAnimeCrypto.deriveKey(handshake.mask, partB),
+                epoch = handshake.bootstrap.epoch,
+                buildId = handshake.build.buildId,
                 expiresAt = now + MATERIAL_TTL_MS,
                 fetchedAt = now,
             ).also { cachedMaterial = it }
         }
     }
 
-    fun aaReq(material: Material): String = AllAnimeCrypto.buildAaReq(material.key, material.epoch, CLIENT_BUILD_ID, STREAM_HASH)
+    fun aaReq(material: Material): String = AllAnimeCrypto.buildAaReq(material.key, material.epoch, material.buildId, STREAM_HASH, ANIME_LANE)
 
     fun decrypt(tobeparsed: String, material: Material): String? = AllAnimeCrypto.decrypt(tobeparsed, material.key)
 
@@ -87,76 +91,182 @@ class AllAnimeKeyManager(
         cachedMaterial = null
     }
 
+    /**
+     * Drops the cached build so the next [material] call re-scrapes the bundle. Used when the
+     * streams API rejects a token the bootstrap was happy to mint, which the bootstrap alone
+     * cannot detect. Clearing a flag rather than crawling here keeps parallel episode fetches
+     * from each kicking off their own crawl.
+     */
+    fun invalidateBuild() {
+        storedBuild = ""
+        cachedMaterial = null
+    }
+
     fun isCryptoError(body: String): Boolean = runCatching { body.parseAs<AaApiError>().errors }.getOrNull()
         ?.any { it.extensions?.code?.startsWith("AA_CRYPTO") == true } == true
 
-    suspend fun healMask(): Boolean = resolveMask() != null
-
-    private suspend fun mask(): ByteArray = storedMaskHex.takeIf { it.length == MASK_HEX_LENGTH }?.let(AllAnimeCrypto::hexToBytesOrNull)
-        ?: resolveMask()
-        ?: throw Exception("Unable to obtain AllAnime crypto material")
+    private class Handshake(
+        val build: AllAnimeBundle.BuildInfo,
+        val mask: ByteArray,
+        val bootstrap: AaCryptoBootstrap,
+    )
 
     /**
-     * Crawls the app's chunks for the crypto chunk and reads its mask, skipping the value
-     * we already have (so it doubles as rotation detection). Persists and returns the new
-     * mask bytes, or null if none different was found.
+     * A null [bootstrap] with [stale] set means the server refused this build (403 wrong mask,
+     * 404 unknown id) and re-scraping is worth it; without it the failure was a network fault or
+     * an unparseable body, which says nothing about whether the build is current.
      */
-    private suspend fun resolveMask(): ByteArray? = maskMutex.withLock {
-        val appUrl = appEntryUrl ?: return@withLock null
-        val chunkBase = appUrl.substringBeforeLast("/entry/", "") + "/chunks/"
-        if (!chunkBase.startsWith("http")) return@withLock null
+    private class BootstrapResult(
+        val bootstrap: AaCryptoBootstrap?,
+        val stale: Boolean,
+    )
+
+    /**
+     * Exchanges a build for `partB`, escalating only as far as each failure justifies. The epoch
+     * retry costs one or two plain API calls, whereas re-scraping starts with the Cloudflare-gated
+     * site HTML, which can mean a WebView challenge — so it is worth ruling out a skewed clock
+     * first even though the request counts are comparable.
+     */
+    private suspend fun handshake(): Handshake? {
+        val cached = cachedBuild()
+        val mask = cached?.let { AllAnimeCrypto.deriveMask(it.buildId, it.seeds) }
+
+        if (cached != null && mask != null) {
+            val first = bootstrap(cached.buildId, mask, AllAnimeCrypto.epochCandidates())
+            first.bootstrap?.let { return Handshake(cached, mask, it) }
+            // Nothing about a timeout implies the build rotated; let the caller's retry loop run.
+            if (!first.stale) return null
+
+            // A device clock off by more than the grace window looks exactly like a stale build.
+            bootstrap(cached.buildId, mask, AllAnimeCrypto.skewedEpochCandidates()).bootstrap
+                ?.let { return Handshake(cached, mask, it) }
+        }
+
+        val fresh = resolveBuild() ?: return null
+        val freshMask = AllAnimeCrypto.deriveMask(fresh.buildId, fresh.seeds) ?: return null
+        return bootstrap(fresh.buildId, freshMask, AllAnimeCrypto.epochCandidates())
+            .bootstrap?.let { Handshake(fresh, freshMask, it) }
+    }
+
+    /** `GET /client-crypto/v1/bootstrap?buildId=&k=`, gated by an HMAC of the client mask. */
+    private suspend fun bootstrap(buildId: String, mask: ByteArray, epochs: List<Long>): BootstrapResult {
+        val host = siteUrl.toHttpUrl().host
+        val url = "${apiUrl.trimEnd('/')}$BOOTSTRAP_PATH".toHttpUrl().newBuilder()
+            .addQueryParameter("buildId", buildId)
+            .addQueryParameter("k", ANIME_LANE)
+            .build()
+
+        var sawStale = false
+        for (epoch in epochs) {
+            val requestHeaders = headers.newBuilder()
+                .set("x-build-id", buildId)
+                .set("x-aa-boot", AllAnimeCrypto.bootToken(mask, buildId, epoch, KEY_GROUP, host, ANIME_LANE))
+                .set("Origin", siteUrl)
+                .set("Referer", "$siteUrl/")
+                .build()
+
+            val response = runCatching { client.newCall(GET(url, requestHeaders)).await() }.getOrNull()
+                ?: return BootstrapResult(null, stale = false)
+
+            if (!response.isSuccessful) {
+                response.close()
+                if (response.code in STALE_CODES) sawStale = true
+                continue
+            }
+
+            val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
+                ?: return BootstrapResult(null, stale = false)
+
+            // A partB minted for another lane would silently derive the wrong key.
+            if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
+
+            return BootstrapResult(bootstrap, stale = false)
+        }
+        return BootstrapResult(null, stale = sawStale)
+    }
+
+    private fun cachedBuild(): AllAnimeBundle.BuildInfo? {
+        val buildId = storedBuild.substringBefore(FIELD_SEPARATOR, "").takeIf(String::isNotEmpty) ?: return null
+        val seeds = storedBuild.substringAfter(FIELD_SEPARATOR, "").split(",").filter(String::isNotBlank)
+        if (seeds.size != AllAnimeCrypto.SEED_COUNT) return null
+        return AllAnimeBundle.BuildInfo(buildId, seeds)
+    }
+
+    /**
+     * Crawls the app's chunks for the crypto chunk and parses `buildId` + mask seeds out of it.
+     * The app entry is always re-read from the site: chunk URLs are content-hashed and immutable,
+     * so a rebuild is only ever visible in the HTML.
+     */
+    private suspend fun resolveBuild(): AllAnimeBundle.BuildInfo? {
+        val appUrl = entryUrlFromSite()?.toHttpUrl() ?: return null
 
         val appJs = runCatching {
             client.newCall(GET(appUrl, headers)).awaitSuccess().bodyString()
-        }.getOrNull() ?: return@withLock null
+        }.getOrNull() ?: return null
 
-        val chunkNames = CHUNK_REF_REGEX.findAll(appJs)
+        // The ref pattern deliberately matches every relative import, not just `../chunks/`, so a
+        // change to the bundle layout cannot hide the crypto chunk. Shared chunks still go first,
+        // since that is where it has always lived and the cap has to fall somewhere.
+        val chunkRefs = CHUNK_REF_REGEX.findAll(appJs)
             .map { it.groupValues[1] }
             .distinct()
-            .take(MAX_MASK_CHUNKS)
+            .sortedByDescending { it.contains("/chunks/") }
+            .take(MAX_BUILD_CHUNKS)
 
-        for (name in chunkNames) {
+        for (ref in chunkRefs) {
+            val chunkUrl = appUrl.resolve(ref) ?: continue
             val body = runCatching {
-                client.newCall(GET(chunkBase + name, headers)).awaitSuccess().bodyString()
+                client.newCall(GET(chunkUrl, headers)).awaitSuccess().bodyString()
             }.getOrNull() ?: continue
 
             if (!body.contains(CRYPTO_CHUNK_MARKER)) continue
 
-            val hex = HEX64_REGEX.findAll(body)
-                .map { it.value }
-                .firstOrNull { !it.equals(STREAM_HASH, ignoreCase = true) && !it.equals(storedMaskHex, ignoreCase = true) }
-                ?: continue
-
-            val bytes = AllAnimeCrypto.hexToBytesOrNull(hex) ?: continue
-            storedMaskHex = hex
-            return@withLock bytes
+            AllAnimeBundle.parse(body)?.let { return it }
         }
-        null
+        return null
+    }
+
+    /** The mkissa page is Cloudflare-gated; it is only needed to locate the CDN app entry. */
+    private suspend fun entryUrlFromSite(): String? {
+        val html = runCatching {
+            client.newCall(GET("$siteUrl/", headers)).awaitSuccess().bodyString()
+        }.getOrNull() ?: return null
+
+        return APP_ENTRY_REGEX.find(html)?.groupValues?.get(1)
     }
 
     private fun Material.isExpired(): Boolean = System.currentTimeMillis() >= expiresAt
 
-    companion object {
-        // Cosmetic: the server derives its key from the epoch and never validates this.
-        private const val CLIENT_BUILD_ID = "12"
+    private fun AllAnimeBundle.BuildInfo.serialize(): String = "$buildId$FIELD_SEPARATOR${seeds.joinToString(",")}"
 
-        private const val PREF_MASK_KEY = "client_mask_cache"
-        private const val MAX_MASK_CHUNKS = 40
-        private const val MASK_HEX_LENGTH = 64
+    companion object {
+        private const val MATERIAL_ERROR = "Unable to obtain AllAnime crypto material"
+
+        private const val BOOTSTRAP_PATH = "/client-crypto/v1/bootstrap"
+
+        // 403 invalid_boot_token (mask no longer matches), 404 unknown_build_id (build aged out of
+        // the server's rolling window). Anything else is not evidence that our build is wrong.
+        private val STALE_CODES = setOf(403, 404)
+
+        // The site buckets its hosts; mkissa.to (and anything unrecognised) maps to "mkissa".
+        // Adding a mirror to the site-domain ListPreference means revisiting this.
+        private const val KEY_GROUP = "mkissa"
+
+        private const val PREF_BUILD_KEY = "client_build_cache"
+        private const val FIELD_SEPARATOR = "|"
+
+        // Bounds the worst-case cost of a re-scrape; the crypto chunk is normally the first ref.
+        private const val MAX_BUILD_CHUNKS = 40
 
         private const val MATERIAL_TTL_MS = 6 * 60 * 60 * 1000L
-
-        private val AA_CRYPTO_REGEX = Regex("""window\.__aaCrypto\s*=\s*(\{[^{}]*\})""")
 
         // SvelteKit app entry `import("…/entry/app.<hash>.js")` inside the mkissa HTML.
         private val APP_ENTRY_REGEX = Regex("""import\("([^"]*/entry/app\.[^"]*\.js)"\)""")
 
-        // Chunk references inside the app entry's `__vite__mapDeps` array.
-        private val CHUNK_REF_REGEX = Regex("""\.\./chunks/([A-Za-z0-9_-]+\.js)""")
+        // Relative chunk references inside the app entry's `__vite__mapDeps` array, resolved
+        // against the entry URL so a change to the bundle's directory layout does not matter.
+        private val CHUNK_REF_REGEX = Regex("""["'](\.\.?/[\w./-]+\.js)["']""")
 
         private const val CRYPTO_CHUNK_MARKER = "aaReq"
-
-        // Boundaries stop a 64-hex slice of a longer hash (e.g. sha512) from matching.
-        private val HEX64_REGEX = Regex("""(?<![0-9a-fA-F])[0-9a-fA-F]{64}(?![0-9a-fA-F])""")
     }
 }

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeKeyManager.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeKeyManager.kt
@@ -16,12 +16,9 @@ import okhttp3.OkHttpClient
 import javax.crypto.spec.SecretKeySpec
 
 /**
- * Owns the "aaReq" key material.
- *
- * The build's `buildId` and mask seeds are scraped from the live JS bundle ([resolveBuild]) and
- * cached in preferences; together they fold into the 32-byte client mask. That mask signs the
- * `x-aa-boot` token for the crypto bootstrap endpoint, which returns the per-epoch `partB`; the
- * AES-GCM key is `mask XOR partB`.
+ * Owns the "aaReq" key material: `buildId` + mask seeds are scraped from the live JS bundle and
+ * fold into the client mask, which signs the bootstrap request for `partB`; the key is
+ * `mask XOR partB`.
  */
 class AllAnimeKeyManager(
     private val client: OkHttpClient,
@@ -43,8 +40,7 @@ class AllAnimeKeyManager(
     private var cachedMaterial: Material? = null
     private val materialMutex = Mutex()
 
-    // Both halves live in one preference so a concurrent write can never pair one build's id
-    // with another's seeds.
+    // One preference, so a concurrent write cannot pair one build's id with another's seeds.
     private var storedBuild by preferences.delegate(PREF_BUILD_KEY, "")
 
     suspend fun material(forceRefresh: Boolean = false): Material {
@@ -54,7 +50,6 @@ class AllAnimeKeyManager(
         }
 
         return materialMutex.withLock {
-            // Reuse if another coroutine refreshed while we waited on the lock.
             cachedMaterial?.let {
                 if (it.fetchedAt > enteredAt || (!forceRefresh && !it.isExpired())) return@withLock it
             }
@@ -65,13 +60,10 @@ class AllAnimeKeyManager(
                 .getOrElse { throw Exception(MATERIAL_ERROR) }
             require(partB.size >= 32) { MATERIAL_ERROR }
 
-            // Persisted only now that the server has accepted this build, so a bad parse cannot
-            // overwrite a working one and wedge every later launch.
+            // Only after the server accepted it, so a bad parse cannot wedge every later launch.
             storedBuild = handshake.build.serialize()
 
-            // Fixed TTL rather than the bootstrap's switchAt: that boundary can already be in the
-            // past while the epoch is live, which would refetch on every playback. Real rotations
-            // are caught by the AA_CRYPTO_STALE retry, so this is a performance knob only.
+            // Not the bootstrap's switchAt: it can already be past while the epoch is live.
             val now = System.currentTimeMillis()
             Material(
                 key = AllAnimeCrypto.deriveKey(handshake.mask, partB),
@@ -91,12 +83,7 @@ class AllAnimeKeyManager(
         cachedMaterial = null
     }
 
-    /**
-     * Drops the cached build so the next [material] call re-scrapes the bundle. Used when the
-     * streams API rejects a token the bootstrap was happy to mint, which the bootstrap alone
-     * cannot detect. Clearing a flag rather than crawling here keeps parallel episode fetches
-     * from each kicking off their own crawl.
-     */
+    /** Used when the streams API rejects a token the bootstrap minted, which it cannot detect. */
     fun invalidateBuild() {
         storedBuild = ""
         cachedMaterial = null
@@ -111,22 +98,13 @@ class AllAnimeKeyManager(
         val bootstrap: AaCryptoBootstrap,
     )
 
-    /**
-     * A null [bootstrap] with [stale] set means the server refused this build (403 wrong mask,
-     * 404 unknown id) and re-scraping is worth it; without it the failure was a network fault or
-     * an unparseable body, which says nothing about whether the build is current.
-     */
+    /** [stale] distinguishes "server refused this build" from a network fault. */
     private class BootstrapResult(
         val bootstrap: AaCryptoBootstrap?,
         val stale: Boolean,
     )
 
-    /**
-     * Exchanges a build for `partB`, escalating only as far as each failure justifies. The epoch
-     * retry costs one or two plain API calls, whereas re-scraping starts with the Cloudflare-gated
-     * site HTML, which can mean a WebView challenge — so it is worth ruling out a skewed clock
-     * first even though the request counts are comparable.
-     */
+    /** Re-scraping starts at the Cloudflare-gated HTML, so cheaper causes are ruled out first. */
     private suspend fun handshake(): Handshake? {
         val cached = cachedBuild()
         val mask = cached?.let { AllAnimeCrypto.deriveMask(it.buildId, it.seeds) }
@@ -134,10 +112,9 @@ class AllAnimeKeyManager(
         if (cached != null && mask != null) {
             val first = bootstrap(cached.buildId, mask, AllAnimeCrypto.epochCandidates())
             first.bootstrap?.let { return Handshake(cached, mask, it) }
-            // Nothing about a timeout implies the build rotated; let the caller's retry loop run.
             if (!first.stale) return null
 
-            // A device clock off by more than the grace window looks exactly like a stale build.
+            // A clock off by more than the grace window looks exactly like a stale build.
             bootstrap(cached.buildId, mask, AllAnimeCrypto.skewedEpochCandidates()).bootstrap
                 ?.let { return Handshake(cached, mask, it) }
         }
@@ -177,7 +154,7 @@ class AllAnimeKeyManager(
             val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
                 ?: return BootstrapResult(null, stale = false)
 
-            // A partB minted for another lane would silently derive the wrong key.
+            // A partB from another lane would silently derive the wrong key.
             if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
 
             return BootstrapResult(bootstrap, stale = false)
@@ -192,11 +169,7 @@ class AllAnimeKeyManager(
         return AllAnimeBundle.BuildInfo(buildId, seeds)
     }
 
-    /**
-     * Crawls the app's chunks for the crypto chunk and parses `buildId` + mask seeds out of it.
-     * The app entry is always re-read from the site: chunk URLs are content-hashed and immutable,
-     * so a rebuild is only ever visible in the HTML.
-     */
+    /** The entry is re-read every time: chunk URLs are immutable, so a rebuild only shows in HTML. */
     private suspend fun resolveBuild(): AllAnimeBundle.BuildInfo? {
         val appUrl = entryUrlFromSite()?.toHttpUrl() ?: return null
 
@@ -204,9 +177,7 @@ class AllAnimeKeyManager(
             client.newCall(GET(appUrl, headers)).awaitSuccess().bodyString()
         }.getOrNull() ?: return null
 
-        // The ref pattern deliberately matches every relative import, not just `../chunks/`, so a
-        // change to the bundle layout cannot hide the crypto chunk. Shared chunks still go first,
-        // since that is where it has always lived and the cap has to fall somewhere.
+        // Shared chunks first: that is where it has always lived.
         val chunkRefs = CHUNK_REF_REGEX.findAll(appJs)
             .map { it.groupValues[1] }
             .distinct()
@@ -226,7 +197,7 @@ class AllAnimeKeyManager(
         return null
     }
 
-    /** The mkissa page is Cloudflare-gated; it is only needed to locate the CDN app entry. */
+    /** Cloudflare-gated; only needed to locate the CDN app entry. */
     private suspend fun entryUrlFromSite(): String? {
         val html = runCatching {
             client.newCall(GET("$siteUrl/", headers)).awaitSuccess().bodyString()
@@ -244,27 +215,21 @@ class AllAnimeKeyManager(
 
         private const val BOOTSTRAP_PATH = "/client-crypto/v1/bootstrap"
 
-        // 403 invalid_boot_token (mask no longer matches), 404 unknown_build_id (build aged out of
-        // the server's rolling window). Anything else is not evidence that our build is wrong.
+        // 403 invalid_boot_token, 404 unknown_build_id.
         private val STALE_CODES = setOf(403, 404)
 
-        // The site buckets its hosts; mkissa.to (and anything unrecognised) maps to "mkissa".
-        // Adding a mirror to the site-domain ListPreference means revisiting this.
+        // The site buckets its hosts; adding a mirror to the domain pref means revisiting this.
         private const val KEY_GROUP = "mkissa"
 
         private const val PREF_BUILD_KEY = "client_build_cache"
         private const val FIELD_SEPARATOR = "|"
 
-        // Bounds the worst-case cost of a re-scrape; the crypto chunk is normally the first ref.
         private const val MAX_BUILD_CHUNKS = 40
 
         private const val MATERIAL_TTL_MS = 6 * 60 * 60 * 1000L
 
-        // SvelteKit app entry `import("…/entry/app.<hash>.js")` inside the mkissa HTML.
         private val APP_ENTRY_REGEX = Regex("""import\("([^"]*/entry/app\.[^"]*\.js)"\)""")
 
-        // Relative chunk references inside the app entry's `__vite__mapDeps` array, resolved
-        // against the entry URL so a change to the bundle's directory layout does not matter.
         private val CHUNK_REF_REGEX = Regex("""["'](\.\.?/[\w./-]+\.js)["']""")
 
         private const val CRYPTO_CHUNK_MARKER = "aaReq"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeQueries.kt
@@ -6,6 +6,10 @@ fun buildQuery(queryAction: () -> String): String = queryAction()
 
 const val STREAM_HASH = "f4662f4b7510b26795dd53ef824a0bf1740fbbc5d1273fab18222ac831bca8d0"
 
+// Content lane: the site scopes crypto material per content type, picking the lane from the
+// query it is about to send. `k7` is anime episodes (`k9` manga chapter pages, `k2` music).
+const val ANIME_LANE = "k7"
+
 val POPULAR_QUERY: String = buildQuery {
     """
         query(

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -22,18 +22,13 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
         val megabyte = kilobyte * 1000
         val gigabyte = megabyte * 1000
         val terabyte = gigabyte * 1000
-        return if (bytes in 0 until kilobyte) {
-            "$bytes b/s"
-        } else if (bytes in kilobyte until megabyte) {
-            (bytes / kilobyte).toString() + " kb/s"
-        } else if (bytes in megabyte until gigabyte) {
-            (bytes / megabyte).toString() + " mb/s"
-        } else if (bytes in gigabyte until terabyte) {
-            (bytes / gigabyte).toString() + " gb/s"
-        } else if (bytes >= terabyte) {
-            (bytes / terabyte).toString() + " tb/s"
-        } else {
-            "$bytes bits/s"
+        return when {
+            bytes < 0 -> "$bytes bits/s"
+            bytes < kilobyte -> "$bytes b/s"
+            bytes < megabyte -> "${bytes / kilobyte} kb/s"
+            bytes < gigabyte -> String.format(Locale.US, "%.2f mb/s", bytes.toDouble() / megabyte)
+            bytes < terabyte -> String.format(Locale.US, "%.2f gb/s", bytes.toDouble() / gigabyte)
+            else -> String.format(Locale.US, "%.2f tb/s", bytes.toDouble() / terabyte)
         }
     }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/extractors/AllAnimeExtractor.kt
@@ -17,6 +17,12 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
 
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
 
+    companion object {
+        // The DASH CDN 403s any request with a Referer, and an unset header set makes the player
+        // fall back to the source's, which has one.
+        private val DASH_HEADERS = Headers.headersOf("Accept", "*/*")
+    }
+
     private fun bytesIntoHumanReadable(bytes: Long): String {
         val kilobyte: Long = 1000
         val megabyte = kilobyte * 1000
@@ -106,6 +112,7 @@ class AllAnimeExtractor(private val client: OkHttpClient, private val headers: H
                             it.url,
                             "$name - ${it.height} ${bytesIntoHumanReadable(it.bandwidth)}",
                             it.url,
+                            headers = DASH_HEADERS,
                             audioTracks = audioList,
                             subtitleTracks = subtitles,
                         )


### PR DESCRIPTION
Closes #702
Closes #287

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Welp, hope that this change will last longer than the last one...

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update AllAnime extension to work with the new stream encryption scheme and bootstrap API.

New Features:
- Support AllAnime's new client-crypto bootstrap flow using per-build masks and epochs.
- Route stream encryption through a new bundle parser that recovers buildId and mask seeds from obfuscated JS chunks.

Bug Fixes:
- Fix AllAnime stream decryption and token generation so episode playback works again when the site updates its crypto.

Enhancements:
- Persist and reuse per-build crypto material with robust retry and recovery logic for stale builds and clock skew.
- Align stream requests and headers with AllAnime's lane-based crypto scoping and x-build-id validation.

Build:
- Bump AllAnime extension version code to 58.