### PR TITLE
MKissa [EN]: Fix stream persisted query & minor cleanups

### DIFF
--- a/src/en/mkissa/build.gradle
+++ b/src/en/mkissa/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MKissa'
     extClass = '.MKissa'
-    extVersionCode = 61
+    extVersionCode = 62
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissa.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissa.kt
@@ -574,7 +574,7 @@ class MKissa :
         // Compiled once: the source-name match used to run through a freshly built Regex for every
         // internal hoster, for every source, on every episode.
         private val INTERNAL_HOSTER_MATCHERS = INTERAL_HOSTER_NAMES.map {
-            it.lowercase() to Regex("""\b${it.lowercase()}\b""")
+            it.lowercase() to Regex("""\b${Regex.escape(it.lowercase())}\b""")
         }
 
         private val HOSTER_MAPPINGS = listOf(

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissa.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissa.kt
@@ -21,13 +21,13 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.appendGraphQLParams
 import keiyoushi.utils.bodyString
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.graphQLPost
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
-import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.toJsonString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -72,16 +72,13 @@ class MKissa :
     // ============================== Popular ===============================
 
     override fun popularAnimeRequest(page: Int): Request {
-        val data = buildJsonObject {
-            putJsonObject("variables") {
-                put("type", "anime")
-                put("size", PAGE_SIZE)
-                put("dateRange", 7)
-                put("page", page)
-            }
-            put("query", POPULAR_QUERY)
+        val variables = buildJsonObject {
+            put("type", "anime")
+            put("size", PAGE_SIZE)
+            put("dateRange", 7)
+            put("page", page)
         }
-        return buildPost(data)
+        return buildPost(POPULAR_QUERY, variables)
     }
 
     override fun popularAnimeParse(response: Response): AnimesPage {
@@ -106,20 +103,17 @@ class MKissa :
     // =============================== Latest ===============================
 
     override fun latestUpdatesRequest(page: Int): Request {
-        val data = buildJsonObject {
-            putJsonObject("variables") {
-                putJsonObject("search") {
-                    put("allowAdult", true)
-                    put("allowUnknown", true)
-                }
-                put("limit", PAGE_SIZE)
-                put("page", page)
-                put("translationType", preferences.subPref)
-                put("countryOrigin", "ALL")
+        val variables = buildJsonObject {
+            putJsonObject("search") {
+                put("allowAdult", true)
+                put("allowUnknown", true)
             }
-            put("query", SEARCH_QUERY)
+            put("limit", PAGE_SIZE)
+            put("page", page)
+            put("translationType", preferences.subPref)
+            put("countryOrigin", "ALL")
         }
-        return buildPost(data)
+        return buildPost(SEARCH_QUERY, variables)
     }
 
     override fun latestUpdatesParse(response: Response): AnimesPage = parseAnime(response)
@@ -129,29 +123,26 @@ class MKissa :
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val filters = MKissaFilters.getSearchParameters(filters)
 
-        val data = buildJsonObject {
-            putJsonObject("variables") {
-                putJsonObject("search") {
-                    if (query.isNotBlank()) put("query", query)
-                    put("allowAdult", true)
-                    put("allowUnknown", true)
-                    filters.sortBy.takeIf { it != "Recent" && it.isNotBlank() }?.let { put("sortBy", it) }
-                    filters.season.takeIf { it != "all" && it.isNotBlank() }?.let { put("season", it) }
-                    filters.releaseYear.toIntOrNull()?.let { put("year", it) }
-                    if (filters.genres != "all" && filters.genres.isNotBlank()) {
-                        put("genres", filters.genres.parseAs<JsonElement>())
-                        put("excludeGenres", buildJsonArray { })
-                    }
-                    if (filters.types != "all" && filters.types.isNotBlank()) put("types", filters.types.parseAs<JsonElement>())
+        val variables = buildJsonObject {
+            putJsonObject("search") {
+                if (query.isNotBlank()) put("query", query)
+                put("allowAdult", true)
+                put("allowUnknown", true)
+                filters.sortBy.takeIf { it != "Recent" && it.isNotBlank() }?.let { put("sortBy", it) }
+                filters.season.takeIf { it != "all" && it.isNotBlank() }?.let { put("season", it) }
+                filters.releaseYear.toIntOrNull()?.let { put("year", it) }
+                if (filters.genres != "all" && filters.genres.isNotBlank()) {
+                    put("genres", filters.genres.parseAs<JsonElement>())
+                    put("excludeGenres", buildJsonArray { })
                 }
-                put("limit", PAGE_SIZE)
-                put("page", page)
-                put("translationType", preferences.subPref)
-                put("countryOrigin", filters.origin)
+                if (filters.types != "all" && filters.types.isNotBlank()) put("types", filters.types.parseAs<JsonElement>())
             }
-            put("query", SEARCH_QUERY)
+            put("limit", PAGE_SIZE)
+            put("page", page)
+            put("translationType", preferences.subPref)
+            put("countryOrigin", filters.origin)
         }
-        return buildPost(data)
+        return buildPost(SEARCH_QUERY, variables)
     }
 
     override fun searchAnimeParse(response: Response): AnimesPage = parseAnime(response)
@@ -161,20 +152,17 @@ class MKissa :
             .split(",")
             .map { it.trim() }
             .toJsonString()
-        val data = buildJsonObject {
-            putJsonObject("variables") {
-                putJsonObject("search") {
-                    put("allowAdult", true)
-                    put("allowUnknown", true)
-                    put("genres", genres.parseAs<JsonElement>())
-                }
-                put("limit", PAGE_SIZE)
-                put("page", 1)
-                put("translationType", preferences.subPref)
+        val variables = buildJsonObject {
+            putJsonObject("search") {
+                put("allowAdult", true)
+                put("allowUnknown", true)
+                put("genres", genres.parseAs<JsonElement>())
             }
-            put("query", SEARCH_QUERY)
+            put("limit", PAGE_SIZE)
+            put("page", 1)
+            put("translationType", preferences.subPref)
         }
-        return buildPost(data)
+        return buildPost(SEARCH_QUERY, variables)
     }
 
     override fun relatedAnimeListParse(response: Response): List<SAnime> = parseAnime(response).animes
@@ -186,13 +174,10 @@ class MKissa :
     // =========================== Anime Details ============================
 
     override fun animeDetailsRequest(anime: SAnime): Request {
-        val data = buildJsonObject {
-            putJsonObject("variables") {
-                put("_id", anime.url.split("<&sep>").first())
-            }
-            put("query", DETAILS_QUERY)
+        val variables = buildJsonObject {
+            put("_id", anime.url.split("<&sep>").first())
         }
-        return buildPost(data)
+        return buildPost(DETAILS_QUERY, variables)
     }
 
     override fun getAnimeUrl(anime: SAnime): String {
@@ -224,13 +209,10 @@ class MKissa :
     // ============================== Episodes ==============================
 
     override fun episodeListRequest(anime: SAnime): Request {
-        val data = buildJsonObject {
-            putJsonObject("variables") {
-                put("_id", anime.url.split("<&sep>").first())
-            }
-            put("query", EPISODES_QUERY)
+        val variables = buildJsonObject {
+            put("_id", anime.url.split("<&sep>").first())
         }
-        return buildPost(data)
+        return buildPost(EPISODES_QUERY, variables)
     }
 
     override fun episodeListParse(response: Response): List<SEpisode> {
@@ -286,11 +268,16 @@ class MKissa :
             put("aaReq", keyManager.aaReq(material))
         }
 
-        val url = apiUrl.toHttpUrl().newBuilder().apply {
-            addPathSegment("api")
-            addQueryParameter("variables", variables.toJsonString())
-            addQueryParameter("extensions", extensions.toJsonString())
-        }.build()
+        // The text goes out next to the hash so the server can register the query itself rather
+        // than having to already know it; see STREAM_QUERY.
+        val url = apiUrl.toHttpUrl().newBuilder()
+            .addPathSegment("api")
+            .appendGraphQLParams(
+                query = STREAM_QUERY,
+                variables = variables,
+                extensions = extensions,
+            )
+            .build()
 
         // The build the token was minted for; the server rejects a mismatch with AA_CRYPTO_BUILD_MISMATCH.
         val streamHeaders = headers.newBuilder().set("x-build-id", material.buildId).build()
@@ -313,32 +300,20 @@ class MKissa :
         val hosterSelection = preferences.getHosters
         val altHosterSelection = preferences.getAltHosters
 
-        val mappings = listOf(
-            "vidstreaming" to listOf("vidstreaming", "https://gogo", "playgo1.cc", "playtaku", "vidcloud"),
-            "doodstream" to listOf("dood"),
-            "okru" to listOf("ok.ru", "okru"),
-            "mp4upload" to listOf("mp4upload.com"),
-            "streamlare" to listOf("streamlare.com"),
-            // Fm-Hls is Filemoon; the embed domain rotates (bysekoze.com is current), so match the
-            // legacy filemoon domains too.
-            "Fm-Hls" to listOf("bysekoze.com", "fastmoon", "filemoon", "moonplayer"),
-            "streamwish" to listOf("wish"),
-        )
-
         val serverList = mutableListOf<Server>()
         sourceUrls.forEach { video ->
             val videoUrl = video.sourceUrl.decryptSource()
+            val sourceName = video.sourceName.lowercase()
 
-            val matchingMapping = mappings.firstOrNull { (altHoster, urlMatches) ->
+            val matchingMapping = HOSTER_MAPPINGS.firstOrNull { (altHoster, urlMatches) ->
                 // Fm-Hls lives in the Hoster selection (lowercased); the rest are Alternative Hosts.
                 (hosterSelection.contains(altHoster.lowercase()) || altHosterSelection.contains(altHoster)) &&
                     videoUrl.containsAny(urlMatches)
             }
 
             when {
-                videoUrl.startsWith("/apivtwo/") && INTERAL_HOSTER_NAMES.any {
-                    Regex("""\b${it.lowercase()}\b""").find(video.sourceName.lowercase()) != null &&
-                        hosterSelection.contains(it.lowercase())
+                videoUrl.startsWith("/apivtwo/") && INTERNAL_HOSTER_MATCHERS.any { (name, pattern) ->
+                    hosterSelection.contains(name) && pattern.containsMatchIn(sourceName)
                 } ->
                     Server(videoUrl, "internal ${video.sourceName}", video.priority)
                         .let(serverList::add)
@@ -464,20 +439,20 @@ class MKissa :
     // First match, not the largest: names can end in a bitrate ("Ak - 1080 5 mb/s").
     private fun String.resolution(): Int = RESOLUTION_REGEX.find(this)?.value?.toIntOrNull() ?: 0
 
-    private fun buildPost(dataObject: JsonObject): Request {
-        val payload = dataObject.toJsonString().toJsonBody()
-
-        val postHeaders = headers.newBuilder().apply {
+    private val postHeaders by lazy {
+        headers.newBuilder().apply {
             add("Accept", "*/*")
-            add("Content-Length", payload.contentLength().toString())
-            add("Content-Type", payload.contentType().toString())
-            add("Host", apiUrl.toHttpUrl().host)
             add("Origin", GRAPHQL_ORIGIN)
             add("Referer", "$GRAPHQL_ORIGIN/")
         }.build()
-
-        return POST("$apiUrl/api", headers = postHeaders, body = payload)
     }
+
+    private fun buildPost(query: String, variables: JsonObject): Request = graphQLPost(
+        url = "$apiUrl/api",
+        headers = postHeaders,
+        query = query,
+        variables = variables,
+    )
 
     data class Server(
         val sourceUrl: String,
@@ -549,6 +524,14 @@ class MKissa :
                     responseBody.parseAs<EncryptedEpisodeResult>().data.tobeparsed
                 }.getOrNull()
 
+                // NEED_CAPTCHA and the rate limiter answer 200 with a null episode and no payload,
+                // which the branches below read as an empty episode or a changed format. Retrying
+                // only deepens the block, and the generic message sends people chasing an extension
+                // update that does not exist.
+                if (tobeparsed.isNullOrBlank()) {
+                    keyManager.apiErrorMessage(responseBody)?.let { throw Exception(it) }
+                }
+
                 when {
                     !tobeparsed.isNullOrBlank() -> {
                         runCatching { keyManager.decrypt(tobeparsed, material)?.parseAs<DecryptedEpisodeResult>() }
@@ -586,6 +569,24 @@ class MKissa :
         private val INTERAL_HOSTER_NAMES = arrayOf(
             "Default", "Ac", "Ak", "Kir", "Rab", "Luf-mp4",
             "Si-Hls", "S-mp4", "Ac-Hls", "Uv-mp4", "Pn-Hls",
+        )
+
+        // Compiled once: the source-name match used to run through a freshly built Regex for every
+        // internal hoster, for every source, on every episode.
+        private val INTERNAL_HOSTER_MATCHERS = INTERAL_HOSTER_NAMES.map {
+            it.lowercase() to Regex("""\b${it.lowercase()}\b""")
+        }
+
+        private val HOSTER_MAPPINGS = listOf(
+            "vidstreaming" to listOf("vidstreaming", "https://gogo", "playgo1.cc", "playtaku", "vidcloud"),
+            "doodstream" to listOf("dood"),
+            "okru" to listOf("ok.ru", "okru"),
+            "mp4upload" to listOf("mp4upload.com"),
+            "streamlare" to listOf("streamlare.com"),
+            // Fm-Hls is Filemoon; the embed domain rotates (bysekoze.com is current), so match the
+            // legacy filemoon domains too.
+            "Fm-Hls" to listOf("bysekoze.com", "fastmoon", "filemoon", "moonplayer"),
+            "streamwish" to listOf("wish"),
         )
 
         private val ALT_HOSTER_NAMES = arrayOf(

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -36,6 +36,11 @@ object MKissaCrypto {
     private const val EPOCH_WINDOW_MS = 7 * 24 * 60 * 60 * 1000L
     private const val EPOCH_GRACE_MS = 24 * 60 * 60 * 1000L
 
+    /** Identifies a persisted query: the server hashes the query text the same way. */
+    fun sha256Hex(value: String): String = MessageDigest.getInstance(HASH_ALGO)
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .toHex()
+
     /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild. */
     fun deriveMask(buildId: String, seeds: List<String>): ByteArray? {
         if (buildId.isEmpty() || seeds.size != SEED_COUNT) return null

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaDto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaDto.kt
@@ -157,6 +157,7 @@ class AaApiError(
 ) {
     @Serializable
     class GraphQlError(
+        val message: String? = null,
         val extensions: Extensions? = null,
     ) {
         @Serializable

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.bodyString
 import keiyoushi.utils.delegate
+import keiyoushi.utils.parallelCatchingMapNotNull
 import keiyoushi.utils.parseAs
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -91,6 +92,25 @@ class MKissaKeyManager(
 
     fun isCryptoError(body: String): Boolean = runCatching { body.parseAs<AaApiError>().errors }.getOrNull()
         ?.any { it.extensions?.code?.startsWith("AA_CRYPTO") == true } == true
+
+    /**
+     * The server's own complaint — a captcha gate, a rate limit — for responses it refuses outright.
+     * Null while a crypto error is present, since fresh material can still rescue those.
+     */
+    fun apiErrorMessage(body: String): String? {
+        if (isCryptoError(body)) return null
+        val message = runCatching { body.parseAs<AaApiError>().errors }.getOrNull()
+            ?.firstNotNullOfOrNull { it.message }
+            ?: return null
+        // The bare code says nothing to someone whose episode just refused to load, and the gate is
+        // on the network rather than the account, so there is nothing to sign in to or re-install.
+        return if (message == CAPTCHA_ERROR) {
+            "MKissa is rate limiting this network ($CAPTCHA_ERROR). Browsing still works; " +
+                "streams should return on their own after a while."
+        } else {
+            "MKissa: $message"
+        }
+    }
 
     private class Handshake(
         val build: MKissaBundle.BuildInfo,
@@ -183,16 +203,20 @@ class MKissaKeyManager(
             .distinct()
             .sortedByDescending { it.contains("/chunks/") }
             .take(MAX_BUILD_CHUNKS)
+            .toList()
 
-        for (ref in chunkRefs) {
-            val chunkUrl = appUrl.resolve(ref) ?: continue
-            val body = runCatching {
-                client.newCall(GET(chunkUrl, headers)).awaitSuccess().bodyString()
-            }.getOrNull() ?: continue
-
-            if (!body.contains(CRYPTO_CHUNK_MARKER)) continue
-
-            MKissaBundle.parse(body)?.let { return it }
+        // In batches rather than all at once: the chunks run to about a megabyte each, so fetching
+        // the whole list in parallel would pull tens of megabytes to use one of them, while walking
+        // them one at a time pays a full round trip per miss.
+        for (batch in chunkRefs.chunked(BUILD_CHUNK_BATCH)) {
+            val found = batch.parallelCatchingMapNotNull { ref ->
+                val chunkUrl = appUrl.resolve(ref) ?: return@parallelCatchingMapNotNull null
+                val body = client.newCall(GET(chunkUrl, headers)).awaitSuccess().bodyString()
+                if (!body.contains(CRYPTO_CHUNK_MARKER)) return@parallelCatchingMapNotNull null
+                MKissaBundle.parse(body)
+            }
+            // Order is preserved, so this stays the first hit in the site's own chunk order.
+            found.firstOrNull()?.let { return it }
         }
         return null
     }
@@ -213,6 +237,8 @@ class MKissaKeyManager(
     companion object {
         private const val MATERIAL_ERROR = "Unable to obtain MKissa crypto material"
 
+        private const val CAPTCHA_ERROR = "NEED_CAPTCHA"
+
         private const val BOOTSTRAP_PATH = "/client-crypto/v1/bootstrap"
 
         // 403 invalid_boot_token, 404 unknown_build_id.
@@ -225,6 +251,7 @@ class MKissaKeyManager(
         private const val FIELD_SEPARATOR = "|"
 
         private const val MAX_BUILD_CHUNKS = 40
+        private const val BUILD_CHUNK_BATCH = 4
 
         private const val MATERIAL_TTL_MS = 6 * 60 * 60 * 1000L
 

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaQueries.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaQueries.kt
@@ -4,7 +4,36 @@ fun buildQuery(queryAction: () -> String): String = queryAction()
     .trimIndent()
     .replace("%", "$")
 
-const val STREAM_HASH = "f4662f4b7510b26795dd53ef824a0bf1740fbbc5d1273fab18222ac831bca8d0"
+// The streams endpoint speaks Apollo's automatic persisted queries: it registers a query the first
+// time a client sends the text, then keys both that cache and the `qh` field inside `aaReq` on the
+// SHA-256 of the exact text. Sending our own query instead of quoting the site's hash means a
+// site-side edit to its query can no longer strand the extension on a hash the server has dropped,
+// and the reply carries the two fields we read rather than the ~9 kB the site's query asks for.
+//
+// Nothing reads `show`, but the episode resolver writes to it while resolving `sourceUrls` and
+// fails with "Cannot set properties of undefined" when the selection set leaves it out.
+val STREAM_QUERY: String = buildQuery {
+    """
+        query(
+            %showId: String!
+            %translationType: VaildTranslationTypeEnumType!
+            %episodeString: String!
+        ) {
+            episode(
+                showId: %showId
+                translationType: %translationType
+                episodeString: %episodeString
+            ) {
+                sourceUrls
+                show {
+                    _id
+                }
+            }
+        }
+    """
+}
+
+val STREAM_HASH: String = MKissaCrypto.sha256Hex(STREAM_QUERY)
 
 // Content lane: the site scopes crypto material per content type, picking the lane from the
 // query it is about to send. `k7` is anime episodes (`k9` manga chapter pages, `k2` music).


### PR DESCRIPTION
The streams endpoint stopped resolving the hardcoded persisted-query hash after the site edited its episode query (PersistedQueryNotFound). Send our own query text alongside the hash so the server registers it via APQ, and derive STREAM_HASH from that text at runtime — a future site-side query edit can no longer strand the extension on a dropped hash. The query also selects only the two fields the extension reads, shrinking the response from ~9 kB to ~1.6 kB.

Alongside:
- Route the GraphQL requests through the shared graphQLPost/appendGraphQLParams utils instead of the hand-rolled envelope and header math.
- Scan the build chunks in parallel batches rather than one round trip per miss.
- Precompile the internal-hoster regexes and the URL mapping table instead of rebuilding them per source per episode.
- Surface the server's NEED_CAPTCHA/rate-limit message instead of a generic "encryption changed" error when the resolver refuses outright.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Make MKissa stream resolution resilient to persisted-query changes while improving request efficiency, error reporting, and source processing performance.

New Features:
- Make stream persisted queries self-registering by sending the query text and deriving its hash at runtime.
- Report actionable CAPTCHA and rate-limit messages when stream resolution is refused.

Bug Fixes:
- Fix stream resolution after site-side persisted-query changes caused the server to reject the previously hardcoded hash.

Enhancements:
- Route GraphQL requests through shared request utilities and reduce stream query responses to the fields consumed by the extension.
- Improve crypto bundle discovery by fetching build chunks in bounded parallel batches.
- Reuse precompiled hoster matchers and mappings while selecting stream sources.

Build:
- Bump the MKissa extension version code to 62.