### PR TITLE
HentaiHaven[EN]: Migrate to AnimeHttpSource and clean up

### DIFF
--- a/src/en/hentaihaven/AndroidManifest.xml
+++ b/src/en/hentaihaven/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/src/en/hentaihaven/build.gradle
+++ b/src/en/hentaihaven/build.gradle
@@ -1,14 +1,13 @@
 ext {
     extName = 'HentaiHaven'
     extClass = '.HentaiHaven'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 
 apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
-    implementation(libs.jsoup)
     implementation(project(":lib:m3u8server"))
     implementation(project(":lib:playlistutils"))
 }

--- a/src/en/hentaihaven/src/eu/kanade/tachiyomi/animeextension/en/hentaihaven/HentaiHaven.kt
+++ b/src/en/hentaihaven/src/eu/kanade/tachiyomi/animeextension/en/hentaihaven/HentaiHaven.kt
@@ -10,7 +10,7 @@ import eu.kanade.tachiyomi.animesource.model.AnimesPage
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
-import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
+import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.getPreferencesLazy
@@ -22,7 +22,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
 class HentaiHaven :
-    ParsedAnimeHttpSource(),
+    AnimeHttpSource(),
     ConfigurableAnimeSource {
 
     override val name = "HentaiHaven"
@@ -30,7 +30,7 @@ class HentaiHaven :
     override val lang = "en"
     override val supportsLatest = true
 
-    override val client = network.cloudflareClient.newBuilder()
+    override val client = network.client.newBuilder()
         .addInterceptor { chain ->
             val request = chain.request().newBuilder()
                 .header("Accept-Language", "en-US,en;q=0.9")
@@ -46,6 +46,10 @@ class HentaiHaven :
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_DEFAULT = "1080p"
         private val QUALITY_OPTIONS = arrayOf("1080p", "720p", "360p")
+
+        private const val ANIME_LIST_SELECTOR = "div.page-item-detail.video"
+        private const val NEXT_PAGE_SELECTOR = "a.nextpostslink, div.wp-pagenavi a.next"
+        private const val SEARCH_SELECTOR = "div.c-tabs-item, div.page-item-detail.video"
     }
 
     // ── Preferences ───────────────────────────────────────────────────────────
@@ -65,10 +69,14 @@ class HentaiHaven :
 
     override fun popularAnimeRequest(page: Int): Request = GET("$baseUrl/page/$page/?m_orderby=views", headers)
 
-    override fun popularAnimeSelector() = "div.page-item-detail.video"
-    override fun popularAnimeNextPageSelector() = "a.nextpostslink, div.wp-pagenavi a.next"
+    override fun popularAnimeParse(response: Response): AnimesPage {
+        val document = response.useAsJsoup()
+        val animes = document.select(ANIME_LIST_SELECTOR).map(::animeFromElement)
+        val hasNextPage = document.selectFirst(NEXT_PAGE_SELECTOR) != null
+        return AnimesPage(animes, hasNextPage)
+    }
 
-    override fun popularAnimeFromElement(element: Element): SAnime = SAnime.create().apply {
+    private fun animeFromElement(element: Element): SAnime = SAnime.create().apply {
         setUrlWithoutDomain(element.selectFirst("div.item-thumb a")?.attr("href") ?: "")
         title = element.selectFirst("div.post-title a, h3.h5 a")?.text() ?: ""
         thumbnail_url = element.selectFirst("img")?.attr("abs:src")
@@ -78,9 +86,7 @@ class HentaiHaven :
 
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/page/$page/?m_orderby=latest", headers)
 
-    override fun latestUpdatesSelector() = popularAnimeSelector()
-    override fun latestUpdatesNextPageSelector() = popularAnimeNextPageSelector()
-    override fun latestUpdatesFromElement(element: Element) = popularAnimeFromElement(element)
+    override fun latestUpdatesParse(response: Response): AnimesPage = popularAnimeParse(response)
 
     // ── Search ────────────────────────────────────────────────────────────────
 
@@ -111,26 +117,23 @@ class HentaiHaven :
         return GET(urlBuilder.build().toString(), headers)
     }
 
-    override fun searchAnimeSelector() = "div.c-tabs-item, div.page-item-detail.video"
-    override fun searchAnimeNextPageSelector() = popularAnimeNextPageSelector()
+    override fun searchAnimeParse(response: Response): AnimesPage {
+        val document = response.useAsJsoup()
+        val items = document.select(SEARCH_SELECTOR)
+            .map(::searchAnimeFromElement)
+            .distinctBy { it.url }
+            .filter { it.url.isNotBlank() && it.title.isNotBlank() }
+        val hasNextPage = document.selectFirst(NEXT_PAGE_SELECTOR) != null
+        return AnimesPage(items, hasNextPage)
+    }
 
-    override fun searchAnimeFromElement(element: Element): SAnime = SAnime.create().apply {
+    private fun searchAnimeFromElement(element: Element): SAnime = SAnime.create().apply {
         val linkEl = element.selectFirst("a[href*='/watch/']")
         setUrlWithoutDomain(linkEl?.attr("href") ?: "")
         title = linkEl?.attr("title")?.takeIf { it.isNotBlank() }
             ?: element.selectFirst("div.post-title a, h3 a, h4 a")?.text()
             ?: ""
         thumbnail_url = element.selectFirst("img")?.attr("abs:src")
-    }
-
-    override fun searchAnimeParse(response: Response): AnimesPage {
-        val document = response.useAsJsoup()
-        val items = document.select(searchAnimeSelector())
-            .map { searchAnimeFromElement(it) }
-            .distinctBy { it.url }
-            .filter { it.url.isNotBlank() && it.title.isNotBlank() }
-        val hasNextPage = document.selectFirst(searchAnimeNextPageSelector()) != null
-        return AnimesPage(items, hasNextPage)
     }
 
     override fun getFilterList() = AnimeFilterList(
@@ -143,7 +146,8 @@ class HentaiHaven :
 
     // ── Details ───────────────────────────────────────────────────────────────
 
-    override fun animeDetailsParse(document: Document): SAnime = SAnime.create().apply {
+    override fun animeDetailsParse(response: Response): SAnime = SAnime.create().apply {
+        val document = response.useAsJsoup()
         title = document.selectFirst("div.post-title h1")?.text()
             ?: document.selectFirst("h1.entry-title")?.text() ?: ""
         thumbnail_url = document.selectFirst(
@@ -179,8 +183,10 @@ class HentaiHaven :
 
     // ── Episodes ──────────────────────────────────────────────────────────────
 
-    override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
-        val document = client.newCall(animeDetailsRequest(anime)).awaitSuccess().useAsJsoup()
+    override fun episodeListRequest(anime: SAnime): Request = animeDetailsRequest(anime)
+
+    override fun episodeListParse(response: Response): List<SEpisode> {
+        val document = response.useAsJsoup()
         return parseEpisodesFromHtml(document)
     }
 
@@ -210,9 +216,6 @@ class HentaiHaven :
             runCatching { fmt.parse(raw.trim())?.time }.getOrNull()
         } ?: 0L
     }.getOrDefault(0L)
-
-    override fun episodeListSelector() = "li.wp-manga-chapter"
-    override fun episodeFromElement(element: Element): SEpisode = throw UnsupportedOperationException()
 
     // ── Videos ────────────────────────────────────────────────────────────────
 
@@ -257,7 +260,5 @@ class HentaiHaven :
         return videos.sortedWith(compareByDescending { it.quality.contains(preferred) })
     }
 
-    override fun videoListSelector() = ""
-    override fun videoFromElement(element: Element): Video = throw UnsupportedOperationException()
-    override fun videoUrlParse(document: Document) = throw UnsupportedOperationException()
+    override fun videoListParse(response: Response): List<Video> = throw UnsupportedOperationException()
 }

--- a/src/en/hentaihaven/src/eu/kanade/tachiyomi/animeextension/en/hentaihaven/extractors/OctopusExtractor.kt
+++ b/src/en/hentaihaven/src/eu/kanade/tachiyomi/animeextension/en/hentaihaven/extractors/OctopusExtractor.kt
@@ -8,7 +8,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.bodyString
-import kotlinx.serialization.json.Json
+import keiyoushi.utils.parseAs
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonArray
@@ -19,8 +19,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 /**
  * OctopusExtractor — Orchestrator + VP9/CMAF split-stream handler.
@@ -109,7 +107,6 @@ import uy.kohesive.injekt.api.get
  */
 class OctopusExtractor(private val client: OkHttpClient) {
 
-    private val json: Json = Injekt.get()
     private val masterExtractor by lazy { MasterExtractor(client) }
 
     // ── Public entry point ────────────────────────────────────────────────────
@@ -167,16 +164,16 @@ class OctopusExtractor(private val client: OkHttpClient) {
                     .headers(apiHeaders)
                     .build(),
             ).awaitSuccess().use { response ->
-                response.body?.string()
+                response.body.string()
             }
         } catch (e: Exception) {
             Log.e(TAG, "API POST to $apiUrl failed", e)
             return emptyList()
-        } ?: return emptyList()
+        }
 
         // ── Step 3: parse JSON response ───────────────────────────────────────
         val payload = runCatching {
-            json.decodeFromString<JsonObject>(responseBody)
+            responseBody.parseAs<JsonObject>()
         }.getOrElse {
             Log.e(TAG, "JSON parse failed. Body preview: ${responseBody.take(200)}")
             return emptyList()


### PR DESCRIPTION
Solve the crashing app

Close #391

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [X] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Migrate the HentaiHaven extension to the AnimeHttpSource API and update networking and parsing to align with the newer source patterns.

Bug Fixes:
- Prevent app crashes by adapting HentaiHaven to the updated AnimeHttpSource interfaces and response-based parsing.

Enhancements:
- Unify anime, latest, and search parsing logic using shared CSS selectors and helper methods.
- Refactor episode and video handling to use request/parse methods required by AnimeHttpSource.
- Simplify JSON parsing in OctopusExtractor by using shared utility helpers and removing direct Json dependency.

Build:
- Bump the HentaiHaven extension version code to 4 and drop the unused jsoup dependency from its Gradle config.