### PR TITLE
AnimeWorld India: Update base URL to watchanimeworld.top

### DIFF
--- a/gradle/build-logic/bin/main/PluginAndroidBase.kt
+++ b/gradle/build-logic/bin/main/PluginAndroidBase.kt
@@ -1,0 +1,46 @@
+import com.android.build.api.dsl.ApplicationDefaultConfig
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.DefaultConfig
+import com.android.build.api.dsl.LibraryDefaultConfig
+import keiyoushi.gradle.configurations.configureKotlin
+import keiyoushi.gradle.extensions.kei
+import keiyoushi.gradle.extensions.spotlessTaskName
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+@Suppress("UNUSED")
+class PluginAndroidBase : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        configureKotlin()
+
+        android {
+            compileSdk = kei.versions.android.sdk.compile.get().toInt()
+
+            defaultConfig {
+                minSdk = kei.versions.android.sdk.min.get().toInt()
+                if (this is ApplicationDefaultConfig) {
+                    targetSdk = kei.versions.android.sdk.target.get().toInt()
+                }
+
+                val proguardFile = file("proguard-rules.pro")
+                if (proguardFile.exists()) {
+                    when (this) {
+                        is ApplicationDefaultConfig -> proguardFile(proguardFile)
+                        is LibraryDefaultConfig -> consumerProguardFiles(proguardFile)
+                    }
+                }
+            }
+        }
+
+        tasks.getByName("preBuild").dependsOn(spotlessTaskName())
+    }
+}
+
+private fun Project.android(block: CommonExtension.() -> Unit) {
+    extensions.configure(block)
+}
+
+private fun CommonExtension.defaultConfig(block: DefaultConfig.() -> Unit) {
+    defaultConfig.apply(block)
+}

--- a/gradle/build-logic/bin/main/PluginExtensionLegacy.kt
+++ b/gradle/build-logic/bin/main/PluginExtensionLegacy.kt
@@ -1,0 +1,201 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.gradle.tasks.PackageAndroidArtifact
+import keiyoushi.gradle.extensions.alias
+import keiyoushi.gradle.extensions.baseVersionCode
+import keiyoushi.gradle.extensions.compileOnly
+import keiyoushi.gradle.extensions.implementation
+import keiyoushi.gradle.extensions.kei
+import keiyoushi.gradle.extensions.libs
+import keiyoushi.gradle.extensions.plugins
+import keiyoushi.gradle.tasks.GenerateKeepRulesTask
+import keiyoushi.gradle.utils.assertWithoutFlag
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.BasePluginExtension
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.extra
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+
+@Suppress("UNUSED")
+class PluginExtensionLegacy : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        plugins {
+            alias(libs.plugins.android.application)
+            alias(libs.plugins.kotlin.serialization)
+
+            alias(kei.plugins.android.base)
+            alias(kei.plugins.spotless)
+        }
+
+        assertWithoutFlag(!extra.has("pkgNameSuffix")) { "Gradle configuration cannot contain 'pkgNameSuffix'" }
+        assertWithoutFlag(!extra.has("libVersion")) { "Gradle configuration cannot contain 'libVersion'" }
+
+        assertWithoutFlag(extName.max().code < 0x180) { "Extension name should be romanized" }
+
+        val theme: Project? = if (extra.has("themePkg")) project(":lib-multisrc:$themePkg") else null
+        if (theme != null) evaluationDependsOn(theme.path)
+
+        android {
+            namespace = "eu.kanade.tachiyomi.animeextension"
+
+            sourceSets {
+                named("main") {
+                    manifest.srcFile(rootProject.file("common/AndroidManifest.xml"))
+                    java.directories.clear()
+                    java.directories.add("src")
+                    kotlin.directories.clear()
+                    kotlin.directories.add("src")
+                    res.directories.clear()
+                    res.directories.add("res")
+                    assets.directories.clear()
+                    assets.directories.add("assets")
+                }
+            }
+
+            defaultConfig {
+                applicationIdSuffix = project.parent?.name + "." + project.name
+                versionCode = if (theme == null) extVersionCode else theme.baseVersionCode + overrideVersionCode
+                versionName = "14.$versionCode"
+                base {
+                    archivesName.set("aniyomi-$applicationIdSuffix-v$versionName")
+                }
+                assertWithoutFlag(extClass.startsWith(".")) { "'extClass' must start with '.'" }
+                manifestPlaceholders += mapOf(
+                    "appName" to "Aniyomi: $extName",
+                    "extClass" to extClass,
+                    "nsfw" to if (isNsfw) 1 else 0,
+                )
+                if (theme != null && baseUrl.isNotEmpty()) {
+                    val split = baseUrl.split("://")
+                    assertWithoutFlag(split.size == 2) { "'baseUrl' must be in the format of 'https://example.com'" }
+                    val path = split[1].split("/")
+                    manifestPlaceholders += mapOf(
+                        "SOURCEHOST" to path[0],
+                        "SOURCESCHEME" to split[0],
+                    )
+                }
+            }
+
+            lint {
+                checkReleaseBuilds = false
+            }
+
+            signingConfigs {
+                create("release") {
+                    storeFile = rootProject.file("signingkey.jks")
+                    storePassword = providers.environmentVariable("KEY_STORE_PASSWORD").orNull
+                    keyAlias = providers.environmentVariable("ALIAS").orNull
+                    keyPassword = providers.environmentVariable("KEY_PASSWORD").orNull
+                }
+            }
+
+            buildTypes {
+                named("release") {
+                    signingConfig = if (rootProject.file("signingkey.jks").exists()) {
+                        signingConfigs.getByName("release")
+                    } else {
+                        signingConfigs.getByName("debug")
+                    }
+                    isMinifyEnabled = true
+                    proguardFiles(rootProject.file("common/proguard-rules.pro"))
+                    @Suppress("UnstableApiUsage")
+                    vcsInfo.include = false
+                }
+            }
+
+            dependenciesInfo {
+                includeInApk = false
+            }
+
+            buildFeatures {
+                buildConfig = true
+            }
+
+            buildTypes {
+                configureEach {
+                    buildConfigField("String", "MEGACLOUD_API", "\"https://script.google.com/macros/s/AKfycbxHbYHbrGMXYD2-bC-C43D3njIbU-wGiYQuJL61H4vyy6YVXkybMNNEPJNPPuZrD1gRVA/exec\"")
+                    buildConfigField("String", "KISSKH_API", "\"https://script.google.com/macros/s/AKfycbzn8B31PuDxzaMa9_CQ0VGEDasFqfzI5bXvjaIZH4DM8DNq9q6xj1ALvZNz_JT3jF0suA/exec?id=\"")
+                    buildConfigField("String", "KISSKH_SUB_API", "\"https://script.google.com/macros/s/AKfycbyq6hTj0ZhlinYC6xbggtgo166tp6XaDKBCGtnYk8uOfYBUFwwxBui0sGXiu_zIFmA/exec?id=\"")
+                    buildConfigField("String", "KAISVA", "\"https://c-kai-8090.amarullz.com\"")
+                    buildConfigField("String", "TMDB_API", "\"${System.getenv("TMDB_API")}\"")
+                }
+            }
+
+            packaging {
+                resources.excludes.add("kotlin-tooling-metadata.json")
+            }
+        }
+
+        androidComponents {
+            onVariants { variant ->
+                val variantName = variant.name.replaceFirstChar { it.uppercase() }
+
+                @Suppress("UnstableApiUsage")
+                val keepRules = variant.sources.keepRules
+                if (keepRules != null) {
+                    val task = tasks.register<GenerateKeepRulesTask>("generate${variantName}KeepRules") {
+                        this.applicationId.set(variant.applicationId)
+                        this.extClass.set(this@with.extClass)
+                    }
+                    keepRules.addGeneratedSourceDirectory(task) { it.outputDir }
+                }
+
+                variant.sources.manifests.addStaticManifestFile("AndroidManifest.xml")
+            }
+        }
+
+        dependencies {
+            if (theme != null) implementation(theme) // Overrides core launcher icons
+            implementation(project(":core"))
+            compileOnly(libs.bundles.common)
+        }
+
+        afterEvaluate {
+            tasks.withType<PackageAndroidArtifact>().configureEach {
+                createdBy.set("")
+                doFirst {
+                    appMetadata.asFile.orNull?.writeText("")
+                }
+            }
+        }
+    }
+}
+
+private fun Project.android(block: ApplicationExtension.() -> Unit) {
+    extensions.configure(block)
+}
+
+private fun Project.androidComponents(block: ApplicationAndroidComponentsExtension.() -> Unit) {
+    extensions.configure(block)
+}
+
+private fun Project.base(block: BasePluginExtension.() -> Unit) {
+    extensions.configure(block)
+}
+
+private val Project.extName: String
+    get() = extra.get("extName") as String
+
+private val Project.extVersionCode: Int
+    get() = extra.get("extVersionCode") as Int
+
+private val Project.extClass: String
+    get() = extra.get("extClass") as String
+
+private val Project.isNsfw: Boolean
+    get() = extra.getOrNull("isNsfw") == true
+
+private val Project.baseUrl: String
+    get() = (extra.getOrNull("baseUrl") as String?).orEmpty()
+
+private val Project.overrideVersionCode: Int
+    get() = extra.get("overrideVersionCode") as Int
+
+private val Project.themePkg: String
+    get() = extra.get("themePkg") as String
+
+private fun ExtraPropertiesExtension.getOrNull(name: String) = if (has(name)) get(name) else null

--- a/gradle/build-logic/bin/main/PluginLibrary.kt
+++ b/gradle/build-logic/bin/main/PluginLibrary.kt
@@ -1,0 +1,50 @@
+import com.android.build.api.dsl.LibraryExtension
+import keiyoushi.gradle.extensions.alias
+import keiyoushi.gradle.extensions.compileOnly
+import keiyoushi.gradle.extensions.implementation
+import keiyoushi.gradle.extensions.kei
+import keiyoushi.gradle.extensions.libs
+import keiyoushi.gradle.extensions.plugins
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+
+@Suppress("UNUSED")
+class PluginLibrary : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        plugins {
+            alias(libs.plugins.android.library)
+            alias(libs.plugins.kotlin.serialization)
+
+            alias(kei.plugins.android.base)
+            alias(kei.plugins.spotless)
+        }
+
+        android {
+            namespace = "aniyomi.lib.${project.name}"
+
+            sourceSets {
+                named("main") {
+                    java.directories.clear()
+                    java.directories.add("src")
+                    kotlin.directories.clear()
+                    kotlin.directories.add("src")
+                    assets.directories.clear()
+                    assets.directories.add("assets")
+                }
+            }
+
+            androidResources.enable = false
+        }
+
+        dependencies {
+            compileOnly(libs.bundles.common)
+            implementation(project(":core"))
+        }
+    }
+}
+
+private fun Project.android(block: LibraryExtension.() -> Unit) {
+    extensions.configure(block)
+}

--- a/gradle/build-logic/bin/main/PluginMultiSrc.kt
+++ b/gradle/build-logic/bin/main/PluginMultiSrc.kt
@@ -1,0 +1,49 @@
+import com.android.build.api.dsl.LibraryExtension
+import keiyoushi.gradle.extensions.alias
+import keiyoushi.gradle.extensions.compileOnly
+import keiyoushi.gradle.extensions.implementation
+import keiyoushi.gradle.extensions.kei
+import keiyoushi.gradle.extensions.libs
+import keiyoushi.gradle.extensions.plugins
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+
+@Suppress("UNUSED")
+class PluginMultiSrc : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        plugins {
+            alias(libs.plugins.android.library)
+            alias(libs.plugins.kotlin.serialization)
+
+            alias(kei.plugins.android.base)
+            alias(kei.plugins.spotless)
+        }
+
+        android {
+            namespace = "eu.kanade.tachiyomi.multisrc.${project.name}"
+
+            sourceSets {
+                named("main") {
+                    manifest.srcFile("AndroidManifest.xml")
+                    kotlin.directories.clear()
+                    kotlin.directories.add("src")
+                    res.directories.clear()
+                    res.directories.add("res")
+                    assets.directories.clear()
+                    assets.directories.add("assets")
+                }
+            }
+        }
+
+        dependencies {
+            compileOnly(libs.bundles.common)
+            implementation(project(":core"))
+        }
+    }
+}
+
+private fun Project.android(block: LibraryExtension.() -> Unit) {
+    extensions.configure(block)
+}

--- a/gradle/build-logic/bin/main/PluginSpotless.kt
+++ b/gradle/build-logic/bin/main/PluginSpotless.kt
@@ -1,0 +1,83 @@
+import com.diffplug.gradle.spotless.SpotlessExtension
+import com.diffplug.spotless.FormatterFunc
+import com.diffplug.spotless.FormatterStep
+import keiyoushi.gradle.extensions.alias
+import keiyoushi.gradle.extensions.libs
+import keiyoushi.gradle.extensions.plugins
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.invoke
+import java.io.Serializable
+
+@Suppress("UNUSED")
+class PluginSpotless : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        plugins {
+            alias(libs.plugins.spotless)
+        }
+
+        // Configuration should be synced with [/gradle/build-logic/build.gradle.kts]
+        val ktlintVersion = libs.ktlint.bom.get().version
+        spotless {
+            kotlin {
+                target("src/**/*.kt", "*.kts")
+                ktlint(ktlintVersion)
+                    .editorConfigOverride(
+                        mapOf(
+                            "max_line_length" to 2147483647,
+                        ),
+                    )
+                trimTrailingWhitespace()
+                endWithNewline()
+                addStep(RandomUACheck.create())
+            }
+
+            java {
+                target("src/**/*.java")
+                googleJavaFormat()
+                removeUnusedImports()
+                trimTrailingWhitespace()
+                endWithNewline()
+            }
+
+            format("gradle") {
+                target("*.gradle")
+                trimTrailingWhitespace()
+                endWithNewline()
+            }
+
+            format("xml") {
+                target("src/**/*.xml")
+                trimTrailingWhitespace()
+                endWithNewline()
+            }
+        }
+    }
+}
+
+private object RandomUACheck {
+    fun create(): FormatterStep = FormatterStep.create(
+        "randomua-requires-getMangaUrl",
+        State(),
+        State::toFormatter,
+    )
+
+    private class State : Serializable {
+        fun toFormatter() = FormatterFunc { content ->
+            if ("package keiyoushi.lib.randomua" !in content &&
+                "keiyoushi.lib.randomua" in content &&
+                "override fun getMangaUrl(" !in content
+            ) {
+                throw AssertionError(
+                    "usage of :lib:randomua requires override of getMangaUrl()",
+                )
+            }
+            content
+        }
+    }
+}
+
+private fun Project.spotless(block: SpotlessExtension.() -> Unit) {
+    extensions.configure(block)
+}

--- a/gradle/build-logic/bin/main/keiyoushi/gradle/configurations/Kotlin.kt
+++ b/gradle/build-logic/bin/main/keiyoushi/gradle/configurations/Kotlin.kt
@@ -1,0 +1,28 @@
+package keiyoushi.gradle.configurations
+
+import keiyoushi.gradle.extensions.kei
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.HasConfigurableKotlinCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
+import tapmoc.configureJavaCompatibility
+
+fun Project.configureKotlin() {
+    configureJavaCompatibility(kei.versions.java.get().toInt())
+
+    kotlin {
+        compilerOptions {
+            optIn.add("kotlinx.serialization.ExperimentalSerializationApi")
+            freeCompilerArgs.add("-Xcontext-parameters")
+        }
+    }
+}
+
+private fun Project.kotlin(block: KotlinBaseExtension.() -> Unit) {
+    extensions.configure(block)
+}
+
+private fun KotlinBaseExtension.compilerOptions(block: KotlinCommonCompilerOptions.() -> Unit) {
+    if (this is HasConfigurableKotlinCompilerOptions<*>) compilerOptions(block)
+}

--- a/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/DependencyHandlerScope.kt
+++ b/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/DependencyHandlerScope.kt
@@ -1,0 +1,33 @@
+package keiyoushi.gradle.extensions
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ExternalModuleDependencyBundle
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.DependencyHandlerScope
+
+fun DependencyHandlerScope.api(dependencyNotation: Provider<MinimalExternalModuleDependency>) {
+    add("api", dependencyNotation)
+}
+
+fun DependencyHandlerScope.compileOnly(dependencyNotation: Provider<ExternalModuleDependencyBundle>) {
+    add("compileOnly", dependencyNotation)
+}
+
+@JvmName("implementationBundle")
+fun DependencyHandlerScope.implementation(dependencyNotation: Provider<ExternalModuleDependencyBundle>) {
+    add("implementation", dependencyNotation)
+}
+
+fun DependencyHandlerScope.implementation(dependencyNotation: Provider<MinimalExternalModuleDependency>) {
+    add("implementation", dependencyNotation)
+}
+
+fun DependencyHandlerScope.implementation(dependencyNotation: Project) {
+    add("implementation", dependencyNotation)
+}
+
+fun DependencyHandlerScope.implementation(dependencyNotation: ProjectDependency) {
+    add("implementation", dependencyNotation)
+}

--- a/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/ExtensionAware.kt
+++ b/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/ExtensionAware.kt
@@ -1,0 +1,8 @@
+package keiyoushi.gradle.extensions
+
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.extra
+
+var ExtensionAware.baseVersionCode: Int
+    get() = (extra.get("baseVersionCode") as Int)
+    set(value) = extra.set("baseVersionCode", value)

--- a/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/PluginManager.kt
+++ b/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/PluginManager.kt
@@ -1,0 +1,9 @@
+package keiyoushi.gradle.extensions
+
+import org.gradle.api.plugins.PluginManager
+import org.gradle.api.provider.Provider
+import org.gradle.plugin.use.PluginDependency
+
+fun PluginManager.alias(notation: Provider<PluginDependency>) {
+    apply(notation.get().pluginId)
+}

--- a/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/Project.kt
+++ b/gradle/build-logic/bin/main/keiyoushi/gradle/extensions/Project.kt
@@ -1,0 +1,16 @@
+package keiyoushi.gradle.extensions
+
+import org.gradle.accessors.dm.LibrariesForKei
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.Project
+import org.gradle.api.plugins.PluginManager
+import org.gradle.kotlin.dsl.the
+
+internal val Project.libs get() = the<LibrariesForLibs>()
+internal val Project.kei get() = the<LibrariesForKei>()
+
+internal fun Project.plugins(block: PluginManager.() -> Unit) {
+    pluginManager.apply(block)
+}
+
+fun Project.spotlessTaskName() = if (providers.environmentVariable("CI").orNull != "true") "spotlessApply" else "spotlessCheck"

--- a/gradle/build-logic/bin/main/keiyoushi/gradle/tasks/GenerateKeepRulesTask.kt
+++ b/gradle/build-logic/bin/main/keiyoushi/gradle/tasks/GenerateKeepRulesTask.kt
@@ -1,0 +1,28 @@
+package keiyoushi.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GenerateKeepRulesTask : DefaultTask() {
+
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    @get:Input
+    abstract val extClass: Property<String>
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun action() {
+        outputDir.get().file("extClass.keep").asFile.apply {
+            parentFile.mkdirs()
+            writeText("-keep class ${applicationId.get()}${extClass.get()} { <init>(); }\n")
+        }
+    }
+}

--- a/gradle/build-logic/bin/main/keiyoushi/gradle/utils/Assertion.kt
+++ b/gradle/build-logic/bin/main/keiyoushi/gradle/utils/Assertion.kt
@@ -1,0 +1,11 @@
+package keiyoushi.gradle.utils
+
+/**
+ * Throws an [AssertionError] calculated by [lazyMessage] if the [value] is false.
+ */
+inline fun assertWithoutFlag(value: Boolean, lazyMessage: () -> Any) {
+    if (!value) {
+        val message = lazyMessage()
+        throw AssertionError(message)
+    }
+}

--- a/src/all/animeworldindia/build.gradle
+++ b/src/all/animeworldindia/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimeWorld India'
     extClass = '.AnimeWorldIndiaFactory'
-    extVersionCode = 22
+    extVersionCode = 23
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/all/animeworldindia/src/eu/kanade/tachiyomi/animeextension/all/animeworldindia/AnimeWorldIndia.kt
+++ b/src/all/animeworldindia/src/eu/kanade/tachiyomi/animeextension/all/animeworldindia/AnimeWorldIndia.kt
@@ -27,7 +27,7 @@ class AnimeWorldIndia(
 
     override val name = "AnimeWorld India"
 
-    override val baseUrl = "https://anime-world.co"
+    override val baseUrl = "https://watchanimeworld.top"
 
     override val supportsLatest = true
 


### PR DESCRIPTION
### Summary
Updated the `baseUrl` for **AnimeWorld India** from the old domain to `https://watchanimeworld.top` and bumped `extVersionCode` to `23`.

---

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the AnimeWorld India extension to point to its new domain and integrate centralized Gradle build-logic plugins and utilities for extension and library modules.

Bug Fixes:
- Update AnimeWorld India extension to use the new https://watchanimeworld.top domain instead of the old anime-world.co URL.

Enhancements:
- Bump AnimeWorld India extension version code to 23.
- Introduce shared Gradle build-logic plugins and utilities for legacy extensions, libraries, multisrc modules, Android base configuration, Spotless formatting, and keep-rules generation.

Build:
- Add precompiled Gradle build-logic plugins and helper extensions under gradle/build-logic/bin to centralize Android, library, multisrc, and formatting configuration.