### PR TITLE
AnimePahe [EN]: Normalize Title Search Fallback

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 47
+    extVersionCode = 48
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -609,10 +609,35 @@ class AnimePahe :
     private suspend fun fetchSessionAndId(animeId: String?, title: String?): Pair<String, String>? {
         if (title.isNullOrBlank()) return null
 
+        val searchQuery = normalizeSearchQuery(title)
+        val words = searchQuery.split(" ").filter { it.isNotBlank() }
+
+        // Full normalized title
+        var result = searchApiForId(animeId, title, searchQuery)
+        if (result != null) return result
+
+        // Last 4 words e.g. "Dungeon IV Part 2" or "Break Time From Zero"
+        if (words.size > 4) {
+            val last4 = words.takeLast(4).joinToString(" ")
+            result = searchApiForId(animeId, title, last4)
+            if (result != null) return result
+        }
+
+        // Last 3 words e.g. "IV Part 2" or "Time From Zero"
+        if (words.size > 3) {
+            val last3 = words.takeLast(3).joinToString(" ")
+            result = searchApiForId(animeId, title, last3)
+            if (result != null) return result
+        }
+
+        return null
+    }
+
+    private suspend fun searchApiForId(animeId: String?, originalTitle: String, query: String): Pair<String, String>? {
         val searchUrl = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("api")
             addQueryParameter("m", "search")
-            addQueryParameter("q", title)
+            addQueryParameter("q", query)
         }.build()
 
         return try {
@@ -623,18 +648,21 @@ class AnimePahe :
                 val matchedAnime = if (animeId != null) {
                     searchData.items.firstOrNull { it.id.toString() == animeId }
                 } else {
-                    val normalizedQuery = normalizeTitle(title)
-                    searchData.items.firstOrNull { normalizeTitle(it.title).contains(normalizedQuery) }
+                    val normalizedQuery = normalizeTitle(originalTitle)
+                    searchData.items.firstOrNull { normalizeTitle(it.title) == normalizedQuery }
                 }
 
-                if (matchedAnime == null) return null
-
-                matchedAnime.let { it.id.toString() to it.session }
+                matchedAnime?.let { it.id.toString() to it.session }
             }
         } catch (_: Exception) {
             null
         }
     }
+
+    private fun normalizeSearchQuery(raw: String): String = raw
+        .replace(SEARCH_NORMALIZE_REGEX, "")
+        .replace(SPACE_NORMALIZE_REGEX, " ")
+        .trim()
 
     private fun normalizeTitle(raw: String): String = raw
         .lowercase()
@@ -663,7 +691,8 @@ class AnimePahe :
         }
 
         private val NORMALIZE_REGEX = Regex("[^a-z0-9]+")
-
+        private val SPACE_NORMALIZE_REGEX = Regex("\\s+")
+        private val SEARCH_NORMALIZE_REGEX = Regex("[^a-zA-Z0-9\\s]+")
         private val QUALITY_REGEX_P by lazy { Regex("""(\d+)p""") }
         private val QUALITY_REGEX by lazy { Regex("""(\d+)""") }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -612,28 +612,28 @@ class AnimePahe :
         val searchQuery = normalizeSearchQuery(title)
         val words = searchQuery.split(" ").filter { it.isNotBlank() }
 
-        // Full normalized title
-        var result = searchApiForId(animeId, title, searchQuery)
+        val normalizedTitle = normalizeTitle(title)
+
+        // Define the trailing lengths we want to try
+        // e.g. 4 words ("Dungeon IV Part 2"), 3 words ("IV Part 2")
+        val trailingLengths = listOf(4, 3)
+
+        // Try searching with the full normalized title first
+        var result = searchApiForId(animeId, normalizedTitle, searchQuery)
         if (result != null) return result
 
-        // Last 4 words e.g. "Dungeon IV Part 2" or "Break Time From Zero"
-        if (words.size > 4) {
-            val last4 = words.takeLast(4).joinToString(" ")
-            result = searchApiForId(animeId, title, last4)
-            if (result != null) return result
-        }
-
-        // Last 3 words e.g. "IV Part 2" or "Time From Zero"
-        if (words.size > 3) {
-            val last3 = words.takeLast(3).joinToString(" ")
-            result = searchApiForId(animeId, title, last3)
-            if (result != null) return result
+        for (len in trailingLengths) {
+            if (words.size > len) {
+                val shortQuery = words.takeLast(len).joinToString(" ")
+                result = searchApiForId(animeId, normalizedTitle, shortQuery)
+                if (result != null) return result
+            }
         }
 
         return null
     }
 
-    private suspend fun searchApiForId(animeId: String?, originalTitle: String, query: String): Pair<String, String>? {
+    private suspend fun searchApiForId(animeId: String?, normalizedTitle: String?, query: String): Pair<String, String>? {
         val searchUrl = baseUrl.toHttpUrl().newBuilder().apply {
             addPathSegment("api")
             addQueryParameter("m", "search")
@@ -647,9 +647,10 @@ class AnimePahe :
 
                 val matchedAnime = if (animeId != null) {
                     searchData.items.firstOrNull { it.id.toString() == animeId }
+                } else if (normalizedTitle != null) {
+                    searchData.items.firstOrNull { normalizeTitle(it.title) == normalizedTitle }
                 } else {
-                    val normalizedQuery = normalizeTitle(originalTitle)
-                    searchData.items.firstOrNull { normalizeTitle(it.title) == normalizedQuery }
+                    null
                 }
 
                 matchedAnime?.let { it.id.toString() to it.session }


### PR DESCRIPTION
Closes #765.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve AnimePahe extension title-based search to use normalized queries and more precise matching, and bump the extension version code.

Bug Fixes:
- Resolve cases where AnimePahe session and ID lookup fails due to unnormalized or partially matching titles by introducing normalized search queries and multi-step fallback matching.

Enhancements:
- Refine AnimePahe title matching to use exact normalized comparisons and structured query fallbacks for more reliable search results.

Build:
- Increment AnimePahe extension extVersionCode from 47 to 48.