### PR TITLE
AnimePahe [EN]: Fix Dub Detection

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 45
+    extVersionCode = 46
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -403,7 +403,7 @@ class AnimePahe :
                 }
                 .thenByDescending {
                     val quality = it.quality.lowercase()
-                    val isDub = quality.contains("eng") || quality.contains("dub")
+                    val isDub = quality.contains("eng")
                     if (shouldEndWithEng) isDub else !isDub
                 }
                 .thenByDescending { it.quality.lowercase().contains("av1") == shouldBeAv1 },


### PR DESCRIPTION
Closes #698.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the AnimePahe English extension to correct how dubbed streams are detected and increment its extension version code.

Bug Fixes:
- Adjust AnimePahe stream sorting to treat only qualities containing "eng" as dubbed, avoiding incorrect dub detection.

Build:
- Bump AnimePahe extension version code to 46.