### PR TITLE
workflow: Allow fork's PR to uplload artifacts

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload APKs (${{ matrix.chunk.number }})
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: github.repository == github.event.pull_request.head.repo.full_name
+        if: "github.repository == 'yuzono/anime-extensions'"
         with:
           name: "individual-apks-${{ matrix.chunk.number }}"
           path: "**/*.apk"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust pull request build workflow condition to always upload APK artifacts for a specific repository instead of matching the PR head repo.