### PR TITLE
Hanime1.me [ZH]: Fix hanime1 fetching episode failed

### DIFF
--- a/src/zh/hanime1/build.gradle
+++ b/src/zh/hanime1/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hanime1.me'
     extClass = '.Hanime1'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = true
 }
 

--- a/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
+++ b/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
@@ -91,14 +91,31 @@ class Hanime1 :
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val jsoup = response.useAsJsoup()
-        val nodes = jsoup.select("#playlist-scroll").first()!!.select(">div")
-        return nodes.mapIndexed { index, element ->
+        val nodes = jsoup.select("#playlist-scroll").first()?.select(">div").orEmpty()
+
+        val episodes = nodes.mapNotNull { element ->
+            val href =
+                element.attr("data-href").ifEmpty {
+                    element.select("a.overlay, h4.video-title a, a[href*=/watch]").attr("href")
+                }
+            if (href.isEmpty()) {
+                return@mapNotNull null
+            }
+
+            val title =
+                element.select("h4.video-title a, div.card-mobile-title").firstOrNull()?.text().orEmpty()
+
+            href to title
+        }
+
+        val currentUrl = response.request.url.toString()
+
+        return episodes.mapIndexed { index, (href, title) ->
             SEpisode.create().apply {
-                val href = element.select("a.overlay").attr("href")
                 setUrlWithoutDomain(href)
-                episode_number = (nodes.size - index).toFloat()
-                name = element.select("div.card-mobile-title").text()
-                if (href == response.request.url.toString()) {
+                episode_number = (episodes.size - index).toFloat()
+                name = title
+                if (response.request.url.resolve(href)?.toString() == currentUrl) {
                     // current video
                     val timeStr =
                         jsoup.select("div.video-description-panel > div:first-child").text()


### PR DESCRIPTION
- Fix parsing episode incorrectly

Closed #666 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Fix Hanime1 episode parsing so episode lists load reliably across supported page structures.

Bug Fixes:
- Fix Hanime1 episode fetching by supporting multiple episode link and title formats and safely skipping entries without URLs.

Enhancements:
- Improve current-episode detection for resolved episode URLs and handle missing playlist containers without failing.

Chores:
- Increment the Hanime1 extension version code.