### PR TITLE
AnimePahe [EN]: Fix Error 404

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 46
+    extVersionCode = 47
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
 import android.os.Looper
+import android.util.Log
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.EpisodeDto
@@ -103,7 +104,7 @@ class AnimePahe :
 
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.useAsJsoup()
-        val animeId = ANIME_ID_REGEX.find(document.outerHtml())?.groupValues?.get(1)
+        val animeId = document.selectFirst("meta[name=id]")?.attr("content")
 
         return SAnime.create().apply {
             if (animeId != null) {
@@ -425,6 +426,8 @@ class AnimePahe :
 
     // ============================ Video Links =============================
     override fun videoListRequest(episode: SEpisode): Request {
+        // Strip the `?anime_id=...` query parameter.
+        // This parameter is strictly for database mapping and orphan prevention.
         val urlPath = episode.url.substringBefore("?")
         return GET("$baseUrl$urlPath", headers)
     }
@@ -588,7 +591,8 @@ class AnimePahe :
                 val searchData = response.parseAs<ResponseDto<SearchResultDto>>()
                 searchData.items.firstOrNull { it.id.toString() == animeId }?.session
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.e("AnimePahe", "Error fetching session for ID $animeId ('$title')", e)
             null
         }
     }
@@ -613,8 +617,6 @@ class AnimePahe :
         private val DATE_FORMATTER by lazy {
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
         }
-
-        private val ANIME_ID_REGEX = Regex("""<meta name="id" content="(\d+)">""")
 
         private val QUALITY_REGEX_P by lazy { Regex("""(\d+)p""") }
         private val QUALITY_REGEX by lazy { Regex("""(\d+)""") }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
-import android.util.Log
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.EpisodeDto
@@ -355,11 +354,11 @@ class AnimePahe :
 
     override fun episodeListRequest(anime: SAnime): Request {
         val animeId = anime.getId()
-        val session = animeId?.let { getSessionFromCache(it) } ?: throw IllegalStateException("Anime session not found.")
+        val session = animeId?.let { getSessionFromCache(it) }
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("api")
             addQueryParameter("m", "release")
-            addQueryParameter("id", session)
+            addQueryParameter("id", session ?: "")
             addQueryParameter("sort", "episode_asc")
             addQueryParameter("page", "1")
         }.build()
@@ -585,16 +584,18 @@ class AnimePahe :
                 if (!response.isSuccessful) return null
                 val searchData = response.parseAs<ResponseDto<SearchResultDto>>()
 
+                // If we know the ID, match it exactly.
+                // If no ID, prefer exact title match, then fall back to first result.
                 val matchedAnime = if (animeId != null) {
                     searchData.items.firstOrNull { it.id.toString() == animeId }
                 } else {
-                    searchData.items.firstOrNull()
+                    searchData.items.firstOrNull { it.title.equals(title, ignoreCase = true) }
+                        ?: searchData.items.firstOrNull()
                 }
 
                 matchedAnime?.let { it.id.toString() to it.session }
             }
-        } catch (e: Exception) {
-            Log.e("AnimePahe", "Error fetching session for ID $animeId ('$title')", e)
+        } catch (_: Exception) {
             null
         }
     }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
+import android.os.Looper
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.EpisodeDto
@@ -30,7 +31,6 @@ import okhttp3.Response
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
-import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -75,20 +75,32 @@ class AnimePahe :
     override val supportsLatest = false
 
     // =========================== Anime Details ============================
+    override fun animeDetailsRequest(anime: SAnime): Request {
+        val animeId = anime.getId()
+        if (animeId != null) {
+            val cachedSession = getSessionFromCache(animeId)
+            if (cachedSession != null) {
+                return GET("$baseUrl/anime/$cachedSession")
+            }
 
-    /**
-     * This override is necessary because AnimePahe does not provide permanent
-     * URLs to its animes, so we need to fetch the anime session every time.
-     *
-     * @see episodeListRequest
-     */
-    override fun animeDetailsRequest(anime: SAnime): Request = anime.getId()
-        ?.let { GET("$baseUrl/a/$it") }
-        ?: GET("$baseUrl${anime.url}") // fallback to session URL (when searching by filters): /anime/{sessionId}
+            if (Looper.myLooper() != Looper.getMainLooper()) {
+                val resolvedSession = fetchSessionFromTitle(animeId, anime.title)
+                if (resolvedSession != null) {
+                    saveSessionToCache(animeId, resolvedSession) // Save to cache
+                    return GET("$baseUrl/anime/$resolvedSession")
+                }
+            }
+
+            return GET("$baseUrl/a/$animeId")
+        }
+        return GET("$baseUrl${anime.url}")
+    }
 
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.useAsJsoup()
         return SAnime.create().apply {
+            // We want the database to keep the /a/{id} URL permanently, so that entries never get orphaned.
+
             title = document.selectFirst("div.title-wrapper > h1 > span")!!.text()
             author = document.selectFirst("div.col-sm-4.anime-info p:contains(Studios:)")
                 ?.text()
@@ -131,11 +143,12 @@ class AnimePahe :
         val latestData = response.parseAs<ResponseDto<LatestAnimeDto>>()
         val hasNextPage = latestData.currentPage < latestData.lastPage
         val animeList = latestData.items.map { anime ->
+            saveSessionToCache(anime.id.toString(), anime.session)
+
             SAnime.create().apply {
                 title = anime.title
                 thumbnail_url = anime.snapshot
-                val animeId = anime.id
-                setUrlWithoutDomain("/a/$animeId")
+                setUrlWithoutDomain("/a/${anime.id}")
                 artist = anime.fansub
             }
         }
@@ -206,11 +219,12 @@ class AnimePahe :
         if (url.pathSegments.contains("api") && url.queryParameter("m") == "search") {
             val searchData = response.parseAs<ResponseDto<SearchResultDto>>()
             val animeList = searchData.items.map { anime ->
+                saveSessionToCache(anime.id.toString(), anime.session)
+
                 SAnime.create().apply {
                     title = anime.title
                     thumbnail_url = anime.poster
-                    val animeId = anime.id
-                    setUrlWithoutDomain("/a/$animeId")
+                    setUrlWithoutDomain("/a/${anime.id}")
                 }
             }
             return AnimesPage(animeList, false)
@@ -257,41 +271,53 @@ class AnimePahe :
     }
 
     // ============================== Episodes ==============================
+    private val sessionIdRegex by lazy { Regex("""/anime/([\w-]+)""") }
+    private val newAnimeIdRegex by lazy { Regex("""/a/(\d+)""") }
+    private val oldQueryIdRegex by lazy { Regex("""\?anime_id=(\d+)""") }
 
-    /**
-     * This override is necessary because AnimePahe does not provide permanent
-     * URLs to its animes, so we need to fetch the anime session every time.
-     *
-     * @see animeDetailsRequest
-     */
+    private fun SAnime.getId() = newAnimeIdRegex.find(url)?.groupValues?.get(1)
+        ?: oldQueryIdRegex.find(url)?.groupValues?.get(1)
+
+    private fun SAnime.getSession() = sessionIdRegex.find(url)?.groupValues?.get(1)
+
     override fun episodeListRequest(anime: SAnime): Request {
         val animeId = anime.getId()
-        val session = animeId?.let { fetchSession(it) }
-            ?: sessionIdRegex.find(anime.url)?.groupValues?.get(1)
-            ?: throw IllegalStateException("Anime session not found")
+
+        var session = anime.getSession()
+
+        if (session == null && animeId != null) {
+            session = getSessionFromCache(animeId)
+        }
+
+        if (session == null && animeId != null && Looper.myLooper() != Looper.getMainLooper()) {
+            session = fetchSessionFromTitle(animeId, anime.title)
+            // Save mapping to cache, useful for relatedAnime entries that don't have anime_id in HTML
+            if (session != null) {
+                saveSessionToCache(animeId, session)
+            }
+        }
+
+        if (session == null) {
+            throw IllegalStateException("Anime session not found. Please open the anime details page to update the URL.")
+        }
 
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("api")
             addQueryParameter("m", "release")
             addQueryParameter("id", session)
             addQueryParameter("sort", "episode_asc")
-            animeId?.let { addQueryParameter("anime_id", it) }
             addQueryParameter("page", "1")
         }.build()
 
         return GET(url)
     }
 
-    private val sessionIdRegex by lazy { Regex("""/anime/([\w-]+)""") }
-    private val stableEpisodeRegex by lazy { Regex("""/play/anime/(\d+)/episode/([\d.]+)""") }
-
     override fun episodeListParse(response: Response): List<SEpisode> {
         val url = response.request.url
         val session = url.queryParameter("id")
             ?: throw IllegalStateException("Anime session not found in URL: $url")
-        val animeId = url.queryParameter("anime_id")
         val episodeList = mutableListOf<SEpisode>()
-        recursivePages(episodeList, response, session, animeId)
+        recursivePages(episodeList, response, session)
         val showSiteEpisodeNumber = preferences.getBoolean(PREF_SHOW_SITE_NUMBER_KEY, PREF_SHOW_SITE_NUMBER_DEFAULT)
 
         return episodeList
@@ -309,11 +335,11 @@ class AnimePahe :
             .reversed()
     }
 
-    private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String, animeId: String?): MutableList<SEpisode> = episodes.map { episode ->
+    private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String): MutableList<SEpisode> = episodes.map { episode ->
         SEpisode.create().apply {
             date_upload = episode.createdAt.let { DATE_FORMATTER.tryParse(it) }
             val session = episode.session
-            setUrlWithoutDomain(animeId?.let { "/play/anime/$it/episode/${episode.episodeNumber}" } ?: "/play/$animeSession/$session")
+            setUrlWithoutDomain("/play/$animeSession/$session?anime_id=${episode.animeId}")
             val epNum = episode.episodeNumber
             episode_number = epNum
             val epName = if (floor(epNum) == ceil(epNum)) {
@@ -325,14 +351,20 @@ class AnimePahe :
         }
     }.toMutableList()
 
-    private fun recursivePages(episodeList: MutableList<SEpisode>, response: Response, animeSession: String, animeId: String?) {
+    private fun recursivePages(episodeList: MutableList<SEpisode>, response: Response, animeSession: String) {
         val episodesData = response.parseAs<ResponseDto<EpisodeDto>>()
         val page = episodesData.currentPage
         val hasNextPage = page < episodesData.lastPage
-        episodeList.addAll(parseEpisodePage(episodesData.items, animeSession, animeId))
+
+        if (episodesData.items.isNotEmpty()) {
+            val animeId = episodesData.items.first().animeId.toString()
+            saveSessionToCache(animeId, animeSession)
+        }
+
+        episodeList.addAll(parseEpisodePage(episodesData.items, animeSession))
         if (hasNextPage) {
             nextPageRequest(response.request.url.toString(), page + 1).use { nextPage ->
-                recursivePages(episodeList, nextPage, animeSession, animeId)
+                recursivePages(episodeList, nextPage, animeSession)
             }
         }
     }
@@ -345,14 +377,8 @@ class AnimePahe :
     // ============================ Video Links =============================
 
     override fun videoListRequest(episode: SEpisode): Request {
-        val stableEpisode = stableEpisodeRegex.find(episode.url)
-            ?: return GET("$baseUrl${episode.url}")
-
-        val animeId = stableEpisode.groupValues[1]
-        val episodeNumber = stableEpisode.groupValues[2].toFloat()
-        val animeSession = fetchSession(animeId)
-        val episodeSession = fetchEpisodeSession(animeSession, episodeNumber)
-        return GET("$baseUrl/play/$animeSession/$episodeSession")
+        val urlPath = episode.url.substringBefore("?")
+        return GET("$baseUrl$urlPath", headers)
     }
 
     override fun videoListParse(response: Response): List<Video> {
@@ -485,33 +511,31 @@ class AnimePahe :
 
     // ============================= Utilities ==============================
 
-    /**
-     * AnimePahe does not provide permanent URLs to its animes,
-     * so we need to fetch the anime session every time.
-     */
-    private fun fetchSession(animeId: String): String {
-        val sessionId = client.newCall(GET("$baseUrl/a/$animeId")).execute().use {
-            it.request.url.pathSegments.last()
+    private fun saveSessionToCache(animeId: String, session: String) {
+        if (getSessionFromCache(animeId) != session) {
+            preferences.edit().putString("session_cache_$animeId", session).apply()
         }
-        return sessionId
     }
 
-    private fun fetchEpisodeSession(animeSession: String, episodeNumber: Float): String {
-        var page = 1
-        while (true) {
-            val request = GET("$baseUrl/api?m=release&id=$animeSession&sort=episode_asc&page=$page")
-            val episodesData = client.newCall(request).execute().use { response ->
-                response.parseAs<ResponseDto<EpisodeDto>>()
+    private fun getSessionFromCache(animeId: String): String? = preferences.getString("session_cache_$animeId", null)
+
+    private fun fetchSessionFromTitle(animeId: String, title: String?): String? {
+        if (title.isNullOrBlank()) return null
+
+        val searchUrl = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegment("api")
+            addQueryParameter("m", "search")
+            addQueryParameter("q", title)
+        }.build()
+
+        return try {
+            client.newCall(GET(searchUrl)).execute().use { response ->
+                val searchData = response.parseAs<ResponseDto<SearchResultDto>>()
+                searchData.items.firstOrNull { it.id.toString() == animeId }?.session
             }
-
-            episodesData.items.firstOrNull { abs(it.episodeNumber - episodeNumber) < 0.001f }
-                ?.let { return it.session }
-
-            if (page >= episodesData.lastPage) break
-            page++
+        } catch (_: Exception) {
+            null
         }
-
-        throw IllegalStateException("Episode session not found")
     }
 
     private fun parseStatus(statusString: String?): Int = when (statusString) {
@@ -519,12 +543,6 @@ class AnimePahe :
         "Finished Airing" -> SAnime.COMPLETED
         else -> SAnime.UNKNOWN
     }
-
-    private val newAnimeIdRegex by lazy { Regex("""/a/(\d+)""") }
-    private val oldAnimeIdRegex by lazy { Regex("""\?anime_id=(\d+)""") }
-
-    private fun SAnime.getId() = newAnimeIdRegex.find(url)?.let { it.groupValues[1] }
-        ?: oldAnimeIdRegex.find(url)?.let { it.groupValues[1] }
 
     private val cfBypassUserAgent: String
         get() {
@@ -571,7 +589,6 @@ class AnimePahe :
         private val PREF_LINK_TYPE_SUMMARY = """Enable this if you are having Cloudflare issues.
         """.trimMargin()
 
-        // Big slap to whoever misspelled `preferred`
         private const val PREF_AV1_KEY = "preferred_av1"
         private const val PREF_AV1_TITLE = "Use AV1 Codec"
         private const val PREF_AV1_DEFAULT = false

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -584,20 +584,27 @@ class AnimePahe :
                 if (!response.isSuccessful) return null
                 val searchData = response.parseAs<ResponseDto<SearchResultDto>>()
 
-                // If we know the ID, match it exactly.
-                // If no ID, prefer exact title match, then fall back to first result.
                 val matchedAnime = if (animeId != null) {
                     searchData.items.firstOrNull { it.id.toString() == animeId }
                 } else {
-                    searchData.items.firstOrNull { it.title.equals(title, ignoreCase = true) }
-                        ?: searchData.items.firstOrNull()
+                    val normalizedQuery = normalizeTitle(title)
+                    searchData.items.firstOrNull { normalizeTitle(it.title) == normalizedQuery }
                 }
 
-                matchedAnime?.let { it.id.toString() to it.session }
+                if (matchedAnime == null) return null
+
+                matchedAnime.let { it.id.toString() to it.session }
             }
         } catch (_: Exception) {
             null
         }
+    }
+
+    private fun normalizeTitle(raw: String): String {
+        return raw
+            .lowercase()
+            .replace(NORMALIZE_REGEX, "")
+            .trim()
     }
 
     private fun parseStatus(statusString: String?): Int = when (statusString) {
@@ -620,6 +627,8 @@ class AnimePahe :
         private val DATE_FORMATTER by lazy {
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
         }
+
+        private val NORMALIZE_REGEX = Regex("[^a-z0-9]+")
 
         private val QUALITY_REGEX_P by lazy { Regex("""(\d+)p""") }
         private val QUALITY_REGEX by lazy { Regex("""(\d+)""") }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -76,6 +76,33 @@ class AnimePahe :
     override val supportsLatest = false
 
     // =========================== Anime Details ============================
+    /*** AnimePahe gives anime page {session_id} that varies after a few days.
+     *   Code was remade so that it could fetch new {session_id}
+     *   from a constant {anime_id}, which can be found in airing/search
+     *   API responses.
+     *
+     *   Related (Anikku feature) needs to match {session_id} to
+     *   said {anime_id}, since HTML does not provide the id
+     *   in animeDetails for other anime.
+     *
+     *   Legacy way of fetching a {session_id} was through "$baseUrl/a/$anime_id",
+     *   but that's gone, so we have to do a cat and mouse race to link ids
+     *   that expire every few days to canonical {anime_id}.
+     *
+     *   To limit network calls and prevent orphaning of library entries,
+     *   we double-cache these ids in SharedPreferences:
+     *   - "session_cache" (id -> session): Lets WebView load /anime/{session_id},
+     *     since /a/{anime_id} no longer works.
+     *   - "id_cache" (session -> id): Lets Related Anime list match /anime/{session_id}
+     *     or any entry without {anime_id} to the library's /a/{anime_id}, since
+     *     animeDetails doesn't have any external {anime_id} for related entries.
+     *
+     *   If a cached session 404s, getAnimeDetails and getEpisodeList intercept it,
+     *   search the API by title, match the {anime_id}, overwrite the cache,
+     *   and retry the request automatically. If {anime_id} is missing, user may
+     *   need to migrate the entry to fetch new anime, which migration search
+     *   will map it automatically with {anime_id} and {session_id}.
+     */
     override fun getAnimeUrl(anime: SAnime): String {
         val animeId = anime.getId()
         val cachedSession = animeId?.let { getSessionFromCache(it) }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -403,7 +403,7 @@ class AnimePahe :
 
     private suspend fun fetchEpisodes(response: Response, session: String): List<SEpisode> {
         val episodeList = mutableListOf<SEpisode>()
-        val urlWithoutPage = response.request.url.toString().substringBefore("&page=")
+        val requestUrl = response.request.url
         var currentData = response.parseAs<ResponseDto<EpisodeDto>>()
 
         if (currentData.items.isNotEmpty()) {
@@ -415,7 +415,10 @@ class AnimePahe :
             episodeList.addAll(parseEpisodePage(currentData.items, session))
             if (currentData.currentPage >= currentData.lastPage) break
 
-            val nextUrl = "$urlWithoutPage&page=${currentData.currentPage + 1}"
+            val nextUrl = requestUrl.newBuilder()
+                .setQueryParameter("page", (currentData.currentPage + 1).toString())
+                .build()
+
             currentData = client.newCall(GET(nextUrl)).await().use { it.parseAs() }
         }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -600,12 +600,10 @@ class AnimePahe :
         }
     }
 
-    private fun normalizeTitle(raw: String): String {
-        return raw
-            .lowercase()
-            .replace(NORMALIZE_REGEX, "")
-            .trim()
-    }
+    private fun normalizeTitle(raw: String): String = raw
+        .lowercase()
+        .replace(NORMALIZE_REGEX, "")
+        .trim()
 
     private fun parseStatus(statusString: String?): Int = when (statusString) {
         "Currently Airing" -> SAnime.ONGOING

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -102,6 +102,34 @@ class AnimePahe :
         throw IOException("HTTP error fetching details for '${anime.title}' (ID: ${animeId ?: "N/A"}) at ${request.url}")
     }
 
+    override fun animeDetailsRequest(anime: SAnime): Request {
+        val session = anime.getSession()
+        if (session != null) {
+            val urlPath = anime.url.substringBefore("?")
+            return GET("$baseUrl$urlPath")
+        }
+
+        val animeId = anime.getId()
+        if (animeId != null) {
+            val cachedSession = getSessionFromCache(animeId)
+            if (cachedSession != null) {
+                return GET("$baseUrl/anime/$cachedSession")
+            }
+
+            if (Looper.myLooper() != Looper.getMainLooper()) {
+                val resolvedSession = fetchSessionFromTitle(animeId, anime.title)
+                if (resolvedSession != null) {
+                    saveSessionToCache(animeId, resolvedSession) // Save to cache
+                    return GET("$baseUrl/anime/$resolvedSession")
+                }
+            }
+
+            return GET("$baseUrl/a/$animeId")
+        }
+
+        return GET("$baseUrl${anime.url}")
+    }
+
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.useAsJsoup()
         val animeId = document.selectFirst("meta[name=id]")?.attr("content")

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -98,8 +98,7 @@ class AnimePahe :
 
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.useAsJsoup()
-        val html = document.outerHtml()
-        val animeId = ANIME_ID_REGEX.find(html)?.groupValues?.get(1)
+        val animeId = ANIME_ID_REGEX.find(document.outerHtml())?.groupValues?.get(1)
 
         return SAnime.create().apply {
             if (animeId != null) {
@@ -573,7 +572,7 @@ class AnimePahe :
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
         }
 
-        private val ANIME_ID_REGEX = Regex("""anime_id['"]?\s*[:=]\s*['"]?(\d+)""")
+        private val ANIME_ID_REGEX = Regex("""<meta name="id" content="(\d+)">""")
 
         private val QUALITY_REGEX_P by lazy { Regex("""(\d+)p""") }
         private val QUALITY_REGEX by lazy { Regex("""(\d+)""") }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
+import android.os.Looper
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.EpisodeDto
@@ -28,6 +29,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Element
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.math.ceil
@@ -76,25 +78,31 @@ class AnimePahe :
     // =========================== Anime Details ============================
     override suspend fun getAnimeDetails(anime: SAnime): SAnime {
         val request = animeDetailsRequest(anime)
-        client.newCall(request).execute().use { response ->
-            if (response.isSuccessful) {
-                return animeDetailsParse(response)
-            } else {
-                val animeId = anime.getId()
-                if (animeId != null) {
-                    val newSession = fetchSessionFromTitle(animeId, anime.title)
-                    if (newSession != null) {
-                        saveSessionToCache(animeId, newSession)
-                        val newRequest = GET("$baseUrl/anime/$newSession")
-                        client.newCall(newRequest).execute().use { newResponse ->
-                            if (newResponse.isSuccessful) {
-                                return animeDetailsParse(newResponse)
+        try {
+            client.newCall(request).execute().use { response ->
+                if (response.isSuccessful) {
+                    return animeDetailsParse(response)
+                } else {
+                    val animeId = anime.getId()
+                    if (animeId != null) {
+                        val newSession = fetchSessionFromTitle(animeId, anime.title)
+                        if (newSession != null) {
+                            saveSessionToCache(animeId, newSession)
+                            val newRequest = GET("$baseUrl/anime/$newSession")
+                            client.newCall(newRequest).execute().use { newResponse ->
+                                if (newResponse.isSuccessful) {
+                                    return animeDetailsParse(newResponse)
+                                }
+                                throw IOException("HTTP ${newResponse.code} fetching details for '${anime.title}' (ID: $animeId) at ${newRequest.url}")
                             }
                         }
                     }
+                    throw IOException("HTTP ${response.code} fetching details for '${anime.title}' (ID: ${animeId ?: "N/A"}) at ${request.url}")
                 }
-                throw Exception("HTTP ${response.code}")
             }
+        } catch (e: Exception) {
+            if (e is IOException) throw e
+            throw IOException("Network error fetching details for '${anime.title}' (ID: ${anime.getId() ?: "N/A"})", e)
         }
     }
 
@@ -292,35 +300,69 @@ class AnimePahe :
     // ============================== Episodes ==============================
     override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
         val request = episodeListRequest(anime)
-        client.newCall(request).execute().use { response ->
-            if (response.isSuccessful) {
-                return episodeListParse(response)
-            } else {
-                val animeId = anime.getId()
-                val title = anime.title
-                if (animeId != null && title.isNotBlank()) {
-                    val newSession = fetchSessionFromTitle(animeId, title)
-                    if (newSession != null) {
-                        saveSessionToCache(animeId, newSession)
-                        val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
-                            addPathSegment("api")
-                            addQueryParameter("m", "release")
-                            addQueryParameter("id", newSession)
-                            addQueryParameter("sort", "episode_asc")
-                            addQueryParameter("page", "1")
-                            addQueryParameter("anime_id", animeId)
-                            addQueryParameter("title", title)
-                        }.build()
-                        client.newCall(GET(newUrl)).execute().use { newResponse ->
-                            if (newResponse.isSuccessful) {
-                                return episodeListParse(newResponse)
+        try {
+            client.newCall(request).execute().use { response ->
+                if (response.isSuccessful) {
+                    return episodeListParse(response)
+                } else {
+                    val animeId = anime.getId()
+                    val title = anime.title
+                    if (animeId != null && title.isNotBlank()) {
+                        val newSession = fetchSessionFromTitle(animeId, title)
+                        if (newSession != null) {
+                            saveSessionToCache(animeId, newSession)
+                            val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
+                                addPathSegment("api")
+                                addQueryParameter("m", "release")
+                                addQueryParameter("id", newSession)
+                                addQueryParameter("sort", "episode_asc")
+                                addQueryParameter("page", "1")
+                                addQueryParameter("anime_id", animeId)
+                                addQueryParameter("title", title)
+                            }.build()
+                            client.newCall(GET(newUrl)).execute().use { newResponse ->
+                                if (newResponse.isSuccessful) {
+                                    return episodeListParse(newResponse)
+                                }
+                                throw IOException("HTTP ${newResponse.code} fetching episodes for '$title' (ID: $animeId) at $newUrl")
                             }
                         }
                     }
+                    throw IOException("HTTP ${response.code} fetching episodes for '$title' (ID: ${animeId ?: "N/A"}) at ${request.url}")
                 }
-                throw Exception("HTTP ${response.code}")
+            }
+        } catch (e: Exception) {
+            if (e is IOException) throw e
+            throw IOException("Network error fetching episodes for '${anime.title}' (ID: ${anime.getId() ?: "N/A"})", e)
+        }
+    }
+
+    override fun episodeListRequest(anime: SAnime): Request {
+        val animeId = anime.getId()
+        var session = anime.getSession() ?: animeId?.let { getSessionFromCache(it) }
+
+        if (session == null && animeId != null && Looper.myLooper() != Looper.getMainLooper()) {
+            session = fetchSessionFromTitle(animeId, anime.title)
+            if (session != null) {
+                saveSessionToCache(animeId, session)
             }
         }
+
+        if (session == null) {
+            throw IllegalStateException("Anime session not found.")
+        }
+
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegment("api")
+            addQueryParameter("m", "release")
+            addQueryParameter("id", session)
+            addQueryParameter("sort", "episode_asc")
+            addQueryParameter("page", "1")
+            animeId?.let { addQueryParameter("anime_id", it) }
+            addQueryParameter("title", anime.title)
+        }.build()
+
+        return GET(url)
     }
 
     override fun episodeListParse(response: Response): List<SEpisode> {

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -98,8 +98,13 @@ class AnimePahe :
 
     override fun animeDetailsParse(response: Response): SAnime {
         val document = response.useAsJsoup()
+        val html = document.outerHtml()
+        val animeId = ANIME_ID_REGEX.find(html)?.groupValues?.get(1)
+
         return SAnime.create().apply {
-            // We want the database to keep the /a/{id} URL permanently, so that entries never get orphaned.
+            if (animeId != null) {
+                url = "/a/$animeId"
+            }
 
             title = document.selectFirst("div.title-wrapper > h1 > span")!!.text()
             author = document.selectFirst("div.col-sm-4.anime-info p:contains(Studios:)")
@@ -260,9 +265,12 @@ class AnimePahe :
         val recommendationAnimes = document.select("div.anime-content div.anime-recommendation .mx-n1")
         return (relationAnimes + recommendationAnimes).mapNotNull { entry ->
             entry.selectFirst("h5 > a")?.let { it: Element ->
+                val sessionUrl = it.attr("href")
+                val session = sessionIdRegex.find(sessionUrl)?.groupValues?.get(1)
+                val knownId = session?.let { getIdFromCache(it) }
+
                 SAnime.create().apply {
-                    // Related animes URL using sessionId, it doesn't come with animeId
-                    setUrlWithoutDomain(it.attr("href"))
+                    setUrlWithoutDomain(knownId?.let { "/a/$it" } ?: sessionUrl)
                     title = it.ownText()
                     thumbnail_url = entry.selectFirst("img")?.attr("abs:data-src")
                 }
@@ -375,7 +383,6 @@ class AnimePahe :
     }
 
     // ============================ Video Links =============================
-
     override fun videoListRequest(episode: SEpisode): Request {
         val urlPath = episode.url.substringBefore("?")
         return GET("$baseUrl$urlPath", headers)
@@ -510,14 +517,21 @@ class AnimePahe :
     }
 
     // ============================= Utilities ==============================
-
     private fun saveSessionToCache(animeId: String, session: String) {
-        if (getSessionFromCache(animeId) != session) {
-            preferences.edit().putString("session_cache_$animeId", session).apply()
+        val idCached = getSessionFromCache(animeId) == session
+        val sessionCached = getIdFromCache(session) == animeId
+
+        if (!idCached || !sessionCached) {
+            preferences.edit()
+                .putString("session_cache_$animeId", session)
+                .putString("id_cache_$session", animeId)
+                .apply()
         }
     }
 
     private fun getSessionFromCache(animeId: String): String? = preferences.getString("session_cache_$animeId", null)
+
+    private fun getIdFromCache(session: String): String? = preferences.getString("id_cache_$session", null)
 
     private fun fetchSessionFromTitle(animeId: String, title: String?): String? {
         if (title.isNullOrBlank()) return null
@@ -558,6 +572,8 @@ class AnimePahe :
         private val DATE_FORMATTER by lazy {
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
         }
+
+        private val ANIME_ID_REGEX = Regex("""anime_id['"]?\s*[:=]\s*['"]?(\d+)""")
 
         private val QUALITY_REGEX_P by lazy { Regex("""(\d+)p""") }
         private val QUALITY_REGEX by lazy { Regex("""(\d+)""") }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -78,32 +78,27 @@ class AnimePahe :
     // =========================== Anime Details ============================
     override suspend fun getAnimeDetails(anime: SAnime): SAnime {
         val request = animeDetailsRequest(anime)
-        try {
-            client.newCall(request).execute().use { response ->
-                if (response.isSuccessful) {
-                    return animeDetailsParse(response)
-                } else {
-                    val animeId = anime.getId()
-                    if (animeId != null) {
-                        val newSession = fetchSessionFromTitle(animeId, anime.title)
-                        if (newSession != null) {
-                            saveSessionToCache(animeId, newSession)
-                            val newRequest = GET("$baseUrl/anime/$newSession")
-                            client.newCall(newRequest).execute().use { newResponse ->
-                                if (newResponse.isSuccessful) {
-                                    return animeDetailsParse(newResponse)
-                                }
-                                throw IOException("HTTP ${newResponse.code} fetching details for '${anime.title}' (ID: $animeId) at ${newRequest.url}")
-                            }
-                        }
+        client.newCall(request).execute().use { response ->
+            if (response.isSuccessful) {
+                return animeDetailsParse(response)
+            }
+        }
+
+        val animeId = anime.getId()
+        if (animeId != null) {
+            val newSession = fetchSessionFromTitle(animeId, anime.title)
+            if (newSession != null) {
+                saveSessionToCache(animeId, newSession)
+                val newRequest = GET("$baseUrl/anime/$newSession")
+                client.newCall(newRequest).execute().use { newResponse ->
+                    if (newResponse.isSuccessful) {
+                        return animeDetailsParse(newResponse)
                     }
-                    throw IOException("HTTP ${response.code} fetching details for '${anime.title}' (ID: ${animeId ?: "N/A"}) at ${request.url}")
+                    throw IOException("HTTP ${newResponse.code} fetching details for '${anime.title}' (ID: $animeId) at ${newRequest.url}")
                 }
             }
-        } catch (e: Exception) {
-            if (e is IOException) throw e
-            throw IOException("Network error fetching details for '${anime.title}' (ID: ${anime.getId() ?: "N/A"})", e)
         }
+        throw IOException("HTTP error fetching details for '${anime.title}' (ID: ${animeId ?: "N/A"}) at ${request.url}")
     }
 
     override fun animeDetailsParse(response: Response): SAnime {
@@ -300,41 +295,36 @@ class AnimePahe :
     // ============================== Episodes ==============================
     override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
         val request = episodeListRequest(anime)
-        try {
-            client.newCall(request).execute().use { response ->
-                if (response.isSuccessful) {
-                    return episodeListParse(response)
-                } else {
-                    val animeId = anime.getId()
-                    val title = anime.title
-                    if (animeId != null && title.isNotBlank()) {
-                        val newSession = fetchSessionFromTitle(animeId, title)
-                        if (newSession != null) {
-                            saveSessionToCache(animeId, newSession)
-                            val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
-                                addPathSegment("api")
-                                addQueryParameter("m", "release")
-                                addQueryParameter("id", newSession)
-                                addQueryParameter("sort", "episode_asc")
-                                addQueryParameter("page", "1")
-                                addQueryParameter("anime_id", animeId)
-                                addQueryParameter("title", title)
-                            }.build()
-                            client.newCall(GET(newUrl)).execute().use { newResponse ->
-                                if (newResponse.isSuccessful) {
-                                    return episodeListParse(newResponse)
-                                }
-                                throw IOException("HTTP ${newResponse.code} fetching episodes for '$title' (ID: $animeId) at $newUrl")
-                            }
-                        }
+        client.newCall(request).execute().use { response ->
+            if (response.isSuccessful) {
+                return episodeListParse(response)
+            }
+        }
+
+        val animeId = anime.getId()
+        val title = anime.title
+        if (animeId != null && title.isNotBlank()) {
+            val newSession = fetchSessionFromTitle(animeId, title)
+            if (newSession != null) {
+                saveSessionToCache(animeId, newSession)
+                val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
+                    addPathSegment("api")
+                    addQueryParameter("m", "release")
+                    addQueryParameter("id", newSession)
+                    addQueryParameter("sort", "episode_asc")
+                    addQueryParameter("page", "1")
+                    addQueryParameter("anime_id", animeId)
+                    addQueryParameter("title", title)
+                }.build()
+                client.newCall(GET(newUrl)).execute().use { newResponse ->
+                    if (newResponse.isSuccessful) {
+                        return episodeListParse(newResponse)
                     }
-                    throw IOException("HTTP ${response.code} fetching episodes for '$title' (ID: ${animeId ?: "N/A"}) at ${request.url}")
+                    throw IOException("HTTP ${newResponse.code} fetching episodes for '$title' (ID: $animeId) at $newUrl")
                 }
             }
-        } catch (e: Exception) {
-            if (e is IOException) throw e
-            throw IOException("Network error fetching episodes for '${anime.title}' (ID: ${anime.getId() ?: "N/A"})", e)
         }
+        throw IOException("HTTP error fetching episodes for '$title' (ID: ${animeId ?: "N/A"}) at ${request.url}")
     }
 
     override fun episodeListRequest(anime: SAnime): Request {
@@ -569,20 +559,20 @@ class AnimePahe :
 
     // ============================= Utilities ==============================
     private fun saveSessionToCache(animeId: String, session: String) {
-        val idCached = getSessionFromCache(animeId) == session
-        val sessionCached = getIdFromCache(session) == animeId
+        val idKey = SESSION_CACHE_PREFIX + animeId
+        val sessionKey = ID_CACHE_PREFIX + session
 
-        if (!idCached || !sessionCached) {
+        if (preferences.getString(idKey, null) != session || preferences.getString(sessionKey, null) != animeId) {
             preferences.edit()
-                .putString("session_cache_$animeId", session)
-                .putString("id_cache_$session", animeId)
+                .putString(idKey, session)
+                .putString(sessionKey, animeId)
                 .apply()
         }
     }
 
-    private fun getSessionFromCache(animeId: String): String? = preferences.getString("session_cache_$animeId", null)
+    private fun getSessionFromCache(animeId: String): String? = preferences.getString(SESSION_CACHE_PREFIX + animeId, null)
 
-    private fun getIdFromCache(session: String): String? = preferences.getString("id_cache_$session", null)
+    private fun getIdFromCache(session: String): String? = preferences.getString(ID_CACHE_PREFIX + session, null)
 
     private fun fetchSessionFromTitle(animeId: String, title: String?): String? {
         if (title.isNullOrBlank()) return null
@@ -667,6 +657,10 @@ class AnimePahe :
         private const val PREF_SHOW_SITE_NUMBER_TITLE = "Show Site Episode Number"
         private const val PREF_SHOW_SITE_NUMBER_DEFAULT = false
         private const val PREF_SHOW_SITE_NUMBER_SUMMARY = "Show the actual episode number from the site in the episode title"
+
+        private const val CACHE_VERSION = 1
+        private const val SESSION_CACHE_PREFIX = "v${CACHE_VERSION}_session_cache_"
+        private const val ID_CACHE_PREFIX = "v${CACHE_VERSION}_id_cache_"
 
         const val UA = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36"
         private const val PREF_CF_UA_KEY = "cf_bypass_ua"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
-import android.os.Looper
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animeextension.en.animepahe.dto.EpisodeDto
@@ -75,25 +74,28 @@ class AnimePahe :
     override val supportsLatest = false
 
     // =========================== Anime Details ============================
-    override fun animeDetailsRequest(anime: SAnime): Request {
-        val animeId = anime.getId()
-        if (animeId != null) {
-            val cachedSession = getSessionFromCache(animeId)
-            if (cachedSession != null) {
-                return GET("$baseUrl/anime/$cachedSession")
-            }
-
-            if (Looper.myLooper() != Looper.getMainLooper()) {
-                val resolvedSession = fetchSessionFromTitle(animeId, anime.title)
-                if (resolvedSession != null) {
-                    saveSessionToCache(animeId, resolvedSession) // Save to cache
-                    return GET("$baseUrl/anime/$resolvedSession")
+    override suspend fun getAnimeDetails(anime: SAnime): SAnime {
+        val request = animeDetailsRequest(anime)
+        client.newCall(request).execute().use { response ->
+            if (response.isSuccessful) {
+                return animeDetailsParse(response)
+            } else {
+                val animeId = anime.getId()
+                if (animeId != null) {
+                    val newSession = fetchSessionFromTitle(animeId, anime.title)
+                    if (newSession != null) {
+                        saveSessionToCache(animeId, newSession)
+                        val newRequest = GET("$baseUrl/anime/$newSession")
+                        client.newCall(newRequest).execute().use { newResponse ->
+                            if (newResponse.isSuccessful) {
+                                return animeDetailsParse(newResponse)
+                            }
+                        }
+                    }
                 }
+                throw Exception("HTTP ${response.code}")
             }
-
-            return GET("$baseUrl/a/$animeId")
         }
-        return GET("$baseUrl${anime.url}")
     }
 
     override fun animeDetailsParse(response: Response): SAnime {
@@ -287,59 +289,85 @@ class AnimePahe :
 
     private fun SAnime.getSession() = sessionIdRegex.find(url)?.groupValues?.get(1)
 
-    override fun episodeListRequest(anime: SAnime): Request {
-        val animeId = anime.getId()
-
-        var session = anime.getSession()
-
-        if (session == null && animeId != null) {
-            session = getSessionFromCache(animeId)
-        }
-
-        if (session == null && animeId != null && Looper.myLooper() != Looper.getMainLooper()) {
-            session = fetchSessionFromTitle(animeId, anime.title)
-            // Save mapping to cache, useful for relatedAnime entries that don't have anime_id in HTML
-            if (session != null) {
-                saveSessionToCache(animeId, session)
+    // ============================== Episodes ==============================
+    override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
+        val request = episodeListRequest(anime)
+        client.newCall(request).execute().use { response ->
+            if (response.isSuccessful) {
+                return episodeListParse(response)
+            } else {
+                val animeId = anime.getId()
+                val title = anime.title
+                if (animeId != null && title.isNotBlank()) {
+                    val newSession = fetchSessionFromTitle(animeId, title)
+                    if (newSession != null) {
+                        saveSessionToCache(animeId, newSession)
+                        val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
+                            addPathSegment("api")
+                            addQueryParameter("m", "release")
+                            addQueryParameter("id", newSession)
+                            addQueryParameter("sort", "episode_asc")
+                            addQueryParameter("page", "1")
+                            addQueryParameter("anime_id", animeId)
+                            addQueryParameter("title", title)
+                        }.build()
+                        client.newCall(GET(newUrl)).execute().use { newResponse ->
+                            if (newResponse.isSuccessful) {
+                                return episodeListParse(newResponse)
+                            }
+                        }
+                    }
+                }
+                throw Exception("HTTP ${response.code}")
             }
         }
-
-        if (session == null) {
-            throw IllegalStateException("Anime session not found. Please open the anime details page to update the URL.")
-        }
-
-        val url = baseUrl.toHttpUrl().newBuilder().apply {
-            addPathSegment("api")
-            addQueryParameter("m", "release")
-            addQueryParameter("id", session)
-            addQueryParameter("sort", "episode_asc")
-            addQueryParameter("page", "1")
-        }.build()
-
-        return GET(url)
     }
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val url = response.request.url
         val session = url.queryParameter("id")
             ?: throw IllegalStateException("Anime session not found in URL: $url")
+
+        val episodesData = response.parseAs<ResponseDto<EpisodeDto>>()
         val episodeList = mutableListOf<SEpisode>()
-        recursivePages(episodeList, response, session)
+        recursivePages(episodeList, episodesData, session, url.toString().substringBefore("&page="))
+
         val showSiteEpisodeNumber = preferences.getBoolean(PREF_SHOW_SITE_NUMBER_KEY, PREF_SHOW_SITE_NUMBER_DEFAULT)
 
-        return episodeList
-            .mapIndexed { index, episode ->
-                val siteEpisodeNumber = episode.name.removePrefix("Episode ")
-                episode.apply {
-                    episode_number = (index + 1).toFloat()
-                    name = if (showSiteEpisodeNumber && siteEpisodeNumber != (index + 1).toString()) {
-                        "Episode ${index + 1} ($siteEpisodeNumber)"
-                    } else {
-                        "Episode ${index + 1}"
-                    }
+        return episodeList.mapIndexed { index, episode ->
+            val siteEpisodeNumber = episode.name.removePrefix("Episode ")
+            episode.apply {
+                episode_number = (index + 1).toFloat()
+                name = if (showSiteEpisodeNumber && siteEpisodeNumber != (index + 1).toString()) {
+                    "Episode ${index + 1} ($siteEpisodeNumber)"
+                } else {
+                    "Episode ${index + 1}"
                 }
             }
-            .reversed()
+        }.reversed()
+    }
+
+    private fun recursivePages(
+        episodeList: MutableList<SEpisode>,
+        episodesData: ResponseDto<EpisodeDto>,
+        animeSession: String,
+        urlWithoutPage: String,
+    ) {
+        val page = episodesData.currentPage
+        val hasNextPage = page < episodesData.lastPage
+
+        if (episodesData.items.isNotEmpty()) {
+            val animeId = episodesData.items.first().animeId.toString()
+            saveSessionToCache(animeId, animeSession)
+        }
+
+        episodeList.addAll(parseEpisodePage(episodesData.items, animeSession))
+        if (hasNextPage) {
+            nextPageRequest(urlWithoutPage, page + 1).use { nextPage ->
+                val nextData = nextPage.parseAs<ResponseDto<EpisodeDto>>()
+                recursivePages(episodeList, nextData, animeSession, urlWithoutPage)
+            }
+        }
     }
 
     private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String): MutableList<SEpisode> = episodes.map { episode ->
@@ -358,26 +386,8 @@ class AnimePahe :
         }
     }.toMutableList()
 
-    private fun recursivePages(episodeList: MutableList<SEpisode>, response: Response, animeSession: String) {
-        val episodesData = response.parseAs<ResponseDto<EpisodeDto>>()
-        val page = episodesData.currentPage
-        val hasNextPage = page < episodesData.lastPage
-
-        if (episodesData.items.isNotEmpty()) {
-            val animeId = episodesData.items.first().animeId.toString()
-            saveSessionToCache(animeId, animeSession)
-        }
-
-        episodeList.addAll(parseEpisodePage(episodesData.items, animeSession))
-        if (hasNextPage) {
-            nextPageRequest(response.request.url.toString(), page + 1).use { nextPage ->
-                recursivePages(episodeList, nextPage, animeSession)
-            }
-        }
-    }
-
-    private fun nextPageRequest(url: String, page: Int): Response {
-        val request = GET(url.substringBeforeLast("&page=") + "&page=$page")
+    private fun nextPageRequest(urlWithoutPage: String, page: Int): Response {
+        val request = GET("$urlWithoutPage&page=$page")
         return client.newCall(request).execute()
     }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -76,6 +76,7 @@ class AnimePahe :
     override val supportsLatest = false
 
     // =========================== Anime Details ============================
+
     /*** AnimePahe gives anime page {session_id} that varies after a few days.
      *   Code was remade so that it could fetch new {session_id}
      *   from a constant {anime_id}, which can be found in airing/search

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
-import android.os.Looper
 import android.util.Log
 import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceScreen
@@ -18,6 +17,7 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.await
 import keiyoushi.utils.addEditTextPreference
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSwitchPreference
@@ -77,57 +77,42 @@ class AnimePahe :
     override val supportsLatest = false
 
     // =========================== Anime Details ============================
-    override suspend fun getAnimeDetails(anime: SAnime): SAnime {
-        val request = animeDetailsRequest(anime)
-        client.newCall(request).execute().use { response ->
-            if (response.isSuccessful) {
-                return animeDetailsParse(response)
-            }
-        }
-
+    override fun getAnimeUrl(anime: SAnime): String {
         val animeId = anime.getId()
-        if (animeId != null) {
-            val newSession = fetchSessionFromTitle(animeId, anime.title)
-            if (newSession != null) {
-                saveSessionToCache(animeId, newSession)
-                val newRequest = GET("$baseUrl/anime/$newSession")
-                client.newCall(newRequest).execute().use { newResponse ->
-                    if (newResponse.isSuccessful) {
-                        return animeDetailsParse(newResponse)
-                    }
-                    throw IOException("HTTP ${newResponse.code} fetching details for '${anime.title}' (ID: $animeId) at ${newRequest.url}")
-                }
-            }
+        val cachedSession = animeId?.let { getSessionFromCache(it) }
+        return if (cachedSession != null) {
+            "$baseUrl/anime/$cachedSession"
+        } else {
+            "$baseUrl${anime.url}"
         }
-        throw IOException("HTTP error fetching details for '${anime.title}' (ID: ${animeId ?: "N/A"}) at ${request.url}")
     }
 
-    override fun animeDetailsRequest(anime: SAnime): Request {
-        val session = anime.getSession()
-        if (session != null) {
-            val urlPath = anime.url.substringBefore("?")
-            return GET("$baseUrl$urlPath")
+    override fun animeDetailsRequest(anime: SAnime): Request = GET(getAnimeUrl(anime), headers)
+
+    override suspend fun getAnimeDetails(anime: SAnime): SAnime {
+        val request = animeDetailsRequest(anime)
+        val response = client.newCall(request).await()
+
+        if (response.isSuccessful) {
+            return response.use { animeDetailsParse(it) }
         }
+        response.close()
 
         val animeId = anime.getId()
-        if (animeId != null) {
-            val cachedSession = getSessionFromCache(animeId)
-            if (cachedSession != null) {
-                return GET("$baseUrl/anime/$cachedSession")
-            }
+        val result = fetchSessionAndId(animeId, anime.title)
 
-            if (Looper.myLooper() != Looper.getMainLooper()) {
-                val resolvedSession = fetchSessionFromTitle(animeId, anime.title)
-                if (resolvedSession != null) {
-                    saveSessionToCache(animeId, resolvedSession) // Save to cache
-                    return GET("$baseUrl/anime/$resolvedSession")
-                }
+        if (result != null) {
+            val (newId, newSession) = result
+            saveSessionToCache(newId, newSession)
+            val newRequest = GET("$baseUrl/anime/$newSession", headers)
+            val newResponse = client.newCall(newRequest).await()
+            if (newResponse.isSuccessful) {
+                return newResponse.use { animeDetailsParse(it) }
             }
-
-            return GET("$baseUrl/a/$animeId")
+            newResponse.close()
+            throw IOException("HTTP ${newResponse.code} fetching details for '${anime.title}' (ID: $newId) at ${newRequest.url}")
         }
-
-        return GET("$baseUrl${anime.url}")
+        throw IOException("HTTP error fetching details for '${anime.title}' (ID: ${animeId ?: "N/A"}) at ${request.url}")
     }
 
     override fun animeDetailsParse(response: Response): SAnime {
@@ -303,7 +288,8 @@ class AnimePahe :
                 val knownId = session?.let { getIdFromCache(it) }
 
                 SAnime.create().apply {
-                    setUrlWithoutDomain(knownId?.let { "/a/$it" } ?: sessionUrl)
+                    // If we know the ID from cache, use /a/{id} so it matches the library
+                    setUrlWithoutDomain(knownId?.let { id -> "/a/$id" } ?: sessionUrl)
                     title = it.ownText()
                     thumbnail_url = entry.selectFirst("img")?.attr("abs:data-src")
                 }
@@ -319,56 +305,21 @@ class AnimePahe :
     private fun SAnime.getId() = newAnimeIdRegex.find(url)?.groupValues?.get(1)
         ?: oldQueryIdRegex.find(url)?.groupValues?.get(1)
 
-    private fun SAnime.getSession() = sessionIdRegex.find(url)?.groupValues?.get(1)
-
-    // ============================== Episodes ==============================
     override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
-        val request = episodeListRequest(anime)
-        client.newCall(request).execute().use { response ->
-            if (response.isSuccessful) {
-                return episodeListParse(response)
-            }
-        }
-
         val animeId = anime.getId()
-        val title = anime.title
-        if (animeId != null && title.isNotBlank()) {
-            val newSession = fetchSessionFromTitle(animeId, title)
-            if (newSession != null) {
-                saveSessionToCache(animeId, newSession)
-                val newUrl = baseUrl.toHttpUrl().newBuilder().apply {
-                    addPathSegment("api")
-                    addQueryParameter("m", "release")
-                    addQueryParameter("id", newSession)
-                    addQueryParameter("sort", "episode_asc")
-                    addQueryParameter("page", "1")
-                    addQueryParameter("anime_id", animeId)
-                    addQueryParameter("title", title)
-                }.build()
-                client.newCall(GET(newUrl)).execute().use { newResponse ->
-                    if (newResponse.isSuccessful) {
-                        return episodeListParse(newResponse)
-                    }
-                    throw IOException("HTTP ${newResponse.code} fetching episodes for '$title' (ID: $animeId) at $newUrl")
-                }
-            }
-        }
-        throw IOException("HTTP error fetching episodes for '$title' (ID: ${animeId ?: "N/A"}) at ${request.url}")
-    }
+        var session = animeId?.let { getSessionFromCache(it) }
 
-    override fun episodeListRequest(anime: SAnime): Request {
-        val animeId = anime.getId()
-        var session = anime.getSession() ?: animeId?.let { getSessionFromCache(it) }
-
-        if (session == null && animeId != null && Looper.myLooper() != Looper.getMainLooper()) {
-            session = fetchSessionFromTitle(animeId, anime.title)
-            if (session != null) {
-                saveSessionToCache(animeId, session)
+        if (session == null) {
+            val result = fetchSessionAndId(animeId, anime.title)
+            if (result != null) {
+                val (newId, newSession) = result
+                saveSessionToCache(newId, newSession)
+                session = newSession
             }
         }
 
         if (session == null) {
-            throw IllegalStateException("Anime session not found.")
+            throw IOException("Anime session not found for '${anime.title}' (ID: ${animeId ?: "N/A"})")
         }
 
         val url = baseUrl.toHttpUrl().newBuilder().apply {
@@ -377,21 +328,64 @@ class AnimePahe :
             addQueryParameter("id", session)
             addQueryParameter("sort", "episode_asc")
             addQueryParameter("page", "1")
-            animeId?.let { addQueryParameter("anime_id", it) }
-            addQueryParameter("title", anime.title)
+        }.build()
+
+        val response = client.newCall(GET(url)).await()
+        if (!response.isSuccessful) {
+            response.close()
+            val result = fetchSessionAndId(animeId, anime.title)
+            if (result != null) {
+                val (newId, newSession) = result
+                if (newSession != session) {
+                    saveSessionToCache(newId, newSession)
+                    val newUrl = url.newBuilder().setQueryParameter("id", newSession).build()
+                    val newResponse = client.newCall(GET(newUrl)).await()
+                    if (newResponse.isSuccessful) {
+                        return newResponse.use { fetchEpisodes(it, newSession) }
+                    }
+                    newResponse.close()
+                    throw IOException("HTTP ${newResponse.code} fetching episodes for '${anime.title}' (ID: $newId) at $newUrl")
+                }
+            }
+            throw IOException("HTTP ${response.code} fetching episodes for '${anime.title}' (ID: ${animeId ?: "N/A"}) at $url")
+        }
+
+        return response.use { fetchEpisodes(it, session) }
+    }
+
+    override fun episodeListRequest(anime: SAnime): Request {
+        val animeId = anime.getId()
+        val session = animeId?.let { getSessionFromCache(it) } ?: throw IllegalStateException("Anime session not found.")
+        val url = baseUrl.toHttpUrl().newBuilder().apply {
+            addPathSegment("api")
+            addQueryParameter("m", "release")
+            addQueryParameter("id", session)
+            addQueryParameter("sort", "episode_asc")
+            addQueryParameter("page", "1")
         }.build()
 
         return GET(url)
     }
 
-    override fun episodeListParse(response: Response): List<SEpisode> {
-        val url = response.request.url
-        val session = url.queryParameter("id")
-            ?: throw IllegalStateException("Anime session not found in URL: $url")
+    override fun episodeListParse(response: Response): List<SEpisode> = emptyList()
 
-        val episodesData = response.parseAs<ResponseDto<EpisodeDto>>()
+    private suspend fun fetchEpisodes(response: Response, session: String): List<SEpisode> {
         val episodeList = mutableListOf<SEpisode>()
-        recursivePages(episodeList, episodesData, session, url.toString().substringBefore("&page="))
+        val urlWithoutPage = response.request.url.toString().substringBefore("&page=")
+        var currentData = response.parseAs<ResponseDto<EpisodeDto>>()
+
+        if (currentData.items.isNotEmpty()) {
+            val animeId = currentData.items.first().animeId.toString()
+            saveSessionToCache(animeId, session)
+        }
+
+        while (true) {
+            episodeList.addAll(parseEpisodePage(currentData.items, session))
+            if (currentData.currentPage >= currentData.lastPage) break
+
+            val nextUrl = "$urlWithoutPage&page=${currentData.currentPage + 1}"
+            currentData = client.newCall(GET(nextUrl)).await().use { it.parseAs() }
+        }
 
         val showSiteEpisodeNumber = preferences.getBoolean(PREF_SHOW_SITE_NUMBER_KEY, PREF_SHOW_SITE_NUMBER_DEFAULT)
 
@@ -406,29 +400,6 @@ class AnimePahe :
                 }
             }
         }.reversed()
-    }
-
-    private fun recursivePages(
-        episodeList: MutableList<SEpisode>,
-        episodesData: ResponseDto<EpisodeDto>,
-        animeSession: String,
-        urlWithoutPage: String,
-    ) {
-        val page = episodesData.currentPage
-        val hasNextPage = page < episodesData.lastPage
-
-        if (episodesData.items.isNotEmpty()) {
-            val animeId = episodesData.items.first().animeId.toString()
-            saveSessionToCache(animeId, animeSession)
-        }
-
-        episodeList.addAll(parseEpisodePage(episodesData.items, animeSession))
-        if (hasNextPage) {
-            nextPageRequest(urlWithoutPage, page + 1).use { nextPage ->
-                val nextData = nextPage.parseAs<ResponseDto<EpisodeDto>>()
-                recursivePages(episodeList, nextData, animeSession, urlWithoutPage)
-            }
-        }
     }
 
     private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String): MutableList<SEpisode> = episodes.map { episode ->
@@ -447,15 +418,10 @@ class AnimePahe :
         }
     }.toMutableList()
 
-    private fun nextPageRequest(urlWithoutPage: String, page: Int): Response {
-        val request = GET("$urlWithoutPage&page=$page")
-        return client.newCall(request).execute()
-    }
-
     // ============================ Video Links =============================
     override fun videoListRequest(episode: SEpisode): Request {
         // Strip the `?anime_id=...` query parameter.
-        // This parameter is strictly for database mapping and orphan prevention.
+        // This parameter is strictly for database mapping and orphaning prevention.
         val urlPath = episode.url.substringBefore("?")
         return GET("$baseUrl$urlPath", headers)
     }
@@ -590,8 +556,8 @@ class AnimePahe :
 
     // ============================= Utilities ==============================
     private fun saveSessionToCache(animeId: String, session: String) {
-        val idKey = SESSION_CACHE_PREFIX + animeId
-        val sessionKey = ID_CACHE_PREFIX + session
+        val idKey = "session_cache_$animeId"
+        val sessionKey = "id_cache_$session"
 
         if (preferences.getString(idKey, null) != session || preferences.getString(sessionKey, null) != animeId) {
             preferences.edit()
@@ -601,11 +567,11 @@ class AnimePahe :
         }
     }
 
-    private fun getSessionFromCache(animeId: String): String? = preferences.getString(SESSION_CACHE_PREFIX + animeId, null)
+    private fun getSessionFromCache(animeId: String): String? = preferences.getString("session_cache_$animeId", null)
 
-    private fun getIdFromCache(session: String): String? = preferences.getString(ID_CACHE_PREFIX + session, null)
+    private fun getIdFromCache(session: String): String? = preferences.getString("id_cache_$session", null)
 
-    private fun fetchSessionFromTitle(animeId: String, title: String?): String? {
+    private suspend fun fetchSessionAndId(animeId: String?, title: String?): Pair<String, String>? {
         if (title.isNullOrBlank()) return null
 
         val searchUrl = baseUrl.toHttpUrl().newBuilder().apply {
@@ -615,9 +581,17 @@ class AnimePahe :
         }.build()
 
         return try {
-            client.newCall(GET(searchUrl)).execute().use { response ->
+            client.newCall(GET(searchUrl)).await().use { response ->
+                if (!response.isSuccessful) return null
                 val searchData = response.parseAs<ResponseDto<SearchResultDto>>()
-                searchData.items.firstOrNull { it.id.toString() == animeId }?.session
+
+                val matchedAnime = if (animeId != null) {
+                    searchData.items.firstOrNull { it.id.toString() == animeId }
+                } else {
+                    searchData.items.firstOrNull()
+                }
+
+                matchedAnime?.let { it.id.toString() to it.session }
             }
         } catch (e: Exception) {
             Log.e("AnimePahe", "Error fetching session for ID $animeId ('$title')", e)
@@ -687,10 +661,6 @@ class AnimePahe :
         private const val PREF_SHOW_SITE_NUMBER_TITLE = "Show Site Episode Number"
         private const val PREF_SHOW_SITE_NUMBER_DEFAULT = false
         private const val PREF_SHOW_SITE_NUMBER_SUMMARY = "Show the actual episode number from the site in the episode title"
-
-        private const val CACHE_VERSION = 1
-        private const val SESSION_CACHE_PREFIX = "v${CACHE_VERSION}_session_cache_"
-        private const val ID_CACHE_PREFIX = "v${CACHE_VERSION}_id_cache_"
 
         const val UA = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36"
         private const val PREF_CF_UA_KEY = "cf_bypass_ua"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -332,6 +332,8 @@ class AnimePahe :
     private fun SAnime.getId() = newAnimeIdRegex.find(url)?.groupValues?.get(1)
         ?: oldQueryIdRegex.find(url)?.groupValues?.get(1)
 
+    private fun SAnime.getSession() = sessionIdRegex.find(url)?.groupValues?.get(1)
+
     override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
         val animeId = anime.getId()
         var session = animeId?.let { getSessionFromCache(it) }
@@ -382,11 +384,14 @@ class AnimePahe :
 
     override fun episodeListRequest(anime: SAnime): Request {
         val animeId = anime.getId()
-        val session = animeId?.let { getSessionFromCache(it) }
+        val session = animeId?.let { getSessionFromCache(it) } ?: anime.getSession()
+        if (session == null) {
+            throw IllegalStateException("Anime session not found.")
+        }
         val url = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("api")
             addQueryParameter("m", "release")
-            addQueryParameter("id", session ?: "")
+            addQueryParameter("id", session)
             addQueryParameter("sort", "episode_asc")
             addQueryParameter("page", "1")
         }.build()
@@ -616,7 +621,7 @@ class AnimePahe :
                     searchData.items.firstOrNull { it.id.toString() == animeId }
                 } else {
                     val normalizedQuery = normalizeTitle(title)
-                    searchData.items.firstOrNull { normalizeTitle(it.title) == normalizedQuery }
+                    searchData.items.firstOrNull { normalizeTitle(it.title).contains(normalizedQuery) }
                 }
 
                 if (matchedAnime == null) return null

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/dto/AnimePaheDto.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/dto/AnimePaheDto.kt
@@ -17,26 +17,25 @@ data class ResponseDto<T>(
 
 @Serializable
 data class LatestAnimeDto(
-    @SerialName("anime_title")
-    val title: String,
+    @SerialName("anime_id") val id: Int,
+    @SerialName("anime_session") val session: String,
+    @SerialName("anime_title") val title: String,
     val snapshot: String,
-    @SerialName("anime_id")
-    val id: Int,
-    val fansub: String,
+    val fansub: String? = null,
 )
 
 @Serializable
 data class SearchResultDto(
+    val id: Int,
     val title: String,
     val poster: String,
-    val id: Int,
+    val session: String,
 )
 
 @Serializable
 data class EpisodeDto(
-    @SerialName("created_at")
-    val createdAt: String,
+    @SerialName("created_at") val createdAt: String,
     val session: String,
-    @SerialName("episode")
-    val episodeNumber: Float,
+    @SerialName("episode") val episodeNumber: Float,
+    @SerialName("anime_id") val animeId: Int,
 )


### PR DESCRIPTION
Closes #760.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve AnimePahe handling of non-permanent anime URLs and resolve 404 errors by introducing session/id caching and resilient API-based lookups.

New Features:
- Cache AnimePahe anime session IDs and corresponding anime IDs in shared preferences to provide stable library and related-anime links despite expiring sessions.

Bug Fixes:
- Fix 404 errors when loading anime details and episode lists by falling back to search API to refresh expired session IDs and retry requests.
- Ensure episode playback URLs remain valid by removing reliance on deprecated stable episode URLs and stripping database-only query parameters from video links.

Enhancements:
- Refactor AnimePahe requests to use suspend-compatible HTTP calls and paginated episode fetching via the API.
- Update DTO models to include anime ID and session fields so latest, search, and episode responses can be consistently tied back to canonical anime IDs.
- Standardize URL patterns to use canonical /a/{anime_id} for library entries and related anime when possible.

Build:
- Bump AnimePahe extension version code to 47.