### PR TITLE
Cineby [EN]: Update API Domain & Fix Quality Expansion For Some Servers

### DIFF
--- a/src/en/cineby/build.gradle
+++ b/src/en/cineby/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cineby'
     extClass = '.Cineby'
-    extVersionCode = 7
+    extVersionCode = 8
     isNsfw = true
 }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -45,7 +45,7 @@ class Cineby :
         get() = preferences.domainPref
 
     // Cineby/Videasy proxy
-    private val apiUrl = "https://db.wingsdatabase.com/3"
+    private val apiUrl = "https://db.speedracelight.com/3"
 
     private fun apiOrigin(url: String): String = url.toHttpUrl().run { "$scheme://$host" }
 
@@ -632,6 +632,6 @@ class Cineby :
 
         private const val PREF_SERVERS_KEY = "pref_servers_v2"
         private val PREF_SERVERS_DEFAULT =
-            setOf("Jett", "Neon", "Yoru", "Tejo")
+            setOf("Yoru", "Breach", "Neon", "Vyse")
     }
 }

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -221,9 +221,11 @@ class CinebyExtractor(
      * (e.g. "1080p", "720p", "480p", "4K", "2160p", or bare digits like "1080").
      * These don't need HLS expansion — the server already provided the correct label.
      */
-    private fun isRealResolution(quality: String): Boolean = qualityRegex.containsMatchIn(quality) ||
-        quality.contains("4k", ignoreCase = true) ||
-        quality.all { it.isDigit() }
+    private fun isRealResolution(quality: String): Boolean = quality.isNotBlank() && (
+        qualityRegex.containsMatchIn(quality) ||
+            quality.contains("4k", ignoreCase = true) ||
+            quality.all { it.isDigit() }
+        )
 
     /**
      * Extracts a numeric quality value for sorting. Maps "4K" to 2160
@@ -278,10 +280,14 @@ class CinebyExtractor(
                     // - URL is .m3u8/.mpd (standard HLS/DASH), or
                     // - Quality is a language name (these are almost always HLS
                     //   even if the URL doesn't contain .m3u8 explicitly)
-                    // Don't expand when quality is already "1080p" etc —
-                    // those servers provide correct labels per source.
-                    val needsExpansion = !isRealResolution(rawQuality) &&
-                        (isHls || isDash || isLang)
+                    // - Quality is a generic placeholder (e.g. "Auto", "video")
+                    //   to catch playlists that lack a file extension.
+                    //
+                    // FORCE EXPANSION FOR BREACH: m4uhd often returns a master playlist
+                    // without a .m3u8 extension. We force it here to extract the variants.
+                    val isGeneric = isGenericQuality(rawQuality)
+                    val needsExpansion = (!isRealResolution(rawQuality) && (isHls || isDash || isLang || isGeneric)) ||
+                        (server.displayName == "Breach")
 
                     if (needsExpansion) {
                         val expanded = runCatching {

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -217,6 +217,15 @@ class CinebyExtractor(
     }
 
     /**
+     * Returns true if the quality string already represents a real resolution
+     * (e.g. "1080p", "720p", "480p", "4K", "2160p", or bare digits like "1080").
+     * These don't need HLS expansion — the server already provided the correct label.
+     */
+    private fun isRealResolution(quality: String): Boolean = qualityRegex.containsMatchIn(quality) ||
+        quality.contains("4k", ignoreCase = true) ||
+        quality.all { it.isDigit() }
+
+    /**
      * Extracts a numeric quality value for sorting. Maps "4K" to 2160
      * so it sorts above 1080p instead of being treated as 0.
      */
@@ -265,11 +274,14 @@ class CinebyExtractor(
                     val isDash = source.url.lowercase().contains(".mpd")
                     val isLang = isLanguageAsQuality(server, rawQuality)
 
-                    // Always expand HLS/Dash to extract multiple audio tracks and resolutions.
-                    // For servers with generic playlists (like Yoru/Neon), we must expand
-                    // to find the actual resolutions.
-                    val isGeneric = isGenericQuality(rawQuality)
-                    val needsExpansion = isHls || isDash || isLang || isGeneric
+                    // Expand when quality is NOT a real resolution AND either:
+                    // - URL is .m3u8/.mpd (standard HLS/DASH), or
+                    // - Quality is a language name (these are almost always HLS
+                    //   even if the URL doesn't contain .m3u8 explicitly)
+                    // Don't expand when quality is already "1080p" etc —
+                    // those servers provide correct labels per source.
+                    val needsExpansion = !isRealResolution(rawQuality) &&
+                        (isHls || isDash || isLang)
 
                     if (needsExpansion) {
                         val expanded = runCatching {
@@ -333,18 +345,8 @@ class CinebyExtractor(
             else -> emptyList()
         }
 
-        return videos.distinctBy { it.videoUrl }.map { video ->
-            if (video.audioTracks.size > 1 && !video.quality.contains("Multi audio", ignoreCase = true)) {
-                val newQuality = if (video.quality.contains("audio")) {
-                    video.quality.replace(Regex("""\w+ audio"""), "Multi audio")
-                } else {
-                    video.quality + " · Multi audio"
-                }
-                video.copy(quality = newQuality)
-            } else {
-                video
-            }
-        }
+        // Return directly without post-processing to preserve original labels
+        return videos.distinctBy { it.videoUrl }
     }
 
     private fun cacheKey(
@@ -393,7 +395,7 @@ class CinebyExtractor(
     }
 
     companion object {
-        private const val VIDEASY_API_BASE = "https://api.wingsdatabase.com"
+        private const val VIDEASY_API_BASE = "https://api.speedracelight.com"
         private const val DECRYPTION_API_URL = "https://enc-dec.app/api/dec-videasy"
         private const val HEX = "0123456789ABCDEF"
 
@@ -419,25 +421,15 @@ class CinebyExtractor(
         private val GENERIC_QUALITY_REGEX = Regex("""^(video|stream|hls|dash)(\s+.*)?$""")
 
         //   Official servers (verified against website JS + reference table)
-        //   Jett    = jett                                   (api.wingsdatabase.com)
-        //   Yoru    = cdn          [MOVIE ONLY, MAY HAVE 4K] (api.wingsdatabase.com)
-        //   Tejo    = tejo                                   (api.wingsdatabase.com)
-        //   Neon    = neon2                                  (api.wingsdatabase.com)
-        //   Sage    = ym                                     (api.wingsdatabase.com)
-        //   Cypher  = downloader2                            (api.wingsdatabase.com)
-        //   Breach  = m4uhd                                  (api.wingsdatabase.com)
-        //   Vyse    = hdmovie      [FILTERS quality=English] (api.wingsdatabase.com)
-        //   Killjoy = meine ?lang=german  - German           (api.wingsdatabase.com)
-        //   Fade    = hdmovie      [FILTERS quality=Hindi]   (api.wingsdatabase.com)
-        //   Omen    = lamovie             - Spanish          (api.wingsdatabase.com)
-        //   Raze    = superflix           - Portuguese       (api.wingsdatabase.com)
+        //   Yoru    = cdn          [MOVIE ONLY, MAY HAVE 4K] (api.speedracelight.com)
+        //   Breach  = m4uhd                                  (api.speedracelight.com)
+        //   Neon    = vsrc                                   (api.speedracelight.com)
+        //   Vyse    = hdmovie      [FILTERS quality=English] (api.speedracelight.com)
+        //   Killjoy = meine ?lang=german  - German           (api.speedracelight.com)
+        //   Fade    = hdmovie      [FILTERS quality=Hindi]   (api.speedracelight.com)
+        //   Omen    = lamovie             - Spanish          (api.speedracelight.com)
+        //   Raze    = superflix           - Portuguese       (api.speedracelight.com)
         val VIDEASY_SERVERS = listOf(
-            VideasyServer(
-                "Jett",
-                VIDEASY_API_BASE,
-                "jett",
-                audioLabel = "Original",
-            ),
             VideasyServer(
                 "Yoru",
                 VIDEASY_API_BASE,
@@ -446,33 +438,15 @@ class CinebyExtractor(
                 audioLabel = "Original",
             ),
             VideasyServer(
-                "Tejo",
+                "Breach",
                 VIDEASY_API_BASE,
-                "tejo",
+                "m4uhd",
                 audioLabel = "Original",
             ),
             VideasyServer(
                 "Neon",
                 VIDEASY_API_BASE,
-                "neon2",
-                audioLabel = "Original",
-            ),
-            VideasyServer(
-                "Sage",
-                VIDEASY_API_BASE,
-                "ym",
-                audioLabel = "Original",
-            ),
-            VideasyServer(
-                "Cypher",
-                VIDEASY_API_BASE,
-                "downloader2",
-                audioLabel = "Original",
-            ),
-            VideasyServer(
-                "Breach",
-                VIDEASY_API_BASE,
-                "m4uhd",
+                "vsrc",
                 audioLabel = "Original",
             ),
             VideasyServer(


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update Cineby extension to use the new Videasy API domain and adjust server handling and quality expansion behavior.

New Features:
- Refine quality handling to avoid unnecessary HLS/DASH expansion when a real resolution label is already provided.

Enhancements:
- Preserve original quality labels by removing post-processing that rewrote multi-audio indicators.
- Update Videasy server mappings and default enabled servers to match the new backend configuration.

Build:
- Bump Cineby extension version code to 8 to reflect the updated API and behavior changes.