### PR TITLE
Subsplease [Multi]: Fix Pagination for Latest

### DIFF
--- a/src/all/subsplease/build.gradle
+++ b/src/all/subsplease/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Subsplease'
     extClass = '.Subsplease'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = false
 }
 

--- a/src/all/subsplease/src/eu/kanade/tachiyomi/animeextension/all/subsplease/Subsplease.kt
+++ b/src/all/subsplease/src/eu/kanade/tachiyomi/animeextension/all/subsplease/Subsplease.kt
@@ -78,11 +78,27 @@ class Subsplease :
 
     // Latest
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/api/?f=latest&tz=Europe/Berlin&p=$page")
+    override fun latestUpdatesRequest(page: Int): Request {
+        val url = if (page == 1) {
+            // Page 1
+            "$baseUrl/api/?f=latest&tz=Europe/Berlin"
+        } else {
+            // Page 2+ use '&p' parameter with (page number - 1)
+            "$baseUrl/api/?f=latest&tz=Europe/Berlin&p=${page - 1}"
+        }
+
+        val headers = headersBuilder()
+            .set("X-Requested-With", "XMLHttpRequest")
+            .set("Referer", baseUrl)
+            .build()
+
+        return GET(url, headers)
+    }
 
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val responseString = response.body.string()
-        val currentPage = response.request.url.queryParameter("p")?.toIntOrNull() ?: 1
+        val apiPage = response.request.url.queryParameter("p")?.toIntOrNull() ?: 0
+        val currentPage = apiPage + 1
         return parseLatestAnimeJson(responseString, currentPage)
     }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Fix latest updates pagination behavior for the Subsplease extension.

Bug Fixes:
- Correct latest updates API pagination by offsetting the page parameter and adjusting current page calculation.
- Add appropriate request headers for latest updates API calls to align with the site's expectations.

Build:
- Bump Subsplease extension version code to 7.