### PR TITLE
fix(en/mkissa):  fixing Mkissa "Unable to obtain MKissa crypto material"

### DIFF
--- a/src/en/mkissa/build.gradle
+++ b/src/en/mkissa/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MKissa'
     extClass = '.MKissa'
-    extVersionCode = 59
+    extVersionCode = 60
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -32,8 +32,8 @@ object MKissaCrypto {
 
     private const val WINDOW_MS = 5 * 60 * 1000L
 
-    // The server derives partB from a 3-day epoch and keeps the previous alive for a day.
-    private const val EPOCH_WINDOW_MS = 3 * 24 * 60 * 60 * 1000L
+    // The server derives partB from a 7-day epoch and keeps the previous alive for a day.
+    private const val EPOCH_WINDOW_MS = 7 * 24 * 60 * 60 * 1000L
     private const val EPOCH_GRACE_MS = 24 * 60 * 60 * 1000L
 
     /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild. */


### PR DESCRIPTION
Closes #721

## Problem

Every attempt to play an episode through the MKissa extension fails with:

> Unable to obtain MKissa crypto material

The bootstrap endpoint (`/client-crypto/v1/bootstrap`) returns `HTTP 403 {"error":"invalid_boot_token"}` on every call, so the extension can never obtain the AES-GCM key needed to decrypt stream URLs.

## Root Cause

`EPOCH_WINDOW_MS` in `MKissaCrypto.kt` is set to **3 days** (259,200,000 ms), but the server rolls epochs on a **7-day** window (604,800,000 ms).

The HMAC boot-token contains the epoch in its message:
```
message = "{buildId}:{keyGroup}:{host}:{epoch}:{lane}"
```

With a 3-day window the extension computed `epoch ≈ 6890`; the server expected `epoch ≈ 2952`. Because the epochs differ, the HMAC never matches and the server permanently rejects the token.

The server confirms its own window in the bootstrap response body:
```json
{ "epoch": 2952, "epochMs": 604800000, "graceMs": 86400000, ... }
```
`epochMs: 604800000` = 7 × 24 × 60 × 60 × 1000 ms.

`EPOCH_GRACE_MS` (1 day / 86,400,000 ms) was already correct.

## Fix

```kotlin
// Before
private const val EPOCH_WINDOW_MS = 3 * 24 * 60 * 60 * 1000L

// After
private const val EPOCH_WINDOW_MS = 7 * 24 * 60 * 60 * 1000L
```

## Verification

Live bootstrap call with corrected epoch (2952, 7-day window):
```
HTTP 200
{"epoch":2952,"epochMs":604800000,"graceMs":86400000,"partB":"...","k":"k7"}
```

Live bootstrap call with old epoch (6890, 3-day window):
```
HTTP 403
{"error":"invalid_boot_token"}
```

## Summary by Sourcery

Bug Fixes:
- Fix MKissa extension failing to obtain crypto material due to mismatched epoch window with the server.