### PR TITLE
AnimeQ [PT]: Update domain and fix video extraction

### DIFF
--- a/src/pt/animeq/build.gradle
+++ b/src/pt/animeq/build.gradle
@@ -2,8 +2,8 @@ ext {
     extName = 'AnimeQ'
     extClass = '.AnimeQ'
     themePkg = 'dooplay'
-    baseUrl = 'https://animeq.net'
-    overrideVersionCode = 2
+    baseUrl = 'https://animeq.blog'
+    overrideVersionCode = 3
     isNsfw = true
 }
 

--- a/src/pt/animeq/src/eu/kanade/tachiyomi/animeextension/pt/animeq/AnimeQ.kt
+++ b/src/pt/animeq/src/eu/kanade/tachiyomi/animeextension/pt/animeq/AnimeQ.kt
@@ -9,8 +9,6 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.multisrc.dooplay.DooPlay
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.awaitSuccess
-import keiyoushi.utils.bodyString
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.useAsJsoup
@@ -25,7 +23,7 @@ class AnimeQ :
     DooPlay(
         "pt-BR",
         "AnimeQ",
-        "https://animeq.net",
+        "https://animeq.blog",
     ) {
     // ============================== Popular ===============================
     override fun popularAnimeSelector() = "article.w_item_a > a, article.w_item_b > a"
@@ -115,7 +113,7 @@ class AnimeQ :
     // ============================ Video Links =============================
     override fun videoListParse(response: Response): List<Video> {
         val document = response.useAsJsoup()
-        val players = document.select("ul#playeroptionsul li")
+        val players = document.select("div.animeq-player__source[data-animeq-source]")
         return players.parallelCatchingFlatMapBlocking(::getPlayerVideos)
     }
 
@@ -123,7 +121,13 @@ class AnimeQ :
     private val universalExtractor by lazy { UniversalExtractor(client) }
 
     private suspend fun getPlayerVideos(player: Element): List<Video> {
-        val name = player.selectFirst("span.title")?.text()
+        val sourceIndex = player.attr("data-animeq-source")
+        val name = (
+            player.selectFirst("iframe[title]")?.attr("title")
+                ?: player.closest("section.animeq-player")
+                    ?.selectFirst("button[data-animeq-switch=$sourceIndex]")
+                    ?.attr("data-source-name")
+            )
             ?.run {
                 when (this.uppercase()) {
                     "SD" -> "360p"
@@ -153,6 +157,12 @@ class AnimeQ :
                     Video(videoUrl, name, videoUrl, videoHeaders),
                 )
             }
+            url.contains(".mp4", ignoreCase = true) || "stream.php" in url -> {
+                val videoHeaders = headers.newBuilder()
+                    .set("Referer", "$baseUrl/")
+                    .build()
+                listOf(Video(url, name, url, videoHeaders))
+            }
 
             else -> emptyList()
         }
@@ -163,15 +173,19 @@ class AnimeQ :
         return videos
     }
 
-    private suspend fun getPlayerUrl(player: Element): String {
-        val type = player.attr("data-type")
-        val id = player.attr("data-post")
-        val num = player.attr("data-nume")
-        return client.newCall(GET("$baseUrl/wp-json/dooplayer/v2/$id/$type/$num"))
-            .awaitSuccess().bodyString()
-            .substringAfter("\"embed_url\":\"")
-            .substringBefore("\",")
-            .replace("\\", "")
+    private fun getPlayerUrl(player: Element): String {
+        val iframe = player.selectFirst("iframe")
+        val iframeUrl = iframe?.attr("abs:data-lazy-src")
+            ?.takeIf { it.isNotBlank() && !it.startsWith("about:") }
+            ?: iframe?.attr("abs:src")
+                ?.takeIf { it.isNotBlank() && !it.startsWith("about:") }
+
+        if (!iframeUrl.isNullOrBlank()) return iframeUrl
+
+        val source = player.selectFirst("video source[src], source[src], video[src]") ?: return ""
+        return source.attr("abs:src")
+            .ifBlank { source.attr("src") }
+            .replace("&amp;", "&")
     }
 
     // ============================== Filters ===============================


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the AnimeQ PT extension to use the new domain and player structure to restore video playback.

Bug Fixes:
- Fix video list extraction by targeting the updated player elements and handling iframe/source URLs directly.
- Ensure direct MP4 and stream.php video links are playable with appropriate Referer headers.

Enhancements:
- Update AnimeQ base URL configuration and bump overrideVersionCode for the PT extension to reflect the new site domain.