### PR TITLE
Cineby [EN]: Update Servers

### DIFF
--- a/src/en/cineby/build.gradle
+++ b/src/en/cineby/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Cineby'
     extClass = '.Cineby'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/Cineby.kt
@@ -632,6 +632,6 @@ class Cineby :
 
         private const val PREF_SERVERS_KEY = "pref_servers_v2"
         private val PREF_SERVERS_DEFAULT =
-            setOf("Yoru", "Breach", "Neon", "Vyse")
+            setOf("Yoru", "Cypher", "Breach", "Neon", "Vyse")
     }
 }

--- a/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
+++ b/src/en/cineby/src/eu/kanade/tachiyomi/animeextension/en/cineby/CinebyExtractor.kt
@@ -427,7 +427,8 @@ class CinebyExtractor(
         private val GENERIC_QUALITY_REGEX = Regex("""^(video|stream|hls|dash)(\s+.*)?$""")
 
         //   Official servers (verified against website JS + reference table)
-        //   Yoru    = cdn          [MOVIE ONLY, MAY HAVE 4K] (api.speedracelight.com)
+        //   Yoru    = cdn                      [MAY HAVE 4K] (api.speedracelight.com)
+        //   Cypher  = downloader2                            (api.speedracelight.com)
         //   Breach  = m4uhd                                  (api.speedracelight.com)
         //   Neon    = vsrc                                   (api.speedracelight.com)
         //   Vyse    = hdmovie      [FILTERS quality=English] (api.speedracelight.com)
@@ -441,6 +442,12 @@ class CinebyExtractor(
                 VIDEASY_API_BASE,
                 "cdn",
                 mayHave4K = true,
+                audioLabel = "Original",
+            ),
+            VideasyServer(
+                "Cypher",
+                VIDEASY_API_BASE,
+                "downloader2",
                 audioLabel = "Original",
             ),
             VideasyServer(


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add the new Cypher streaming server to the Cineby extension and update its default configuration.

New Features:
- Introduce the Cypher server backed by the downloader2 endpoint to Cineby and include it in the default enabled servers.

Build:
- Bump the Cineby extension version code to 9 to release the new server configuration.