### PR TITLE
Skip processing if no M3U8 URLs in video list

### DIFF
--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8Integration.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8Integration.kt
@@ -61,6 +61,8 @@ class M3u8Integration(
      * @return Processed video list
      */
     fun processVideoList(videos: List<Video>): List<Video> {
+        if (videos.none { isM3u8Url(it.url) }) return videos
+
         initializeServer()
         return videos.map { video ->
             if (isM3u8Url(video.url)) {


### PR DESCRIPTION
Add a check to skip server spin up if no M3U8 URLs are found. Didn't update extensions because it's not a bugfix, just small perf optimization which could save a bit of boilerplate or resources if lib is used uncorrectly or source changes.

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
---

## Summary by Sourcery

Enhancements:
- Add a guard in video processing to return early when no M3U8 URLs are present, reducing overhead in invalid or non-HLS inputs.