### PR TITLE
Add OLeTV Chinese extension

### DIFF
--- a/src/zh/oletv/CHANGELOG.md
+++ b/src/zh/oletv/CHANGELOG.md
@@ -1,0 +1,17 @@
+# OLeTV extension history
+
+## v14.2 — 2026-08-08
+
+- Accept API `data` returned as a JSON object, JSON array, JSON string, or AES-encrypted string.
+- Fix `IllegalArgumentException: JsonObject is not a JsonPrimitive` on popular and latest lists.
+- Keep the site-generated `_vv` signature flow and HLS `Referer`/`Origin` headers from v14.1.
+- Debug APK SHA-256: `eeb2e4b3c494551a0ff3ba073b85dd918ecb0fdd55cfa6f36a86ec0e5b0da7aa`.
+
+## v14.1 — 2026-08-08
+
+- Initial OLeTV extension for `https://www.olevod.tv`.
+- Add popular, latest, search, details, episodes, and HLS playback.
+- Generate the API `_vv` signature through the site's WebView/WASM implementation.
+- Support daily AES-CBC API response decryption.
+- Capture the real HLS playlist from the player page and pass the required site headers.
+- Debug APK SHA-256: `8eb720c43a5de137de682a3450fa6a3d46582b645b21ef3860d860b3ba35015b`.

--- a/src/zh/oletv/build.gradle
+++ b/src/zh/oletv/build.gradle
@@ -1,0 +1,11 @@
+ext {
+    extName = 'OLeTV'
+    extClass = '.OLeTV'
+    extVersionCode = 2
+}
+
+apply plugin: "kei.plugins.extension.legacy"
+
+dependencies {
+    implementation(project(':lib:playlistutils'))
+}

--- a/src/zh/oletv/src/eu/kanade/tachiyomi/animeextension/zh/oletv/OLeTV.kt
+++ b/src/zh/oletv/src/eu/kanade/tachiyomi/animeextension/zh/oletv/OLeTV.kt
@@ -1,0 +1,170 @@
+package eu.kanade.tachiyomi.animeextension.zh.oletv
+
+import android.util.Base64
+import aniyomi.lib.playlistutils.PlaylistUtils
+import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import eu.kanade.tachiyomi.animesource.model.AnimesPage
+import eu.kanade.tachiyomi.animesource.model.SAnime
+import eu.kanade.tachiyomi.animesource.model.SEpisode
+import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
+import eu.kanade.tachiyomi.network.GET
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import okhttp3.Response
+import uy.kohesive.injekt.injectLazy
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class OLeTV : AnimeHttpSource() {
+    override val name = "OLeTV"
+    override val baseUrl = "https://www.olevod.tv"
+    override val lang = "zh"
+    override val supportsLatest = true
+
+    private val apiUrl = "https://api.olelive.com"
+    private val json: Json by injectLazy()
+    private val webView by lazy { OLeWebView(headers) }
+    private val videoHeaders by lazy {
+        headers.newBuilder()
+            .set("Referer", "$baseUrl/")
+            .set("Origin", baseUrl)
+            .build()
+    }
+    private val playlistUtils by lazy { PlaylistUtils(client, videoHeaders) }
+
+    override fun headersBuilder() = super.headersBuilder()
+        .set("Referer", "$baseUrl/")
+        .set("Origin", baseUrl)
+
+    private fun apiGet(path: String): Request {
+        val url = (apiUrl + path).toHttpUrl().newBuilder()
+            .addQueryParameter("_vv", webView.signature())
+            .build()
+        return GET(url, headers)
+    }
+
+    override fun popularAnimeRequest(page: Int) = apiGet("/v1/pub/vod/list/true/3/0/0/0/0/0/hot/$page/20")
+    override fun latestUpdatesRequest(page: Int) = apiGet("/v1/pub/vod/list/true/3/0/0/0/0/0/update/$page/20")
+
+    override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request = apiGet("/v1/pub/index/search/${java.net.URLEncoder.encode(query, "UTF-8")}/vod/0/$page/20")
+
+    override fun popularAnimeParse(response: Response) = parseList(response)
+    override fun latestUpdatesParse(response: Response) = parseList(response)
+
+    override fun searchAnimeParse(response: Response): AnimesPage {
+        val data = response.decryptedData().obj()
+        val lists = data["data"]?.arr().orEmpty().flatMap { group ->
+            group.obj()["list"]?.arr().orEmpty()
+        }
+        val total = data.int("total")
+        return AnimesPage(lists.mapNotNull(::parseAnime), total > lists.size)
+    }
+
+    private fun parseList(response: Response): AnimesPage {
+        val data = response.decryptedData().obj()
+        val items = data["list"]?.arr().orEmpty()
+        return AnimesPage(items.mapNotNull(::parseAnime), data.int("total") > items.size)
+    }
+
+    private fun parseAnime(element: JsonElement): SAnime? {
+        val item = element.obj()
+        val id = item.int("id")
+        if (id == 0) return null
+        val type = item.int("typeId1").takeIf { it > 0 } ?: item.int("pidId").takeIf { it > 0 } ?: 1
+        return SAnime.create().apply {
+            url = "/details-$type-$id.html"
+            title = item.str("name").ifBlank { item.str("title") }
+            thumbnail_url = imageUrl(item.str("pic").ifBlank { item.str("picThumb") }.ifBlank { item.str("img") })
+            description = item.str("content")
+            genre = item.str("class")
+            status = if (item.str("remarks").contains("完")) SAnime.COMPLETED else SAnime.UNKNOWN
+        }
+    }
+
+    override fun animeDetailsRequest(anime: SAnime): Request = apiGet("/v1/pub/vod/detail/${anime.url.substringAfterLast('-').substringBefore('.')}/false")
+
+    override fun animeDetailsParse(response: Response): SAnime {
+        val item = response.decryptedData().obj()
+        return parseAnime(item)!!.apply {
+            author = item.str("actor")
+            artist = item.str("director")
+            genre = listOf(item.str("class"), item.str("area"), item.str("year")).filter { it.isNotBlank() }.joinToString()
+            description = item.str("content")
+        }
+    }
+
+    override fun episodeListRequest(anime: SAnime): Request = animeDetailsRequest(anime)
+
+    override fun episodeListParse(response: Response): List<SEpisode> {
+        val item = response.decryptedData().obj()
+        val id = item.int("id")
+        val type = item.int("typeId1").takeIf { it > 0 } ?: 1
+        return item["urls"]?.arr().orEmpty().mapIndexed { position, element ->
+            val episode = element.obj()
+            val level = episode.int("index").takeIf { it > 0 } ?: position + 1
+            SEpisode.create().apply {
+                url = "/player/vod/$type-$id-$level.html"
+                name = episode.str("title").ifBlank { "第 $level 集" }
+                episode_number = level.toFloat()
+            }
+        }.reversed()
+    }
+
+    override fun videoListRequest(episode: SEpisode): Request = GET(baseUrl + episode.url, videoHeaders)
+
+    override fun videoListParse(response: Response): List<Video> {
+        val hls = webView.hls(response.request.url.toString())
+        if (hls.isBlank()) return emptyList()
+        return playlistUtils.extractFromHls(
+            hls,
+            referer = "$baseUrl/",
+            videoNameGen = { "OLeTV - $it" },
+        )
+    }
+
+    private fun Response.decryptedData(): JsonElement {
+        val envelope = json.parseToJsonElement(body.string()).jsonObject
+        val data = envelope["data"]
+            ?: error((envelope["msg"] as? JsonPrimitive)?.content ?: "OLeTV API 返回空数据")
+
+        return when (data) {
+            is JsonObject, is JsonArray -> data
+            is JsonPrimitive -> {
+                val value = data.content
+                require(value.isNotBlank()) { "OLeTV API 返回空数据" }
+                runCatching { json.parseToJsonElement(value) }
+                    .getOrElse { json.parseToJsonElement(decrypt(value)) }
+            }
+        }
+    }
+
+    private fun decrypt(value: String): String {
+        val date = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
+        val md5 = MessageDigest.getInstance("MD5").digest(date.toByteArray()).joinToString("") { "%02x".format(it) }
+        val key = md5.substring(8, 24).toByteArray()
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(key))
+        return cipher.doFinal(Base64.decode(value, Base64.DEFAULT)).toString(Charsets.UTF_8)
+    }
+
+    private fun imageUrl(path: String): String? = path.takeIf { it.isNotBlank() }?.let {
+        if (it.startsWith("http")) it else "https://static.olelive.com/${it.trimStart('/')}"
+    }
+
+    private fun JsonElement.obj(): JsonObject = this as? JsonObject ?: JsonObject(emptyMap())
+    private fun JsonElement.arr(): JsonArray = this as? JsonArray ?: JsonArray(emptyList())
+    private fun JsonObject.str(key: String) = (this[key] as? JsonPrimitive)?.content.orEmpty()
+    private fun JsonObject.int(key: String) = str(key).toIntOrNull() ?: 0
+}

--- a/src/zh/oletv/src/eu/kanade/tachiyomi/animeextension/zh/oletv/OLeWebView.kt
+++ b/src/zh/oletv/src/eu/kanade/tachiyomi/animeextension/zh/oletv/OLeWebView.kt
@@ -1,0 +1,79 @@
+package eu.kanade.tachiyomi.animeextension.zh.oletv
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import okhttp3.Headers
+import uy.kohesive.injekt.injectLazy
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class OLeWebView(private val headers: Headers) {
+    private val context: Application by injectLazy()
+    private val handler = Handler(Looper.getMainLooper())
+
+    @Volatile private var cachedSignature: String? = null
+
+    @Volatile private var signatureTime = 0L
+
+    fun signature(): String {
+        cachedSignature?.takeIf { System.currentTimeMillis() - signatureTime < SIGNATURE_TTL }?.let { return it }
+        return intercept("https://www.olevod.tv/") { request ->
+            if (request.url.host == "api.olelive.com") request.url.getQueryParameter("_vv") else null
+        }.also {
+            require(it.isNotBlank()) { "无法生成 OLeTV API 签名，请确认 Android System WebView 可用" }
+            cachedSignature = it
+            signatureTime = System.currentTimeMillis()
+        }
+    }
+
+    fun hls(playerUrl: String): String = intercept(playerUrl) { request ->
+        request.url.toString().takeIf { ".m3u8" in it }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun intercept(url: String, matcher: (WebResourceRequest) -> String?): String {
+        val latch = CountDownLatch(1)
+        var result = ""
+        var webView: WebView? = null
+
+        handler.post {
+            val view = WebView(context)
+            webView = view
+            view.settings.javaScriptEnabled = true
+            view.settings.domStorageEnabled = true
+            view.settings.databaseEnabled = true
+            view.settings.mediaPlaybackRequiresUserGesture = false
+            view.settings.userAgentString = headers["User-Agent"]
+            view.webViewClient = object : WebViewClient() {
+                override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
+                    if (result.isEmpty()) {
+                        matcher(request)?.let {
+                            result = it
+                            latch.countDown()
+                        }
+                    }
+                    return super.shouldInterceptRequest(view, request)
+                }
+            }
+            view.loadUrl(url, mapOf("Referer" to "https://www.olevod.tv/"))
+        }
+
+        latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        handler.post {
+            webView?.stopLoading()
+            webView?.destroy()
+        }
+        return result
+    }
+
+    companion object {
+        private const val TIMEOUT_SECONDS = 25L
+        private const val SIGNATURE_TTL = 20_000L
+    }
+}


### PR DESCRIPTION
## What changed

- Add a Chinese OLeTV extension for `https://www.olevod.tv`.
- Implement popular, latest, search, details, episode listing, and HLS playback.
- Generate OLeTV's required `_vv` API signature through the site's own WebView/WASM flow.
- Support both daily AES-CBC encrypted API payloads and payloads returned directly as JSON objects, arrays, or JSON strings.
- Capture the real HLS playlist from the player page and pass the required `Referer` and `Origin` headers to playlists and segments.
- Add a per-extension changelog retaining the v14.1 and v14.2 implementation and fix history, including debug APK SHA-256 values.

## Why

OLeTV's public pages are a JavaScript SPA backed by `api.olelive.com`. API GET requests require a short-lived `_vv` signature generated by the site's `play.wasm`, and API responses may vary between AES-encrypted strings and already-decoded JSON payloads. Playback URLs are only exposed by the player flow and require the site referer.

## Root cause of the v14.2 fix

The initial parser assumed that every API `data` value was an encrypted JSON string. On devices where the endpoint returned a decoded JSON object, it raised `IllegalArgumentException: JsonObject is not a JsonPrimitive`. The parser now handles every observed payload representation before falling back to AES decryption.

## Validation

- `./gradlew :src:zh:oletv:assembleDebug`
- Build completed successfully.
- Latest debug APK SHA-256: `eeb2e4b3c494551a0ff3ba073b85dd918ecb0fdd55cfa6f36a86ec0e5b0da7aa`.

## Summary by Sourcery

Add a new Chinese OLeTV streaming extension integrating with oletv/olelive APIs, HLS playback, and site-specific WebView-based signing and decryption flows.

New Features:
- Introduce a zh OLeTV anime extension with popular, latest, search, details, episodes, and video playback support.
- Generate short-lived `_vv` API signatures via an in-app WebView that mirrors the site's WASM flow.
- Extract real HLS playlists from the player page and play them using playlist utilities with appropriate headers.

Bug Fixes:
- Handle OLeTV API `data` responses returned as JSON objects, arrays, plain JSON strings, or AES-encrypted strings to avoid parsing crashes on popular and latest lists.

Enhancements:
- Cache API signature values with a TTL to reduce repeated WebView initialization.
- Derive image URLs for content using the OLeTV static asset host when needed.

Build:
- Add Gradle build configuration for the zh OLeTV extension and wire in the playlist utilities library dependency.

Documentation:
- Add a per-extension changelog documenting v14.1 and v14.2 behavior, fixes, and debug APK hashes.