### PR TITLE
Fix VOE decoder, support more subs playlistutil, fix serienstream

### DIFF
--- a/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
@@ -1,6 +1,7 @@
 package aniyomi.lib.playlistutils
 
 import android.net.Uri
+import android.util.Log
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
@@ -405,9 +406,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
      * Fix a common issue in VTT (WebVTT) subtitle files where extra or unexpected newline characters break the subtitle format,
      * potentially causing players to fail to render them correctly.
      */
-    fun fixSubtitles(subtitleList: List<Track>): List<Track> = subtitleList.parallelMapNotNullBlocking {
+    fun fixSubtitles(subtitleList: List<Track>): List<Track> = subtitleList.parallelMapNotNullBlocking { track ->
         runCatching {
-            val subData = client.newCall(GET(it.url))
+            val subData = client.newCall(GET(track.url))
                 .awaitSuccess().bodyString()
 
             val file = File.createTempFile("subs", ".vtt")
@@ -417,7 +418,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
             file.writeText(FIX_SUBTITLE_REGEX.replace(vttData, ::cleanSubtitleData))
             val uri = Uri.fromFile(file)
 
-            Track(uri.toString(), it.lang)
+            Track(uri.toString(), track.lang)
+        }.onFailure { e ->
+            Log.w("PlaylistUtils", "Failed to process subtitle track ${track.url}: ${e.message}")
         }.getOrNull()
     }
 
@@ -453,11 +456,15 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
          *
          * * `$`: Matches the end of a line.
          * * `(\n{2,})`: Captures a group of two or more consecutive newline characters. In VTT files, a double newline usually indicates the end of one "cue" (subtitle block) and the start of another.
-         * * `(?!(?:\d+:)*\d+(?:\.\d+)?\s-+>\s(?:\d+:)*\d+(?:\.\d+)?)`: This is a negative lookahead. It checks that what follows the newlines is NOT a VTT timestamp (e.g., `00:00:10.000 --> 00:00:12.000)`.
+         * * The negative lookahead checks that what follows the newlines is NOT the start of legitimate WebVTT content. It accepts:
+         *     - A VTT timestamp (e.g., `00:00:10.000 --> 00:00:12.000`).
+         *     - A `NOTE` block start (`NOTE` followed by whitespace, newline, or end of line).
+         *     - A `STYLE` block start (`STYLE` followed by whitespace, newline, or end of line).
+         *     - Any single non-blank cue identifier line immediately followed by a cue timing line on the next line (a valid WebVTT cue with an identifier).
          *
-         * **Logic**: If the code finds multiple empty lines, but the next thing it sees isn't a new timestamp, it assumes those empty lines are garbage or mid-text breaks that will break the parser.
+         * **Logic**: If the code finds multiple empty lines, but the next thing it sees isn't a new timestamp, `NOTE`/`STYLE` block, or an identifier line leading into a timing line, it assumes those empty lines are garbage or mid-text breaks that will break the parser.
          */
-        private val FIX_SUBTITLE_REGEX = Regex("""$(\n{2,})(?!(?:\d+:)*\d+(?:\.\d+)?\s-+>\s(?:\d+:)*\d+(?:\.\d+)?)""", RegexOption.MULTILINE)
+        private val FIX_SUBTITLE_REGEX = Regex("""$(\n{2,})(?!(?:(?:\d+:)*\d+(?:\.\d+)?\s-+>\s(?:\d+:)*\d+(?:\.\d+)?|(?:NOTE|STYLE)(?:[ \t\n]|$)|[^\n]+\n(?:(?:\d+:)*\d+(?:\.\d+)?\s-+>\s)))""", RegexOption.MULTILINE)
 
         /**
          * Matches a SubRip cue timing line, e.g. `00:00:03,520 --> 00:00:05,240`.

--- a/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
@@ -459,12 +459,12 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
          * * The negative lookahead checks that what follows the newlines is NOT the start of legitimate WebVTT content. It accepts:
          *     - A VTT timestamp (e.g., `00:00:10.000 --> 00:00:12.000`).
          *     - A `NOTE` block start (`NOTE` followed by whitespace, newline, or end of line).
-         *     - A `STYLE` block start (`STYLE` followed by whitespace, newline, or end of line).
+         *     - A `STYLE` or `REGION` block start (followed by whitespace, newline, or end of line).
          *     - Any single non-blank cue identifier line immediately followed by a cue timing line on the next line (a valid WebVTT cue with an identifier).
          *
-         * **Logic**: If the code finds multiple empty lines, but the next thing it sees isn't a new timestamp, `NOTE`/`STYLE` block, or an identifier line leading into a timing line, it assumes those empty lines are garbage or mid-text breaks that will break the parser.
+         * **Logic**: If the code finds multiple empty lines, but the next thing it sees isn't a new timestamp, `NOTE`/`STYLE`/`REGION` block, or an identifier line leading into a timing line, it assumes those empty lines are garbage or mid-text breaks that will break the parser.
          */
-        private val FIX_SUBTITLE_REGEX = Regex("""$(\n{2,})(?!(?:(?:\d+:)*\d+(?:\.\d+)?\s-+>\s(?:\d+:)*\d+(?:\.\d+)?|(?:NOTE|STYLE)(?:[ \t\n]|$)|[^\n]+\n(?:(?:\d+:)*\d+(?:\.\d+)?\s-+>\s)))""", RegexOption.MULTILINE)
+        private val FIX_SUBTITLE_REGEX = Regex("""$(\n{2,})(?!(?:(?:\d+:)*\d+(?:\.\d+)?\s-+>\s(?:\d+:)*\d+(?:\.\d+)?|(?:NOTE|STYLE|REGION)(?:[ \t\n]|$)|[^\n]+\n(?:(?:\d+:)*\d+(?:\.\d+)?\s-+>\s)))""", RegexOption.MULTILINE)
 
         /**
          * Matches a SubRip cue timing line, e.g. `00:00:03,520 --> 00:00:05,240`.

--- a/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
@@ -410,14 +410,41 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
             val subData = client.newCall(GET(it.url))
                 .awaitSuccess().bodyString()
 
-            val file = File.createTempFile("subs", "vtt")
+            val file = File.createTempFile("subs", ".vtt")
                 .also(File::deleteOnExit)
 
-            file.writeText(FIX_SUBTITLE_REGEX.replace(subData, ::cleanSubtitleData))
+            val vttData = toWebVtt(subData)
+            file.writeText(FIX_SUBTITLE_REGEX.replace(vttData, ::cleanSubtitleData))
             val uri = Uri.fromFile(file)
 
             Track(uri.toString(), it.lang)
         }.getOrNull()
+    }
+
+    /**
+     * Converts SubRip subtitle data to WebVTT, leaving anything else unchanged.
+     *
+     * Some hosters serve SubRip content from a `.vtt` URL or behind a `text/vtt` content type.
+     * Players that sniff the format from the content cope with that, but ones that trust the
+     * declared type do not, so the data is normalized to match what it claims to be: WebVTT
+     * requires the `WEBVTT` header, and its cue timings use a dot as the decimal separator
+     * instead of SubRip's comma.
+     *
+     * SubRip's numeric cue indexes are dropped, because a WebVTT cue identifier is optional and
+     * keeping them breaks [FIX_SUBTITLE_REGEX], which runs next: its lookahead only accepts a cue
+     * timing directly after a blank line, so an index line in between makes it treat every single
+     * cue boundary as an illegal gap and replace it with a `&nbsp;` line. That collapses the blank
+     * lines WebVTT needs to separate cues and leaves a file a player loads but cannot render.
+     *
+     * Data that already is WebVTT, and data in a format that carries no SubRip cue timing at all
+     * (SubStation Alpha, for instance), is returned as-is rather than being given a header it
+     * cannot back up.
+     */
+    private fun toWebVtt(subData: String): String {
+        val data = subData.removePrefix("\uFEFF").replace("\r\n", "\n").trimStart()
+        if (data.startsWith("WEBVTT") || !SRT_TIMECODE_REGEX.containsMatchIn(data)) return data
+        val cues = SRT_TIMECODE_REGEX.replace(data, "$1.$2 --> $3.$4")
+        return "WEBVTT\n\n" + SRT_CUE_INDEX_REGEX.replace(cues, "")
     }
 
     companion object {
@@ -431,6 +458,27 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
          * **Logic**: If the code finds multiple empty lines, but the next thing it sees isn't a new timestamp, it assumes those empty lines are garbage or mid-text breaks that will break the parser.
          */
         private val FIX_SUBTITLE_REGEX = Regex("""$(\n{2,})(?!(?:\d+:)*\d+(?:\.\d+)?\s-+>\s(?:\d+:)*\d+(?:\.\d+)?)""", RegexOption.MULTILINE)
+
+        /**
+         * Matches a SubRip cue timing line, e.g. `00:00:03,520 --> 00:00:05,240`.
+         *
+         * The hour part is optional, and either a comma or a dot is accepted as the decimal
+         * separator so that partly converted data is matched too. Commas inside dialogue are never
+         * touched, because a match has to contain the `-->` arrow, and anything trailing the end
+         * timestamp (WebVTT cue settings) is left in place.
+         */
+        private val SRT_TIMECODE_REGEX by lazy {
+            Regex("""((?:\d{1,3}:)?\d{1,3}:\d{2})[,.](\d{1,3})[ \t]*-->[ \t]*((?:\d{1,3}:)?\d{1,3}:\d{2})[,.](\d{1,3})""")
+        }
+
+        /**
+         * Matches a SubRip numeric cue index on its own line, immediately followed by the cue
+         * timing line. Applied after [SRT_TIMECODE_REGEX] has already converted the timings, so
+         * only the dot form needs matching here.
+         */
+        private val SRT_CUE_INDEX_REGEX by lazy {
+            Regex("""^\d+[ \t]*\n(?=(?:\d{1,3}:)?\d{1,3}:\d{2}\.\d{1,3}[ \t]*-->)""", RegexOption.MULTILINE)
+        }
 
         private const val PLAYLIST_SEPARATOR = "#EXT-X-STREAM-INF:"
 

--- a/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlistutils/src/aniyomi/lib/playlistutils/PlaylistUtils.kt
@@ -415,12 +415,19 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
                 .also(File::deleteOnExit)
 
             val vttData = toWebVtt(subData)
-            file.writeText(FIX_SUBTITLE_REGEX.replace(vttData, ::cleanSubtitleData))
+            // Only WebVTT (or data converted to it) gets the gap cleanup; formats like ASS/SSA
+            // legitimately use blank lines between sections and must not be touched by it.
+            val cleanedData = if (vttData.startsWith("WEBVTT")) {
+                FIX_SUBTITLE_REGEX.replace(vttData, ::cleanSubtitleData)
+            } else {
+                vttData
+            }
+            file.writeText(cleanedData)
             val uri = Uri.fromFile(file)
 
             Track(uri.toString(), track.lang)
         }.onFailure { e ->
-            Log.w("PlaylistUtils", "Failed to process subtitle track ${track.url}: ${e.message}")
+            Log.w("PlaylistUtils", "Failed to process subtitle track (${track.lang}): ${e.javaClass.simpleName}: ${e.message}")
         }.getOrNull()
     }
 
@@ -444,7 +451,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
      * cannot back up.
      */
     private fun toWebVtt(subData: String): String {
-        val data = subData.removePrefix("\uFEFF").replace("\r\n", "\n").trimStart()
+        val data = subData.removePrefix("\uFEFF").replace("\r\n", "\n").replace('\r', '\n').trimStart()
         if (data.startsWith("WEBVTT") || !SRT_TIMECODE_REGEX.containsMatchIn(data)) return data
         val cues = SRT_TIMECODE_REGEX.replace(data, "$1.$2 --> $3.$4")
         return "WEBVTT\n\n" + SRT_CUE_INDEX_REGEX.replace(cues, "")

--- a/lib/voeextractor/src/aniyomi/lib/voeextractor/VoeExtractor.kt
+++ b/lib/voeextractor/src/aniyomi/lib/voeextractor/VoeExtractor.kt
@@ -3,10 +3,13 @@ package aniyomi.lib.voeextractor
 import android.util.Base64
 import android.util.Log
 import aniyomi.lib.playlistutils.PlaylistUtils
+import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.UrlUtils
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Headers
@@ -26,11 +29,13 @@ class VoeExtractor(private val client: OkHttpClient, private val headers: Header
     fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
         val videoList = mutableListOf<Video>()
         var document = clientDdos.newCall(GET(url, headers)).execute().asJsoup()
+        var baseUrl = url
         val scriptData = document.selectFirst("script")?.data()
         val redirectMatch = scriptData?.let { redirectRegex.find(it) }
 
         if (redirectMatch != null) {
             val originalUrl = redirectMatch.groupValues[1]
+            baseUrl = originalUrl
             document = clientDdos.newCall(GET(originalUrl, headers)).execute().asJsoup()
         }
 
@@ -41,15 +46,36 @@ class VoeExtractor(private val client: OkHttpClient, private val headers: Header
         val m3u8 = decryptedJson["source"]?.jsonPrimitive?.content
         val mp4 = decryptedJson["direct_access_url"]?.jsonPrimitive?.content
 
+        val cleanPrefix = prefix.trim().removePrefix("(").removeSuffix(")").removeSuffix("-").trim()
+        val displayPrefix = if (cleanPrefix.isNotBlank()) cleanPrefix else "VOE"
+        val tracks = mutableListOf<Track>()
+        try {
+            val captions = decryptedJson["captions"] as? JsonArray
+            captions?.forEach { elem ->
+                val obj = elem as? JsonObject ?: return@forEach
+                val file = obj["file"]?.jsonPrimitive?.content ?: return@forEach
+                val label = obj["label"]?.jsonPrimitive?.content ?: "Subtitle"
+                val absolute = UrlUtils.fixUrl(file, baseUrl) ?: file
+                if (absolute.isNotBlank()) tracks.add(Track(absolute, label))
+            }
+        } catch (_: Exception) {
+        }
+        val subHint = if (tracks.isNotEmpty()) " [CC ${tracks.size}]" else ""
+
         if (m3u8 != null) {
             playlistUtils.extractFromHls(
                 m3u8,
-                videoNameGen = { quality -> "${prefix}Voe:$quality" },
+                videoNameGen = { quality ->
+                    val base = if (displayPrefix == "VOE") "VOE:$quality" else "$displayPrefix - VOE $quality"
+                    base + subHint
+                },
+                subtitleList = tracks,
             ).let { videoList.addAll(it) }
         }
         if (mp4 != null) {
+            val mp4Quality = if (displayPrefix == "VOE") "VOE:MP4" else "$displayPrefix - VOE MP4"
             videoList.add(
-                Video(mp4, "${prefix}Voe:MP4", mp4),
+                Video(mp4, mp4Quality + subHint, mp4, subtitleTracks = tracks),
             )
         }
 

--- a/lib/voeextractor/src/aniyomi/lib/voeextractor/VoeExtractor.kt
+++ b/lib/voeextractor/src/aniyomi/lib/voeextractor/VoeExtractor.kt
@@ -48,18 +48,18 @@ class VoeExtractor(private val client: OkHttpClient, private val headers: Header
 
         val cleanPrefix = prefix.trim().removePrefix("(").removeSuffix(")").removeSuffix("-").trim()
         val displayPrefix = if (cleanPrefix.isNotBlank()) cleanPrefix else "VOE"
-        val tracks = mutableListOf<Track>()
-        try {
-            val captions = decryptedJson["captions"] as? JsonArray
-            captions?.forEach { elem ->
-                val obj = elem as? JsonObject ?: return@forEach
-                val file = obj["file"]?.jsonPrimitive?.content ?: return@forEach
-                val label = obj["label"]?.jsonPrimitive?.content ?: "Subtitle"
-                val absolute = UrlUtils.fixUrl(file, baseUrl) ?: file
-                if (absolute.isNotBlank()) tracks.add(Track(absolute, label))
-            }
-        } catch (_: Exception) {
-        }
+        // The caption files are SubRip served from a `.srt` url behind a `text/vtt` content type,
+        // which a player will refuse to parse, so they are converted before being handed over.
+        val tracks = runCatching {
+            (decryptedJson["captions"] as? JsonArray).orEmpty()
+                .mapNotNull { caption ->
+                    val obj = caption as? JsonObject ?: return@mapNotNull null
+                    val file = obj["file"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    val url = UrlUtils.fixUrl(file, baseUrl) ?: return@mapNotNull null
+                    Track(url, obj["label"]?.jsonPrimitive?.content ?: "Subtitle")
+                }
+                .let(playlistUtils::fixSubtitles)
+        }.getOrDefault(emptyList())
         val subHint = if (tracks.isNotEmpty()) " [CC ${tracks.size}]" else ""
 
         if (m3u8 != null) {

--- a/lib/voeextractor/src/aniyomi/lib/voeextractor/VoeExtractor.kt
+++ b/lib/voeextractor/src/aniyomi/lib/voeextractor/VoeExtractor.kt
@@ -46,7 +46,13 @@ class VoeExtractor(private val client: OkHttpClient, private val headers: Header
         val m3u8 = decryptedJson["source"]?.jsonPrimitive?.content
         val mp4 = decryptedJson["direct_access_url"]?.jsonPrimitive?.content
 
-        val cleanPrefix = prefix.trim().removePrefix("(").removeSuffix(")").removeSuffix("-").trim()
+        var cleanPrefix = prefix.trim()
+        if (cleanPrefix.startsWith("(") && cleanPrefix.endsWith(")")) {
+            cleanPrefix = cleanPrefix.substring(1, cleanPrefix.length - 1).trim()
+        }
+        if (cleanPrefix.endsWith("-")) {
+            cleanPrefix = cleanPrefix.removeSuffix("-").trim()
+        }
         val displayPrefix = if (cleanPrefix.isNotBlank()) cleanPrefix else "VOE"
         // The caption files are SubRip served from a `.srt` url behind a `text/vtt` content type,
         // which a player will refuse to parse, so they are converted before being handed over.

--- a/src/de/serienstream/build.gradle
+++ b/src/de/serienstream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Serienstream'
     extClass = '.Serienstream'
-    extVersionCode = 32
+    extVersionCode = 33
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/de/serienstream/build.gradle
+++ b/src/de/serienstream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Serienstream'
     extClass = '.Serienstream'
-    extVersionCode = 33
+    extVersionCode = 34
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/de/serienstream/build.gradle
+++ b/src/de/serienstream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Serienstream'
     extClass = '.Serienstream'
-    extVersionCode = 34
+    extVersionCode = 35
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/de/serienstream/build.gradle
+++ b/src/de/serienstream/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Serienstream'
     extClass = '.Serienstream'
-    extVersionCode = 35
+    extVersionCode = 33
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -271,16 +271,10 @@ class Serienstream :
         }
         if (isFilm) {
             episode.name = "Film $epNum : $displayTitle"
-            episode.episode_number = epNum.toFloat()
         } else {
             episode.name = "Staffel $seasonNumRaw Folge $epNum : $displayTitle"
-            episode.episode_number = try {
-                val s = seasonNumRaw.toIntOrNull() ?: 1
-                (s * 1000 + epNum).toFloat()
-            } catch (_: Exception) {
-                epNum.toFloat()
-            }
         }
+        episode.episode_number = epNum.toFloat()
         return episode
     }
 

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -14,7 +14,6 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.Json
@@ -23,12 +22,12 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.FormBody
-import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.injectLazy
+import java.net.URLEncoder
 
 class Serienstream :
     ParsedAnimeHttpSource(),
@@ -36,7 +35,7 @@ class Serienstream :
 
     override val name = "Serienstream"
 
-    override val baseUrl = "http://186.2.175.5"
+    override val baseUrl = "https://s.to"
 
     override val lang = "de"
 
@@ -51,7 +50,7 @@ class Serienstream :
     private val json: Json by injectLazy()
 
     // ===== POPULAR ANIME =====
-    override fun popularAnimeSelector(): String = "div.seriesListContainer div"
+    override fun popularAnimeSelector(): String = "a.show-card"
 
     override fun popularAnimeNextPageSelector(): String? = null
 
@@ -59,45 +58,65 @@ class Serienstream :
 
     override fun popularAnimeFromElement(element: Element): SAnime {
         val anime = SAnime.create()
-        val linkElement = element.selectFirst("a")!!
-        anime.url = linkElement.attr("href")
-        anime.thumbnail_url = baseUrl + linkElement.selectFirst("img")!!.attr("data-src")
-        anime.title = element.selectFirst("h3")!!.text()
+        val rawHref = element.attr("href")
+        // Strip staffel suffix to get base serie url, fallback to raw
+        val href = if (rawHref.contains("/staffel")) rawHref.substringBefore("/staffel") else rawHref
+        anime.url = href.ifEmpty { rawHref }
+        val img = element.selectFirst("img")
+        anime.title = img?.attr("alt")?.takeIf { it.isNotBlank() } ?: element.text().trim()
+        val thumb = img?.let {
+            val ds = it.attr("data-src")
+            if (ds.isNotBlank()) ds else it.attr("src")
+        } ?: ""
+        anime.thumbnail_url = when {
+            thumb.startsWith("http") -> thumb
+            thumb.isNotBlank() -> baseUrl + thumb
+            else -> ""
+        }
         return anime
     }
 
     // ===== LATEST ANIME =====
-    override fun latestUpdatesSelector(): String = "div.seriesListContainer div"
+    override fun latestUpdatesSelector(): String = "table.new-episodes-table tbody tr"
 
     override fun latestUpdatesNextPageSelector(): String? = null
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/neu")
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/neue-episoden")
 
     override fun latestUpdatesFromElement(element: Element): SAnime {
         val anime = SAnime.create()
-        val linkElement = element.selectFirst("a")!!
-        anime.url = linkElement.attr("href")
-        anime.thumbnail_url = baseUrl + linkElement.selectFirst("img")!!.attr("data-src")
-        anime.title = element.selectFirst("h3")!!.text()
+        val link = element.selectFirst("td a[href*=\"/serie/\"]") ?: return anime
+        val href = link.attr("href") // /serie/name/staffel-X/episode-Y
+        val serieHref = if (href.contains("/staffel")) href.substringBefore("/staffel") else href.substringBefore("/episode")
+        anime.url = serieHref
+        anime.title = link.text().trim()
+        // Try to fetch thumbnail from serie page (best effort)
+        try {
+            val doc = client.newCall(GET(baseUrl + serieHref)).execute().asJsoup()
+            val img = doc.selectFirst("div.show-cover-mobile img")
+                ?: doc.selectFirst("div.col-5 picture img")
+                ?: doc.selectFirst("img[data-src*=\"/media/images/channel/\"]")
+                ?: doc.selectFirst("picture img")
+            val thumb = img?.let {
+                val ds = it.attr("data-src")
+                if (ds.isNotBlank()) ds else it.attr("src")
+            } ?: ""
+            anime.thumbnail_url = when {
+                thumb.startsWith("http") -> thumb
+                thumb.isNotBlank() -> baseUrl + thumb
+                else -> ""
+            }
+        } catch (e: Exception) {
+            anime.thumbnail_url = ""
+        }
         return anime
     }
 
     // ===== SEARCH =====
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
-        val headers = Headers.Builder()
-            .add("Referer", "http://186.2.175.5/search")
-            .add("origin", baseUrl)
-            .add("connection", "keep-alive")
-            .add("user-agent", "Mozilla/5.0 (Linux; Android 12; Pixel 5 Build/SP2A.220405.004; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.127 Safari/537.36")
-            .add("Upgrade-Insecure-Requests", "1")
-            .add("content-length", query.length.plus(8).toString())
-            .add("cache-control", "")
-            .add("accept", "*/*")
-            .add("content-type", "application/x-www-form-urlencoded; charset=UTF-8")
-            .add("x-requested-with", "XMLHttpRequest")
-            .build()
-        return POST("$baseUrl/ajax/search", body = FormBody.Builder().add("keyword", query).build(), headers = headers)
+        val encoded = URLEncoder.encode(query, "UTF-8")
+        return GET("$baseUrl/api/search/suggest?term=$encoded", headers)
     }
     override fun searchAnimeSelector() = throw UnsupportedOperationException()
 
@@ -105,25 +124,55 @@ class Serienstream :
 
     override fun searchAnimeParse(response: Response): AnimesPage {
         val body = response.body.string()
-        val results = json.decodeFromString<JsonArray>(body)
-        val animes = results.filter {
-            val link = it.jsonObject["link"]!!.jsonPrimitive.content
-            link.startsWith("/serie/stream/") &&
-                link.count { c -> c == '/' } == 3
-        }.map {
-            animeFromSearch(it.jsonObject)
+        return try {
+            val obj = json.decodeFromString<JsonObject>(body)
+            val shows = obj["shows"] as? JsonArray ?: JsonArray(emptyList())
+            val animes = shows.mapNotNull { elem ->
+                val jo = elem.jsonObject
+                val link = jo["url"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                val title = jo["name"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                animeFromSearch(title, link)
+            }
+            AnimesPage(animes, false)
+        } catch (e: Exception) {
+            // Fallback: try old array format
+            try {
+                val arr = json.decodeFromString<JsonArray>(body)
+                val animes = arr.mapNotNull { elem ->
+                    val jo = elem.jsonObject
+                    val link = jo["link"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    val title = jo["title"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    animeFromSearch(title, link)
+                }
+                AnimesPage(animes, false)
+            } catch (_: Exception) {
+                AnimesPage(emptyList(), false)
+            }
         }
-        return AnimesPage(animes, false)
     }
 
-    private fun animeFromSearch(result: JsonObject): SAnime {
+    private fun animeFromSearch(title: String, link: String): SAnime {
         val anime = SAnime.create()
-        val title = result["title"]!!.jsonPrimitive.content
-        val link = result["link"]!!.jsonPrimitive.content
         anime.title = title.replace("<em>", "").replace("</em>", "")
-        val thumpage = client.newCall(GET("$baseUrl$link")).execute().asJsoup()
-        anime.thumbnail_url = baseUrl + thumpage.selectFirst("div.seriesCoverBox img")!!.attr("data-src")
         anime.url = link
+        try {
+            val doc = client.newCall(GET(baseUrl + link)).execute().asJsoup()
+            val img = doc.selectFirst("div.show-cover-mobile img")
+                ?: doc.selectFirst("div.col-5 picture img")
+                ?: doc.selectFirst("img[data-src*=\"/media/images/channel/\"]")
+                ?: doc.selectFirst("picture img")
+            val thumb = img?.let {
+                val ds = it.attr("data-src")
+                if (ds.isNotBlank()) ds else it.attr("src")
+            } ?: ""
+            anime.thumbnail_url = when {
+                thumb.startsWith("http") -> thumb
+                thumb.isNotBlank() -> baseUrl + thumb
+                else -> ""
+            }
+        } catch (e: Exception) {
+            anime.thumbnail_url = ""
+        }
         return anime
     }
 
@@ -132,14 +181,42 @@ class Serienstream :
     // ===== ANIME DETAILS =====
     override fun animeDetailsParse(document: Document): SAnime {
         val anime = SAnime.create()
-        anime.title = document.selectFirst("div.series-title h1 span")!!.text()
-        anime.thumbnail_url = baseUrl + document.selectFirst("div.seriesCoverBox img")!!.attr("data-src")
-        anime.genre = document.select("div.genres ul li").joinToString { it.text() }
-        anime.description = document.selectFirst("p.seri_des")!!.attr("data-full-description")
-        document.selectFirst("div.cast li:contains(Produzent:) ul")?.let {
-            val author = it.select("li").joinToString { li -> li.text() }
-            anime.author = author
+        anime.title = document.selectFirst("h1")?.text()?.trim()
+            ?: document.selectFirst("title")?.text()?.substringBefore(" |")?.trim() ?: ""
+        val img = document.selectFirst("div.show-cover-mobile img")
+            ?: document.selectFirst("div.col-5 picture img")
+            ?: document.selectFirst("img[data-src*=\"/media/images/channel/\"]")
+            ?: document.selectFirst("picture img")
+        val thumb = img?.let {
+            val ds = it.attr("data-src")
+            if (ds.isNotBlank()) ds else it.attr("src")
+        } ?: ""
+        anime.thumbnail_url = when {
+            thumb.startsWith("http") -> thumb
+            thumb.isNotBlank() -> baseUrl + thumb
+            else -> ""
         }
+        anime.genre = document.select("a[href^=\"/genre/\"]").joinToString(", ") { it.text().trim() }
+        anime.description = document.selectFirst("div.series-description span.description-text")?.text()?.trim()
+            ?: document.selectFirst("div.series-description")?.text()?.trim()
+            ?: document.selectFirst("meta[name=description]")?.attr("content")?.trim() ?: ""
+        // Try chip-based author (episode page) then serie page fallback
+        val producersChip = document.select("[id^=pg-produzenten-] a").eachText()
+        val directorsChip = document.select("[id^=pg-regisseure-] a").eachText()
+        val actorsChip = document.select("[id^=pg-besetzung-] a").eachText()
+        val producersSerie = document.select("li.series-group:has(strong:contains(Produzent)) a").eachText()
+        val directorsSerie = document.select("li.series-group:has(strong:contains(Regisseur)) a").eachText()
+        val actorsSerie = document.select("li.series-group:has(strong:contains(Besetzung)) a").eachText()
+        val author = when {
+            producersChip.isNotEmpty() -> producersChip.joinToString(", ")
+            directorsChip.isNotEmpty() -> directorsChip.joinToString(", ")
+            actorsChip.isNotEmpty() -> actorsChip.joinToString(", ")
+            producersSerie.isNotEmpty() -> producersSerie.joinToString(", ")
+            directorsSerie.isNotEmpty() -> directorsSerie.joinToString(", ")
+            actorsSerie.isNotEmpty() -> actorsSerie.joinToString(", ")
+            else -> document.select("div.chips-wrap a").joinToString(", ") { it.text().trim() }
+        }
+        if (author.isNotBlank()) anime.author = author
         anime.status = SAnime.UNKNOWN
         return anime
     }
@@ -150,51 +227,96 @@ class Serienstream :
     override fun episodeListParse(response: Response): List<SEpisode> {
         val document = response.asJsoup()
         val episodeList = mutableListOf<SEpisode>()
-        val seasonsElements = document.select("#stream > ul:nth-child(1) > li > a")
-        if (seasonsElements.attr("href").contains("/filme")) {
-            seasonsElements.forEach {
-                val seasonEpList = parseMoviesFromSeries(it)
-                episodeList.addAll(seasonEpList)
+        var seasonLinks = document.select("nav#season-nav a[data-season-pill]")
+        if (seasonLinks.isEmpty()) seasonLinks = document.select("a[data-season-pill]")
+        if (seasonLinks.isEmpty()) seasonLinks = document.select("#stream > ul:nth-child(1) > li > a")
+        if (seasonLinks.isEmpty()) {
+            // Single season page: parse table directly
+            val rows = document.select("table.episode-table tbody tr.episode-row")
+            if (rows.isNotEmpty()) {
+                val baseSeasonUrl = response.request.url.toString()
+                rows.forEach { row -> episodeList.add(parseEpisodeRow(row, baseSeasonUrl)) }
+                return episodeList.reversed()
             }
-        } else {
-            seasonsElements.forEach {
-                val seasonEpList = parseEpisodesFromSeries(it)
-                episodeList.addAll(seasonEpList)
+            return emptyList()
+        }
+        val baseRequestUrl = response.request.url.toString()
+        for (seasonLink in seasonLinks) {
+            val seasonHref = seasonLink.attr("abs:href")
+            if (seasonHref.isBlank()) continue
+            val seasonDoc = if (seasonHref == baseRequestUrl) {
+                document
+            } else {
+                try {
+                    client.newCall(GET(seasonHref)).execute().asJsoup()
+                } catch (e: Exception) {
+                    continue
+                }
+            }
+            val rows = seasonDoc.select("table.episode-table tbody tr.episode-row")
+            if (rows.isNotEmpty()) {
+                rows.forEach { row -> episodeList.add(parseEpisodeRow(row, seasonHref)) }
+            } else {
+                // Fallback to nav episode links
+                val epLinks = seasonDoc.select("nav#episode-nav a[href*=\"/episode-\"]")
+                epLinks.forEach { el ->
+                    val ep = SEpisode.create()
+                    val href = el.attr("abs:href")
+                    ep.url = href.ifEmpty { el.attr("href") }
+                    val epNum = el.text().trim().toIntOrNull() ?: 1
+                    val seasonNum = seasonHref.substringAfter("/staffel-").substringBefore("/").ifEmpty { "1" }
+                    ep.name = "Staffel $seasonNum Folge $epNum"
+                    ep.episode_number = epNum.toFloat()
+                    episodeList.add(ep)
+                }
             }
         }
         return episodeList.reversed()
     }
 
-    private fun parseEpisodesFromSeries(element: Element): List<SEpisode> {
-        val seasonId = element.attr("abs:href")
-        val episodesHtml = client.newCall(GET(seasonId)).execute().asJsoup()
-        val episodeElements = episodesHtml.select("table.seasonEpisodesList tbody tr")
-        return episodeElements.map { episodeFromElement(it) }
-    }
-
-    private fun parseMoviesFromSeries(element: Element): List<SEpisode> {
-        val seasonId = element.attr("abs:href")
-        val episodesHtml = client.newCall(GET(seasonId)).execute().asJsoup()
-        val episodeElements = episodesHtml.select("table.seasonEpisodesList tbody tr")
-        return episodeElements.map { episodeFromElement(it) }
+    private fun parseEpisodeRow(element: Element, seasonUrl: String): SEpisode {
+        val episode = SEpisode.create()
+        val onclick = element.attr("onclick")
+        val href = when {
+            onclick.isNotBlank() -> {
+                Regex("""window\.location='([^']+)'""").find(onclick)?.groupValues?.get(1) ?: ""
+            }
+            else -> element.selectFirst("a[href*=\"/episode-\"]")?.attr("href") ?: ""
+        }
+        episode.url = href
+        val seasonNumRaw = seasonUrl.substringAfter("/staffel-").substringBefore("/").substringBefore("?").ifEmpty { "1" }
+        val isFilm = seasonNumRaw == "0" || seasonUrl.contains("/staffel-0")
+        val epNumText = element.selectFirst("th.episode-number-cell")?.text()?.trim()
+            ?: Regex("""episode-(\d+)""").find(href)?.groupValues?.get(1) ?: "1"
+        val epNum = epNumText.toIntOrNull() ?: 1
+        val titleGer = element.selectFirst("strong.episode-title-ger")?.text()?.trim()
+            ?: element.selectFirst("td.episode-title-cell strong")?.text()?.trim() ?: ""
+        val titleEng = element.selectFirst("span.episode-title-eng")?.text()?.trim() ?: ""
+        val displayTitle = when {
+            titleGer.isNotBlank() -> titleGer
+            titleEng.isNotBlank() -> titleEng
+            else -> "Episode $epNum"
+        }
+        if (isFilm) {
+            episode.name = "Film $epNum : $displayTitle"
+            episode.episode_number = epNum.toFloat()
+        } else {
+            episode.name = "Staffel $seasonNumRaw Folge $epNum : $displayTitle"
+            // Use absolute episode number for sorting; keep simple
+            episode.episode_number = try {
+                // Try to keep unique ordering across seasons: season*1000 + ep
+                val s = seasonNumRaw.toIntOrNull() ?: 1
+                (s * 1000 + epNum).toFloat()
+            } catch (_: Exception) {
+                epNum.toFloat()
+            }
+        }
+        return episode
     }
 
     override fun episodeFromElement(element: Element): SEpisode {
-        val episode = SEpisode.create()
-        if (element.select("td.seasonEpisodeTitle a").attr("href").contains("/film")) {
-            val num = element.attr("data-episode-season-id")
-            episode.name = "Film $num" + " : " + element.select("td.seasonEpisodeTitle a span").text()
-            episode.episode_number = element.attr("data-episode-season-id").toFloat()
-            episode.url = element.selectFirst("td.seasonEpisodeTitle a")!!.attr("href")
-        } else {
-            val season = element.select("td.seasonEpisodeTitle a").attr("href")
-                .substringAfter("staffel-").substringBefore("/episode")
-            val num = element.attr("data-episode-season-id")
-            episode.name = "Staffel $season Folge $num" + " : " + element.select("td.seasonEpisodeTitle a span").text()
-            episode.episode_number = element.select("td meta").attr("content").toFloat()
-            episode.url = element.selectFirst("td.seasonEpisodeTitle a")!!.attr("href")
-        }
-        return episode
+        // Keep for compatibility, parse as generic row
+        return parseEpisodeRow(element, element.attr("abs:href").substringBefore("/episode"))
     }
 
     // ===== VIDEO SOURCES =====
@@ -202,37 +324,123 @@ class Serienstream :
 
     override fun videoListParse(response: Response): List<Video> {
         val document = response.asJsoup()
-        val redirectlink = document.select("div.hosterSiteVideo ul.row li")
+        val csrfToken = document.selectFirst("meta[name=csrf-token]")?.attr("content") ?: ""
+        val formToken = document.selectFirst("input[name=_token]")?.attr("value") ?: csrfToken
+        val buttons = document.select("button.link-box[data-play-url]")
+            .ifEmpty { document.select("div.link-wrapper button[data-play-url]") }
+            .ifEmpty { document.select("button[data-play-url]") }
         val videoList = mutableListOf<Video>()
         val hosterSelection = preferences.getStringSet(SConstants.HOSTER_SELECTION, null)
-        redirectlink.forEach {
-            val langkey = it.attr("data-lang-key")
-            val language = getlanguage(langkey)
-            val redirectgs = baseUrl + it.selectFirst("a.watchEpisode")!!.attr("href")
-            val hoster = it.select("a h4").text()
-            if (hosterSelection != null) {
+
+        for (btn in buttons) {
+            val provider = btn.attr("data-provider-name").trim()
+            val langId = btn.attr("data-language-id").trim()
+            val langLabel = btn.attr("data-language-label").trim()
+            val playUrl = btn.attr("data-play-url").trim() // /r?t=...
+            if (playUrl.isBlank()) continue
+            val language = getLanguage(langId) ?: getLanguage(langLabel) ?: langLabel
+            // Pre-filter by provider if possible
+            val preFilterPass = when {
+                hosterSelection == null || hosterSelection.isEmpty() -> true
+                provider.equals("VOE", ignoreCase = true) -> hosterSelection.contains(SConstants.NAME_VOE)
+                provider.equals("Doodstream", ignoreCase = true) || provider.contains("Dood", ignoreCase = true) -> hosterSelection.contains(SConstants.NAME_DOOD)
+                provider.contains("Streamtape", ignoreCase = true) -> hosterSelection.contains(SConstants.NAME_STAPE)
+                provider.equals("Provider", ignoreCase = true) -> true // need to resolve to decide
+                else -> hosterSelection.contains(provider)
+            }
+            if (!preFilterPass) continue
+
+            val t = when {
+                playUrl.contains("t=") -> playUrl.substringAfter("t=").substringBefore("&")
+                else -> playUrl
+            }
+            if (t.isBlank()) continue
+
+            // Resolve hoster URL via POST to /r
+            val hosterUrl = try {
+                val formBody = FormBody.Builder()
+                    .add("_token", formToken.ifEmpty { csrfToken })
+                    .add("t", t)
+                    .build()
+                val req = Request.Builder()
+                    .url("$baseUrl/r")
+                    .post(formBody)
+                    .addHeader("Referer", response.request.url.toString())
+                    .addHeader("X-CSRF-TOKEN", csrfToken)
+                    .addHeader("X-Requested-With", "XMLHttpRequest")
+                    .addHeader("Origin", baseUrl)
+                    .build()
+                val res = client.newCall(req).execute()
+                // Try Location header first
+                var loc = res.header("Location")
+                if (loc.isNullOrBlank()) {
+                    // Try to parse meta refresh from body
+                    val body = res.body.string()
+                    val meta = Regex("""url='([^']+)'""").find(body)?.groupValues?.get(1)
+                        ?: Regex("""URL='([^']+)'""", RegexOption.IGNORE_CASE).find(body)?.groupValues?.get(1)
+                    loc = meta ?: res.request.url.toString()
+                    // If still /r, fallback to request url
+                    if (loc.contains("/r?") || loc == "$baseUrl/r") {
+                        // Try GET fallback
+                        val getRes = client.newCall(GET(baseUrl + playUrl)).execute()
+                        loc = getRes.header("Location") ?: getRes.request.url.toString()
+                        if (loc.contains("/r?")) {
+                            val b = getRes.body.string()
+                            loc = Regex("""url='([^']+)'""").find(b)?.groupValues?.get(1) ?: loc
+                        }
+                    }
+                }
+                res.close()
+                loc ?: ""
+            } catch (e: Exception) {
+                continue
+            }
+            if (hosterUrl.isBlank() || hosterUrl.contains("/r?") || hosterUrl == "$baseUrl/r" || hosterUrl == baseUrl) continue
+            // Post-filter for generic Provider after resolving
+            if (hosterSelection != null && hosterSelection.isNotEmpty() && provider.equals("Provider", ignoreCase = true)) {
+                val isVoe = hosterUrl.contains("voe", ignoreCase = true)
+                val isDood = hosterUrl.contains("dood", ignoreCase = true) || hosterUrl.contains("myvidplay", ignoreCase = true)
+                val isStape = hosterUrl.contains("streamtape", ignoreCase = true)
                 when {
-                    hoster.contains("VOE") && hosterSelection.contains(SConstants.NAME_VOE) -> {
-                        val url = client.newCall(GET(redirectgs)).execute().request.url.toString()
-                        videoList.addAll(VoeExtractor(client, headers).videosFromUrl(url, "($language) "))
+                    isVoe && !hosterSelection.contains(SConstants.NAME_VOE) -> continue
+                    isDood && !hosterSelection.contains(SConstants.NAME_DOOD) -> continue
+                    isStape && !hosterSelection.contains(SConstants.NAME_STAPE) -> continue
+                    !isVoe && !isDood && !isStape -> {
+                        // Unknown hoster, skip if user filtered
+                        // If user selected all, we will try to include via generic handling below
                     }
-
-                    hoster.contains("Doodstream") && hosterSelection.contains(SConstants.NAME_DOOD) -> {
-                        val quality = "Doodstream $language"
-                        val url = client.newCall(GET(redirectgs)).execute().request.url.toString()
-                        val video = DoodExtractor(client).videoFromUrl(url, quality)
-                        if (video != null) {
-                            videoList.add(video)
-                        }
+                }
+            }
+            // Extract via appropriate extractor
+            when {
+                hosterUrl.contains("voe", ignoreCase = true) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_VOE)) -> {
+                    val vids = try {
+                        VoeExtractor(client, headers).videosFromUrl(hosterUrl, "($language) ")
+                    } catch (_: Exception) {
+                        emptyList()
                     }
-
-                    hoster.contains("Streamtape") && hosterSelection.contains(SConstants.NAME_STAPE) -> {
-                        val quality = "Streamtape $language"
-                        val url = client.newCall(GET(redirectgs)).execute().request.url.toString()
-                        val video = StreamTapeExtractor(client).videoFromUrl(url, quality)
-                        if (video != null) {
-                            videoList.add(video)
-                        }
+                    videoList.addAll(vids)
+                }
+                (hosterUrl.contains("dood", ignoreCase = true) || hosterUrl.contains("myvidplay", ignoreCase = true)) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_DOOD)) -> {
+                    val quality = "Doodstream $language"
+                    try {
+                        val v = DoodExtractor(client).videoFromUrl(hosterUrl, quality)
+                        if (v != null) videoList.add(v)
+                    } catch (_: Exception) {}
+                }
+                hosterUrl.contains("streamtape", ignoreCase = true) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_STAPE)) -> {
+                    val quality = "Streamtape $language"
+                    try {
+                        val v = StreamTapeExtractor(client).videoFromUrl(hosterUrl, quality)
+                        if (v != null) videoList.add(v)
+                    } catch (_: Exception) {}
+                }
+                else -> {
+                    // Fallback: try VOE if provider was VOE
+                    if (provider.equals("VOE", ignoreCase = true) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_VOE))) {
+                        try {
+                            videoList.addAll(VoeExtractor(client, headers).videosFromUrl(hosterUrl, "($language) "))
+                        } catch (_: Exception) {}
                     }
                 }
             }
@@ -240,23 +448,16 @@ class Serienstream :
         return videoList
     }
 
-    private fun getlanguage(langkey: String): String? {
-        when {
-            langkey.contains("${SConstants.KEY_GER_SUB}") -> {
-                return "Deutscher Sub"
-            }
-
-            langkey.contains("${SConstants.KEY_GER_DUB}") -> {
-                return "Deutscher Dub"
-            }
-
-            langkey.contains("${SConstants.KEY_ENG_SUB}") -> {
-                return "Englischer Sub"
-            }
-
-            else -> {
-                return null
-            }
+    private fun getLanguage(langKey: String): String? {
+        val k = langKey.trim()
+        return when {
+            k == SConstants.KEY_GER_SUB.toString() || k.equals("Ger-Sub", ignoreCase = true) || k.equals("3", ignoreCase = true) -> SConstants.LANG_GER_SUB
+            k == SConstants.KEY_GER_DUB.toString() || k.equals("Deutsch", ignoreCase = true) || k.equals("1", ignoreCase = true) -> SConstants.LANG_GER_DUB
+            k == SConstants.KEY_ENG_SUB.toString() || k.equals("Englisch", ignoreCase = true) || k.equals("English", ignoreCase = true) || k.equals("2", ignoreCase = true) -> SConstants.LANG_ENG_SUB
+            k.contains(SConstants.KEY_GER_SUB.toString()) -> SConstants.LANG_GER_SUB
+            k.contains(SConstants.KEY_GER_DUB.toString()) -> SConstants.LANG_GER_DUB
+            k.contains(SConstants.KEY_ENG_SUB.toString()) -> SConstants.LANG_ENG_SUB
+            else -> null
         }
     }
 

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -1,7 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.de.serienstream
 
-import androidx.preference.ListPreference
-import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import aniyomi.lib.doodextractor.DoodExtractor
 import aniyomi.lib.streamtapeextractor.StreamTapeExtractor
@@ -14,8 +12,14 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.addListPreference
+import keiyoushi.utils.addSetPreference
+import keiyoushi.utils.bodyString
+import keiyoushi.utils.delegate
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.parallelCatchingFlatMapBlocking
+import keiyoushi.utils.parallelMapNotNullBlocking
+import keiyoushi.utils.useAsJsoup
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -43,13 +47,20 @@ class Serienstream :
 
     private val preferences by getPreferencesLazy()
 
+    private var preferredHoster by preferences.delegate(SConstants.PREFERRED_HOSTER, SConstants.URL_STAPE)
+    private var preferredLang by preferences.delegate(SConstants.PREFERRED_LANG, SConstants.LANG_GER_SUB)
+    private var hosterSelection by preferences.delegate(SConstants.HOSTER_SELECTION, SConstants.HOSTER_NAMES.toSet())
+
     override val client = network.client.newBuilder()
         .addInterceptor(DdosGuardInterceptor(network.client))
         .build()
 
     private val json: Json by injectLazy()
 
-    // ===== POPULAR ANIME =====
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
+    private val doodExtractor by lazy { DoodExtractor(client) }
+    private val streamTapeExtractor by lazy { StreamTapeExtractor(client) }
+
     override fun popularAnimeSelector(): String = "a.show-card"
 
     override fun popularAnimeNextPageSelector(): String? = null
@@ -59,60 +70,54 @@ class Serienstream :
     override fun popularAnimeFromElement(element: Element): SAnime {
         val anime = SAnime.create()
         val rawHref = element.attr("href")
-        // Strip staffel suffix to get base serie url, fallback to raw
         val href = if (rawHref.contains("/staffel")) rawHref.substringBefore("/staffel") else rawHref
         anime.url = href.ifEmpty { rawHref }
         val img = element.selectFirst("img")
         anime.title = img?.attr("alt")?.takeIf { it.isNotBlank() } ?: element.text().trim()
-        val thumb = img?.let {
-            val ds = it.attr("data-src")
-            if (ds.isNotBlank()) ds else it.attr("src")
-        } ?: ""
-        anime.thumbnail_url = when {
-            thumb.startsWith("http") -> thumb
-            thumb.isNotBlank() -> baseUrl + thumb
-            else -> ""
-        }
+        anime.thumbnail_url = img?.let { thumbUrl(it) }
         return anime
     }
 
-    // ===== LATEST ANIME =====
     override fun latestUpdatesSelector(): String = "table.new-episodes-table tbody tr"
 
     override fun latestUpdatesNextPageSelector(): String? = null
 
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/neue-episoden")
 
+    override fun latestUpdatesParse(response: Response): AnimesPage {
+        val document = response.useAsJsoup()
+        val elements = document.select(latestUpdatesSelector())
+        val animes = elements.parallelMapNotNullBlocking { element ->
+            val link = element.selectFirst("td a[href*=\"/serie/\"]") ?: return@parallelMapNotNullBlocking null
+            val href = link.attr("href")
+            val serieHref = if (href.contains("/staffel")) href.substringBefore("/staffel") else href.substringBefore("/episode")
+            val anime = SAnime.create().apply {
+                url = serieHref
+                title = link.text().trim()
+            }
+            try {
+                val doc = client.newCall(GET(baseUrl + serieHref)).execute().useAsJsoup()
+                val img = doc.selectFirst("div.show-cover-mobile img")
+                    ?: doc.selectFirst("div.col-5 picture img")
+                    ?: doc.selectFirst("img[data-src*=\"/media/images/channel/\"]")
+                    ?: doc.selectFirst("picture img")
+                anime.thumbnail_url = img?.let { thumbUrl(it) }
+            } catch (_: Exception) {
+            }
+            anime
+        }
+        return AnimesPage(animes, false)
+    }
+
     override fun latestUpdatesFromElement(element: Element): SAnime {
         val anime = SAnime.create()
         val link = element.selectFirst("td a[href*=\"/serie/\"]") ?: return anime
-        val href = link.attr("href") // /serie/name/staffel-X/episode-Y
+        val href = link.attr("href")
         val serieHref = if (href.contains("/staffel")) href.substringBefore("/staffel") else href.substringBefore("/episode")
         anime.url = serieHref
         anime.title = link.text().trim()
-        // Try to fetch thumbnail from serie page (best effort)
-        try {
-            val doc = client.newCall(GET(baseUrl + serieHref)).execute().asJsoup()
-            val img = doc.selectFirst("div.show-cover-mobile img")
-                ?: doc.selectFirst("div.col-5 picture img")
-                ?: doc.selectFirst("img[data-src*=\"/media/images/channel/\"]")
-                ?: doc.selectFirst("picture img")
-            val thumb = img?.let {
-                val ds = it.attr("data-src")
-                if (ds.isNotBlank()) ds else it.attr("src")
-            } ?: ""
-            anime.thumbnail_url = when {
-                thumb.startsWith("http") -> thumb
-                thumb.isNotBlank() -> baseUrl + thumb
-                else -> ""
-            }
-        } catch (e: Exception) {
-            anime.thumbnail_url = ""
-        }
         return anime
     }
-
-    // ===== SEARCH =====
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val encoded = URLEncoder.encode(query, "UTF-8")
@@ -123,25 +128,24 @@ class Serienstream :
     override fun searchAnimeNextPageSelector() = throw UnsupportedOperationException()
 
     override fun searchAnimeParse(response: Response): AnimesPage {
-        val body = response.body.string()
+        val body = response.bodyString()
         return try {
             val obj = json.decodeFromString<JsonObject>(body)
             val shows = obj["shows"] as? JsonArray ?: JsonArray(emptyList())
-            val animes = shows.mapNotNull { elem ->
+            val animes = shows.parallelMapNotNullBlocking { elem ->
                 val jo = elem.jsonObject
-                val link = jo["url"]?.jsonPrimitive?.content ?: return@mapNotNull null
-                val title = jo["name"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                val link = jo["url"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
+                val title = jo["name"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
                 animeFromSearch(title, link)
             }
             AnimesPage(animes, false)
-        } catch (e: Exception) {
-            // Fallback: try old array format
+        } catch (_: Exception) {
             try {
                 val arr = json.decodeFromString<JsonArray>(body)
-                val animes = arr.mapNotNull { elem ->
+                val animes = arr.parallelMapNotNullBlocking { elem ->
                     val jo = elem.jsonObject
-                    val link = jo["link"]?.jsonPrimitive?.content ?: return@mapNotNull null
-                    val title = jo["title"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                    val link = jo["link"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
+                    val title = jo["title"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
                     animeFromSearch(title, link)
                 }
                 AnimesPage(animes, false)
@@ -156,29 +160,19 @@ class Serienstream :
         anime.title = title.replace("<em>", "").replace("</em>", "")
         anime.url = link
         try {
-            val doc = client.newCall(GET(baseUrl + link)).execute().asJsoup()
+            val doc = client.newCall(GET(baseUrl + link)).execute().useAsJsoup()
             val img = doc.selectFirst("div.show-cover-mobile img")
                 ?: doc.selectFirst("div.col-5 picture img")
                 ?: doc.selectFirst("img[data-src*=\"/media/images/channel/\"]")
                 ?: doc.selectFirst("picture img")
-            val thumb = img?.let {
-                val ds = it.attr("data-src")
-                if (ds.isNotBlank()) ds else it.attr("src")
-            } ?: ""
-            anime.thumbnail_url = when {
-                thumb.startsWith("http") -> thumb
-                thumb.isNotBlank() -> baseUrl + thumb
-                else -> ""
-            }
-        } catch (e: Exception) {
-            anime.thumbnail_url = ""
+            anime.thumbnail_url = img?.let { thumbUrl(it) }
+        } catch (_: Exception) {
         }
         return anime
     }
 
     override fun searchAnimeFromElement(element: Element) = throw UnsupportedOperationException()
 
-    // ===== ANIME DETAILS =====
     override fun animeDetailsParse(document: Document): SAnime {
         val anime = SAnime.create()
         anime.title = document.selectFirst("h1")?.text()?.trim()
@@ -187,20 +181,11 @@ class Serienstream :
             ?: document.selectFirst("div.col-5 picture img")
             ?: document.selectFirst("img[data-src*=\"/media/images/channel/\"]")
             ?: document.selectFirst("picture img")
-        val thumb = img?.let {
-            val ds = it.attr("data-src")
-            if (ds.isNotBlank()) ds else it.attr("src")
-        } ?: ""
-        anime.thumbnail_url = when {
-            thumb.startsWith("http") -> thumb
-            thumb.isNotBlank() -> baseUrl + thumb
-            else -> ""
-        }
+        anime.thumbnail_url = img?.let { thumbUrl(it) }
         anime.genre = document.select("a[href^=\"/genre/\"]").joinToString(", ") { it.text().trim() }
         anime.description = document.selectFirst("div.series-description span.description-text")?.text()?.trim()
             ?: document.selectFirst("div.series-description")?.text()?.trim()
             ?: document.selectFirst("meta[name=description]")?.attr("content")?.trim() ?: ""
-        // Try chip-based author (episode page) then serie page fallback
         val producersChip = document.select("[id^=pg-produzenten-] a").eachText()
         val directorsChip = document.select("[id^=pg-regisseure-] a").eachText()
         val actorsChip = document.select("[id^=pg-besetzung-] a").eachText()
@@ -221,17 +206,15 @@ class Serienstream :
         return anime
     }
 
-    // ===== EPISODE =====
     override fun episodeListSelector() = throw UnsupportedOperationException()
 
     override fun episodeListParse(response: Response): List<SEpisode> {
-        val document = response.asJsoup()
+        val document = response.useAsJsoup()
         val episodeList = mutableListOf<SEpisode>()
         var seasonLinks = document.select("nav#season-nav a[data-season-pill]")
         if (seasonLinks.isEmpty()) seasonLinks = document.select("a[data-season-pill]")
         if (seasonLinks.isEmpty()) seasonLinks = document.select("#stream > ul:nth-child(1) > li > a")
         if (seasonLinks.isEmpty()) {
-            // Single season page: parse table directly
             val rows = document.select("table.episode-table tbody tr.episode-row")
             if (rows.isNotEmpty()) {
                 val baseSeasonUrl = response.request.url.toString()
@@ -248,8 +231,8 @@ class Serienstream :
                 document
             } else {
                 try {
-                    client.newCall(GET(seasonHref)).execute().asJsoup()
-                } catch (e: Exception) {
+                    client.newCall(GET(seasonHref)).execute().useAsJsoup()
+                } catch (_: Exception) {
                     continue
                 }
             }
@@ -257,7 +240,6 @@ class Serienstream :
             if (rows.isNotEmpty()) {
                 rows.forEach { row -> episodeList.add(parseEpisodeRow(row, seasonHref)) }
             } else {
-                // Fallback to nav episode links
                 val epLinks = seasonDoc.select("nav#episode-nav a[href*=\"/episode-\"]")
                 epLinks.forEach { el ->
                     val ep = SEpisode.create()
@@ -302,9 +284,7 @@ class Serienstream :
             episode.episode_number = epNum.toFloat()
         } else {
             episode.name = "Staffel $seasonNumRaw Folge $epNum : $displayTitle"
-            // Use absolute episode number for sorting; keep simple
             episode.episode_number = try {
-                // Try to keep unique ordering across seasons: season*1000 + ep
                 val s = seasonNumRaw.toIntOrNull() ?: 1
                 (s * 1000 + epNum).toFloat()
             } catch (_: Exception) {
@@ -314,241 +294,176 @@ class Serienstream :
         return episode
     }
 
-    override fun episodeFromElement(element: Element): SEpisode {
-        // Keep for compatibility, parse as generic row
-        return parseEpisodeRow(element, element.attr("abs:href").substringBefore("/episode"))
-    }
+    override fun episodeFromElement(element: Element): SEpisode = parseEpisodeRow(element, element.attr("abs:href").substringBefore("/episode"))
 
-    // ===== VIDEO SOURCES =====
     override fun videoListSelector() = throw UnsupportedOperationException()
 
     override fun videoListParse(response: Response): List<Video> {
-        val document = response.asJsoup()
+        val document = response.useAsJsoup()
         val csrfToken = document.selectFirst("meta[name=csrf-token]")?.attr("content") ?: ""
         val formToken = document.selectFirst("input[name=_token]")?.attr("value") ?: csrfToken
         val buttons = document.select("button.link-box[data-play-url]")
             .ifEmpty { document.select("div.link-wrapper button[data-play-url]") }
             .ifEmpty { document.select("button[data-play-url]") }
-        val videoList = mutableListOf<Video>()
-        val hosterSelection = preferences.getStringSet(SConstants.HOSTER_SELECTION, null)
+        val selection = hosterSelection
 
-        for (btn in buttons) {
+        return buttons.parallelCatchingFlatMapBlocking { btn ->
             val provider = btn.attr("data-provider-name").trim()
             val langId = btn.attr("data-language-id").trim()
             val langLabel = btn.attr("data-language-label").trim()
-            val playUrl = btn.attr("data-play-url").trim() // /r?t=...
-            if (playUrl.isBlank()) continue
+            val playUrl = btn.attr("data-play-url").trim()
+            if (playUrl.isBlank()) return@parallelCatchingFlatMapBlocking emptyList()
             val language = getLanguage(langId) ?: getLanguage(langLabel) ?: langLabel
-            // Pre-filter by provider if possible
             val preFilterPass = when {
-                hosterSelection == null || hosterSelection.isEmpty() -> true
-                provider.equals("VOE", ignoreCase = true) -> hosterSelection.contains(SConstants.NAME_VOE)
-                provider.equals("Doodstream", ignoreCase = true) || provider.contains("Dood", ignoreCase = true) -> hosterSelection.contains(SConstants.NAME_DOOD)
-                provider.contains("Streamtape", ignoreCase = true) -> hosterSelection.contains(SConstants.NAME_STAPE)
-                provider.equals("Provider", ignoreCase = true) -> true // need to resolve to decide
-                else -> hosterSelection.contains(provider)
+                selection.isEmpty() -> true
+                provider.equals("VOE", true) -> selection.contains(SConstants.NAME_VOE)
+                provider.equals("Doodstream", true) || provider.contains("Dood", true) -> selection.contains(SConstants.NAME_DOOD)
+                provider.contains("Streamtape", true) -> selection.contains(SConstants.NAME_STAPE)
+                provider.equals("Provider", true) -> true
+                else -> selection.contains(provider)
             }
-            if (!preFilterPass) continue
+            if (!preFilterPass) return@parallelCatchingFlatMapBlocking emptyList()
 
-            val t = when {
-                playUrl.contains("t=") -> playUrl.substringAfter("t=").substringBefore("&")
-                else -> playUrl
+            val t = if (playUrl.contains("t=")) playUrl.substringAfter("t=").substringBefore("&") else playUrl
+            if (t.isBlank()) return@parallelCatchingFlatMapBlocking emptyList()
+
+            val hosterUrl = resolveHosterUrl(t, csrfToken, formToken, response.request.url.toString(), playUrl) ?: return@parallelCatchingFlatMapBlocking emptyList()
+            if (hosterUrl.isBlank() || hosterUrl.contains("/r?") || hosterUrl == "$baseUrl/r" || hosterUrl == baseUrl) return@parallelCatchingFlatMapBlocking emptyList()
+
+            if (provider.equals("Provider", true)) {
+                val isVoe = hosterUrl.contains("voe", true)
+                val isDood = hosterUrl.contains("dood", true) || hosterUrl.contains("myvidplay", true)
+                val isStape = hosterUrl.contains("streamtape", true)
+                when {
+                    isVoe && !selection.contains(SConstants.NAME_VOE) -> return@parallelCatchingFlatMapBlocking emptyList()
+                    isDood && !selection.contains(SConstants.NAME_DOOD) -> return@parallelCatchingFlatMapBlocking emptyList()
+                    isStape && !selection.contains(SConstants.NAME_STAPE) -> return@parallelCatchingFlatMapBlocking emptyList()
+                }
             }
-            if (t.isBlank()) continue
 
-            // Resolve hoster URL via POST to /r
-            val hosterUrl = try {
-                val formBody = FormBody.Builder()
-                    .add("_token", formToken.ifEmpty { csrfToken })
-                    .add("t", t)
-                    .build()
-                val req = Request.Builder()
-                    .url("$baseUrl/r")
-                    .post(formBody)
-                    .addHeader("Referer", response.request.url.toString())
-                    .addHeader("X-CSRF-TOKEN", csrfToken)
-                    .addHeader("X-Requested-With", "XMLHttpRequest")
-                    .addHeader("Origin", baseUrl)
-                    .build()
-                val res = client.newCall(req).execute()
-                // Try Location header first
-                var loc = res.header("Location")
-                if (loc.isNullOrBlank()) {
-                    // Try to parse meta refresh from body
-                    val body = res.body.string()
-                    val meta = Regex("""url='([^']+)'""").find(body)?.groupValues?.get(1)
-                        ?: Regex("""URL='([^']+)'""", RegexOption.IGNORE_CASE).find(body)?.groupValues?.get(1)
-                    loc = meta ?: res.request.url.toString()
-                    // If still /r, fallback to request url
-                    if (loc.contains("/r?") || loc == "$baseUrl/r") {
-                        // Try GET fallback
-                        val getRes = client.newCall(GET(baseUrl + playUrl)).execute()
+            when {
+                hosterUrl.contains("voe", true) && (selection.isEmpty() || selection.contains(SConstants.NAME_VOE)) -> voeExtractor.videosFromUrl(hosterUrl, "($language) ")
+                hosterUrl.contains("dood", true) || hosterUrl.contains("myvidplay", true) -> {
+                    if (selection.isEmpty() || selection.contains(SConstants.NAME_DOOD)) {
+                        doodExtractor.videoFromUrl(hosterUrl, "Doodstream $language")?.let(::listOf) ?: emptyList()
+                    } else {
+                        emptyList()
+                    }
+                }
+                hosterUrl.contains("streamtape", true) -> {
+                    if (selection.isEmpty() || selection.contains(SConstants.NAME_STAPE)) {
+                        streamTapeExtractor.videoFromUrl(hosterUrl, "Streamtape $language")?.let(::listOf) ?: emptyList()
+                    } else {
+                        emptyList()
+                    }
+                }
+                provider.equals("VOE", true) -> voeExtractor.videosFromUrl(hosterUrl, "($language) ")
+                else -> emptyList()
+            }
+        }
+    }
+
+    private fun resolveHosterUrl(t: String, csrfToken: String, formToken: String, referer: String, playUrl: String): String? = try {
+        val formBody = FormBody.Builder()
+            .add("_token", formToken.ifEmpty { csrfToken })
+            .add("t", t)
+            .build()
+        val req = Request.Builder()
+            .url("$baseUrl/r")
+            .post(formBody)
+            .addHeader("Referer", referer)
+            .addHeader("X-CSRF-TOKEN", csrfToken)
+            .addHeader("X-Requested-With", "XMLHttpRequest")
+            .addHeader("Origin", baseUrl)
+            .build()
+        client.newCall(req).execute().use { res ->
+            var loc = res.header("Location")
+            if (loc.isNullOrBlank()) {
+                val body = res.bodyString()
+                val meta = Regex("""url='([^']+)'""").find(body)?.groupValues?.get(1)
+                    ?: Regex("""URL='([^']+)'""", RegexOption.IGNORE_CASE).find(body)?.groupValues?.get(1)
+                loc = meta ?: res.request.url.toString()
+                if (loc.contains("/r?") || loc == "$baseUrl/r") {
+                    client.newCall(GET(baseUrl + playUrl)).execute().use { getRes ->
                         loc = getRes.header("Location") ?: getRes.request.url.toString()
                         if (loc.contains("/r?")) {
-                            val b = getRes.body.string()
+                            val b = getRes.bodyString()
                             loc = Regex("""url='([^']+)'""").find(b)?.groupValues?.get(1) ?: loc
                         }
                     }
                 }
-                res.close()
-                loc ?: ""
-            } catch (e: Exception) {
-                continue
             }
-            if (hosterUrl.isBlank() || hosterUrl.contains("/r?") || hosterUrl == "$baseUrl/r" || hosterUrl == baseUrl) continue
-            // Post-filter for generic Provider after resolving
-            if (hosterSelection != null && hosterSelection.isNotEmpty() && provider.equals("Provider", ignoreCase = true)) {
-                val isVoe = hosterUrl.contains("voe", ignoreCase = true)
-                val isDood = hosterUrl.contains("dood", ignoreCase = true) || hosterUrl.contains("myvidplay", ignoreCase = true)
-                val isStape = hosterUrl.contains("streamtape", ignoreCase = true)
-                when {
-                    isVoe && !hosterSelection.contains(SConstants.NAME_VOE) -> continue
-                    isDood && !hosterSelection.contains(SConstants.NAME_DOOD) -> continue
-                    isStape && !hosterSelection.contains(SConstants.NAME_STAPE) -> continue
-                    !isVoe && !isDood && !isStape -> {
-                        // Unknown hoster, skip if user filtered
-                        // If user selected all, we will try to include via generic handling below
-                    }
-                }
-            }
-            // Extract via appropriate extractor
-            when {
-                hosterUrl.contains("voe", ignoreCase = true) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_VOE)) -> {
-                    val vids = try {
-                        VoeExtractor(client, headers).videosFromUrl(hosterUrl, "($language) ")
-                    } catch (_: Exception) {
-                        emptyList()
-                    }
-                    videoList.addAll(vids)
-                }
-                (hosterUrl.contains("dood", ignoreCase = true) || hosterUrl.contains("myvidplay", ignoreCase = true)) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_DOOD)) -> {
-                    val quality = "Doodstream $language"
-                    try {
-                        val v = DoodExtractor(client).videoFromUrl(hosterUrl, quality)
-                        if (v != null) videoList.add(v)
-                    } catch (_: Exception) {}
-                }
-                hosterUrl.contains("streamtape", ignoreCase = true) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_STAPE)) -> {
-                    val quality = "Streamtape $language"
-                    try {
-                        val v = StreamTapeExtractor(client).videoFromUrl(hosterUrl, quality)
-                        if (v != null) videoList.add(v)
-                    } catch (_: Exception) {}
-                }
-                else -> {
-                    // Fallback: try VOE if provider was VOE
-                    if (provider.equals("VOE", ignoreCase = true) && (hosterSelection == null || hosterSelection.contains(SConstants.NAME_VOE))) {
-                        try {
-                            videoList.addAll(VoeExtractor(client, headers).videosFromUrl(hosterUrl, "($language) "))
-                        } catch (_: Exception) {}
-                    }
-                }
-            }
+            loc
         }
-        return videoList
+    } catch (_: Exception) {
+        null
     }
 
-    private fun getLanguage(langKey: String): String? {
-        val k = langKey.trim()
-        return when {
-            k == SConstants.KEY_GER_SUB.toString() || k.equals("Ger-Sub", ignoreCase = true) || k.equals("3", ignoreCase = true) -> SConstants.LANG_GER_SUB
-            k == SConstants.KEY_GER_DUB.toString() || k.equals("Deutsch", ignoreCase = true) || k.equals("1", ignoreCase = true) -> SConstants.LANG_GER_DUB
-            k == SConstants.KEY_ENG_SUB.toString() || k.equals("Englisch", ignoreCase = true) || k.equals("English", ignoreCase = true) || k.equals("2", ignoreCase = true) -> SConstants.LANG_ENG_SUB
-            k.contains(SConstants.KEY_GER_SUB.toString()) -> SConstants.LANG_GER_SUB
-            k.contains(SConstants.KEY_GER_DUB.toString()) -> SConstants.LANG_GER_DUB
-            k.contains(SConstants.KEY_ENG_SUB.toString()) -> SConstants.LANG_ENG_SUB
-            else -> null
-        }
+    private fun thumbUrl(img: Element): String? {
+        val url = img.attr("abs:data-src").ifBlank { img.attr("abs:src") }
+            .ifBlank {
+                val raw = img.attr("data-src").ifBlank { img.attr("src") }
+                when {
+                    raw.startsWith("http") -> raw
+                    raw.isNotBlank() -> baseUrl + raw
+                    else -> ""
+                }
+            }
+        return url.ifBlank { null }
+    }
+
+    private val langMap = mapOf(
+        "1" to SConstants.LANG_GER_DUB,
+        "Deutsch" to SConstants.LANG_GER_DUB,
+        "3" to SConstants.LANG_GER_SUB,
+        "Ger-Sub" to SConstants.LANG_GER_SUB,
+        "2" to SConstants.LANG_ENG_SUB,
+        "Englisch" to SConstants.LANG_ENG_SUB,
+        "English" to SConstants.LANG_ENG_SUB,
+    )
+
+    private fun getLanguage(key: String): String? {
+        val k = key.trim()
+        return langMap[k] ?: langMap.entries.firstOrNull { k.contains(it.key, true) }?.value
     }
 
     override fun videoFromElement(element: Element): Video = throw UnsupportedOperationException()
 
     override fun List<Video>.sort(): List<Video> {
-        val hoster = preferences.getString(SConstants.PREFERRED_HOSTER, null)
-        val subPreference = preferences.getString(SConstants.PREFERRED_LANG, "Sub")!!
-        val hosterList = mutableListOf<Video>()
-        val otherList = mutableListOf<Video>()
-        if (hoster != null) {
-            for (video in this) {
-                if (video.url.contains(hoster)) {
-                    hosterList.add(video)
-                } else {
-                    otherList.add(video)
-                }
-            }
-        } else {
-            otherList += this
-        }
-        val newList = mutableListOf<Video>()
-        var preferred = 0
-        for (video in hosterList) {
-            if (video.quality.contains(subPreference)) {
-                newList.add(preferred, video)
-                preferred++
-            } else {
-                newList.add(video)
-            }
-        }
-        for (video in otherList) {
-            if (video.quality.contains(subPreference)) {
-                newList.add(preferred, video)
-                preferred++
-            } else {
-                newList.add(video)
-            }
-        }
-
-        return newList
+        val hoster = preferredHoster.takeIf { it.isNotBlank() }
+        val lang = preferredLang
+        return sortedWith(
+            compareByDescending<Video> { hoster != null && it.url.contains(hoster, true) }
+                .thenByDescending { it.quality.contains(lang, true) },
+        )
     }
 
     override fun videoUrlParse(document: Document): String = throw UnsupportedOperationException()
 
-    // ===== PREFERENCES ======
-    @Suppress("UNCHECKED_CAST")
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        val hosterPref = ListPreference(screen.context).apply {
-            key = SConstants.PREFERRED_HOSTER
-            title = "Standard-Hoster"
-            entries = SConstants.HOSTER_NAMES
-            entryValues = SConstants.HOSTER_URLS
-            setDefaultValue(SConstants.URL_STAPE)
-            summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
-        }
-        val subPref = ListPreference(screen.context).apply {
-            key = SConstants.PREFERRED_LANG
-            title = "Bevorzugte Sprache"
-            entries = SConstants.LANGS
-            entryValues = SConstants.LANGS
-            setDefaultValue(SConstants.LANG_GER_SUB)
-            summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
-        }
-        val hosterSelection = MultiSelectListPreference(screen.context).apply {
-            key = SConstants.HOSTER_SELECTION
-            title = "Hoster auswählen"
-            entries = SConstants.HOSTER_NAMES
-            entryValues = SConstants.HOSTER_NAMES
-            setDefaultValue(SConstants.HOSTER_NAMES.toSet())
-
-            setOnPreferenceChangeListener { _, newValue ->
-                preferences.edit().putStringSet(key, newValue as Set<String>).commit()
-            }
-        }
-        screen.addPreference(subPref)
-        screen.addPreference(hosterPref)
-        screen.addPreference(hosterSelection)
+        screen.addListPreference(
+            key = SConstants.PREFERRED_LANG,
+            default = SConstants.LANG_GER_SUB,
+            title = "Bevorzugte Sprache",
+            entries = SConstants.LANGS.toList(),
+            entryValues = SConstants.LANGS.toList(),
+            summary = "%s",
+        )
+        screen.addListPreference(
+            key = SConstants.PREFERRED_HOSTER,
+            default = SConstants.URL_STAPE,
+            title = "Standard-Hoster",
+            entries = SConstants.HOSTER_NAMES.toList(),
+            entryValues = SConstants.HOSTER_URLS.toList(),
+            summary = "%s",
+        )
+        screen.addSetPreference(
+            key = SConstants.HOSTER_SELECTION,
+            default = SConstants.HOSTER_NAMES.toSet(),
+            title = "Hoster auswählen",
+            summary = "",
+            entries = SConstants.HOSTER_NAMES.toList(),
+            entryValues = SConstants.HOSTER_NAMES.toList(),
+        )
     }
 }

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -472,7 +472,11 @@ class Serienstream :
 
     private fun getLanguage(key: String): String? {
         val k = key.trim()
-        return langMap[k] ?: langMap.entries.firstOrNull { k.contains(it.key, true) }?.value
+        langMap[k]?.let { return it }
+        // Only exact matches are meaningful for numeric IDs ("10" must not match "1");
+        // fuzzy matching is reserved for textual labels.
+        if (k.isNotEmpty() && k.all(Char::isDigit)) return null
+        return langMap.entries.firstOrNull { k.contains(it.key, true) }?.value
     }
 
     override fun videoFromElement(element: Element): Video = throw UnsupportedOperationException()

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -39,7 +39,7 @@ class Serienstream :
 
     override val name = "Serienstream"
 
-    override val baseUrl = "https://s.to"
+    override val baseUrl = "https://serienstream.to"
 
     override val lang = "de"
 

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -199,9 +199,9 @@ class Serienstream :
 
     private fun parseStatus(document: Document): Int {
         val yearBlock = document.selectFirst("p.small.text-muted.mb-2")?.text() ?: return SAnime.UNKNOWN
-        if (yearBlock.contains("NA")) return SAnime.ONGOING
-        val years = Regex("""\b(19|20)\d{2}\b""").findAll(yearBlock).toList()
-        return if (years.size >= 2) SAnime.COMPLETED else SAnime.UNKNOWN
+        val yearRange = Regex("""((?:19|20)\d{2})\s*[-–]\s*((?:19|20)\d{2}|NA)""").find(yearBlock)
+            ?: return SAnime.UNKNOWN
+        return if (yearRange.groupValues[2] == "NA") SAnime.ONGOING else SAnime.COMPLETED
     }
 
     override fun episodeListSelector() = throw UnsupportedOperationException()
@@ -242,7 +242,7 @@ class Serienstream :
                 epLinks.forEach { el ->
                     val ep = SEpisode.create()
                     val href = el.attr("abs:href")
-                    ep.url = href.ifEmpty { el.attr("href") }
+                    ep.url = href.ifEmpty { el.attr("href") }.removePrefix(baseUrl)
                     val epNum = el.text().trim().toIntOrNull() ?: 1
                     val seasonNum = seasonHref.substringAfter("/staffel-").substringBefore("/").ifEmpty { "1" }
                     ep.name = "Staffel $seasonNum Folge $epNum"
@@ -389,7 +389,8 @@ class Serienstream :
                     ?: Regex("""URL='([^']+)'""", RegexOption.IGNORE_CASE).find(body)?.groupValues?.get(1)
                 loc = meta ?: res.request.url.toString()
                 if (loc.contains("/r?") || loc == "$baseUrl/r") {
-                    client.newCall(GET(baseUrl + playUrl)).execute().use { getRes ->
+                    val play = UrlUtils.fixUrl(playUrl, baseUrl) ?: return null
+                    client.newCall(GET(play)).execute().use { getRes ->
                         loc = getRes.header("Location") ?: getRes.request.url.toString()
                         if (loc.contains("/r?")) {
                             val b = getRes.bodyString()

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -193,8 +193,15 @@ class Serienstream :
             else -> document.select("div.chips-wrap a").joinToString(", ") { it.text().trim() }
         }
         if (author.isNotBlank()) anime.author = author
-        anime.status = SAnime.UNKNOWN
+        anime.status = parseStatus(document)
         return anime
+    }
+
+    private fun parseStatus(document: Document): Int {
+        val yearBlock = document.selectFirst("p.small.text-muted.mb-2")?.text() ?: return SAnime.UNKNOWN
+        if (yearBlock.contains("NA")) return SAnime.ONGOING
+        val years = Regex("""\b(19|20)\d{2}\b""").findAll(yearBlock).toList()
+        return if (years.size >= 2) SAnime.COMPLETED else SAnime.UNKNOWN
     }
 
     override fun episodeListSelector() = throw UnsupportedOperationException()

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -317,7 +317,13 @@ class Serienstream :
             }
             if (!preFilterPass) return@parallelCatchingFlatMapBlocking emptyList()
 
-            val t = if (playUrl.contains("t=")) playUrl.substringAfter("t=").substringBefore("&") else playUrl
+            val rawT = if (playUrl.contains("t=")) playUrl.substringAfter("t=").substringBefore("&") else playUrl
+            if (rawT.isBlank()) return@parallelCatchingFlatMapBlocking emptyList()
+            val t = try {
+                java.net.URLDecoder.decode(rawT.replace("+", "%2B"), "UTF-8")
+            } catch (_: Exception) {
+                rawT
+            }
             if (t.isBlank()) return@parallelCatchingFlatMapBlocking emptyList()
 
             val hosterUrl = resolveHosterUrl(t, csrfToken, formToken, response.request.url.toString(), playUrl, altcha) ?: return@parallelCatchingFlatMapBlocking emptyList()
@@ -370,7 +376,8 @@ class Serienstream :
             .addHeader("X-Requested-With", "XMLHttpRequest")
             .addHeader("Origin", baseUrl)
             .build()
-        client.newCall(req).execute().use { res ->
+        val noRedirectClient = client.newBuilder().followRedirects(false).build()
+        noRedirectClient.newCall(req).execute().use { res ->
             var loc = res.header("Location")
             if (loc.isNullOrBlank()) {
                 val body = res.bodyString()

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -257,14 +257,11 @@ class Serienstream :
     private fun parseEpisodeRow(element: Element, seasonUrl: String): SEpisode {
         val episode = SEpisode.create()
         val onclick = element.attr("onclick")
-        val href = when {
-            onclick.isNotBlank() -> {
-                Regex("""window\.location='([^']+)'""").find(onclick)?.groupValues?.get(1) ?: ""
-            }
-            else -> element.selectFirst("a[href*=\"/episode-\"]")?.attr("href") ?: ""
-        }
+        val href = Regex("""window\.location='([^']+)'""").find(onclick)?.groupValues?.get(1)
+            ?: element.selectFirst("a[href*=\"/episode-\"]")?.attr("href")
+            ?: ""
         episode.url = href
-        val seasonNumRaw = seasonUrl.substringAfter("/staffel-").substringBefore("/").substringBefore("?").ifEmpty { "1" }
+        val seasonNumRaw = seasonUrl.substringAfter("/staffel-", "").takeWhile(Char::isDigit).ifEmpty { "1" }
         val isFilm = seasonNumRaw == "0" || seasonUrl.contains("/staffel-0")
         val epNumText = element.selectFirst("th.episode-number-cell")?.text()?.trim()
             ?: Regex("""episode-(\d+)""").find(href)?.groupValues?.get(1) ?: "1"
@@ -338,9 +335,9 @@ class Serienstream :
                 val isDood = hosterUrl.contains("dood", true) || hosterUrl.contains("myvidplay", true)
                 val isStape = hosterUrl.contains("streamtape", true)
                 when {
-                    isVoe && !selection.contains(SConstants.NAME_VOE) -> return@parallelCatchingFlatMapBlocking emptyList()
-                    isDood && !selection.contains(SConstants.NAME_DOOD) -> return@parallelCatchingFlatMapBlocking emptyList()
-                    isStape && !selection.contains(SConstants.NAME_STAPE) -> return@parallelCatchingFlatMapBlocking emptyList()
+                    isVoe && selection.isNotEmpty() && !selection.contains(SConstants.NAME_VOE) -> return@parallelCatchingFlatMapBlocking emptyList()
+                    isDood && selection.isNotEmpty() && !selection.contains(SConstants.NAME_DOOD) -> return@parallelCatchingFlatMapBlocking emptyList()
+                    isStape && selection.isNotEmpty() && !selection.contains(SConstants.NAME_STAPE) -> return@parallelCatchingFlatMapBlocking emptyList()
                 }
             }
 

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -101,7 +101,7 @@ class Serienstream :
                 title = link.text().trim()
             }
         }
-        return AnimesPage(animes, false)
+        return AnimesPage(animes.distinctBy { it.url }, false)
     }
 
     override fun latestUpdatesFromElement(element: Element): SAnime {
@@ -216,7 +216,7 @@ class Serienstream :
             val rows = document.select("table.episode-table tbody tr.episode-row")
             if (rows.isNotEmpty()) {
                 val baseSeasonUrl = response.request.url.toString()
-                rows.forEach { row -> episodeList.add(parseEpisodeRow(row, baseSeasonUrl)) }
+                episodeList.addAll(rows.mapNotNull { parseEpisodeRow(it, baseSeasonUrl) })
                 return episodeList.reversed()
             }
             return emptyList()
@@ -236,7 +236,7 @@ class Serienstream :
             }
             val rows = seasonDoc.select("table.episode-table tbody tr.episode-row")
             if (rows.isNotEmpty()) {
-                rows.forEach { row -> episodeList.add(parseEpisodeRow(row, seasonHref)) }
+                episodeList.addAll(rows.mapNotNull { parseEpisodeRow(it, seasonHref) })
             } else {
                 val epLinks = seasonDoc.select("nav#episode-nav a[href*=\"/episode-\"]")
                 epLinks.forEach { el ->
@@ -254,12 +254,13 @@ class Serienstream :
         return episodeList.reversed()
     }
 
-    private fun parseEpisodeRow(element: Element, seasonUrl: String): SEpisode {
+    private fun parseEpisodeRow(element: Element, seasonUrl: String): SEpisode? {
         val episode = SEpisode.create()
         val onclick = element.attr("onclick")
         val href = Regex("""window\.location='([^']+)'""").find(onclick)?.groupValues?.get(1)
             ?: element.selectFirst("a[href*=\"/episode-\"]")?.attr("href")
             ?: ""
+        if (href.isBlank()) return null
         episode.url = href
         val seasonNumRaw = seasonUrl.substringAfter("/staffel-", "").takeWhile(Char::isDigit).ifEmpty { "1" }
         val isFilm = seasonNumRaw == "0" || seasonUrl.contains("/staffel-0")
@@ -283,7 +284,9 @@ class Serienstream :
         return episode
     }
 
-    override fun episodeFromElement(element: Element): SEpisode = parseEpisodeRow(element, element.attr("abs:href").substringBefore("/episode"))
+    // Unreachable: episodeListParse is overridden and episodeListSelector throws, but the base
+    // class requires a non-null episode here.
+    override fun episodeFromElement(element: Element): SEpisode = parseEpisodeRow(element, element.attr("abs:href").substringBefore("/episode")) ?: SEpisode.create()
 
     override fun videoListSelector() = throw UnsupportedOperationException()
 

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.de.serienstream
 
+import android.util.Base64
 import androidx.preference.PreferenceScreen
 import aniyomi.lib.doodextractor.DoodExtractor
 import aniyomi.lib.streamtapeextractor.StreamTapeExtractor
@@ -23,8 +24,10 @@ import keiyoushi.utils.useAsJsoup
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response
@@ -32,6 +35,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.injectLazy
 import java.net.URLEncoder
+import java.security.MessageDigest
 
 class Serienstream :
     ParsedAnimeHttpSource(),
@@ -290,6 +294,11 @@ class Serienstream :
             .ifEmpty { document.select("div.link-wrapper button[data-play-url]") }
             .ifEmpty { document.select("button[data-play-url]") }
         val selection = hosterSelection
+        val altcha = try {
+            fetchAltcha(response.request.url.toString(), csrfToken)
+        } catch (_: Exception) {
+            null
+        }
 
         return buttons.parallelCatchingFlatMapBlocking { btn ->
             val provider = btn.attr("data-provider-name").trim()
@@ -311,7 +320,7 @@ class Serienstream :
             val t = if (playUrl.contains("t=")) playUrl.substringAfter("t=").substringBefore("&") else playUrl
             if (t.isBlank()) return@parallelCatchingFlatMapBlocking emptyList()
 
-            val hosterUrl = resolveHosterUrl(t, csrfToken, formToken, response.request.url.toString(), playUrl) ?: return@parallelCatchingFlatMapBlocking emptyList()
+            val hosterUrl = resolveHosterUrl(t, csrfToken, formToken, response.request.url.toString(), playUrl, altcha) ?: return@parallelCatchingFlatMapBlocking emptyList()
             if (hosterUrl.isBlank() || hosterUrl.contains("/r?") || hosterUrl == "$baseUrl/r" || hosterUrl == baseUrl) return@parallelCatchingFlatMapBlocking emptyList()
 
             if (provider.equals("Provider", true)) {
@@ -347,11 +356,12 @@ class Serienstream :
         }
     }
 
-    private fun resolveHosterUrl(t: String, csrfToken: String, formToken: String, referer: String, playUrl: String): String? = try {
-        val formBody = FormBody.Builder()
+    private fun resolveHosterUrl(t: String, csrfToken: String, formToken: String, referer: String, playUrl: String, altcha: String?): String? = try {
+        val formBuilder = FormBody.Builder()
             .add("_token", formToken.ifEmpty { csrfToken })
             .add("t", t)
-            .build()
+        if (!altcha.isNullOrBlank()) formBuilder.add("altcha", altcha)
+        val formBody = formBuilder.build()
         val req = Request.Builder()
             .url("$baseUrl/r")
             .post(formBody)
@@ -381,6 +391,51 @@ class Serienstream :
         }
     } catch (_: Exception) {
         null
+    }
+
+    private fun fetchAltcha(referer: String, csrfToken: String): String? {
+        val req = Request.Builder()
+            .url("$baseUrl/api/inline/verify-init")
+            .get()
+            .addHeader("Referer", referer)
+            .addHeader("X-CSRF-TOKEN", csrfToken)
+            .addHeader("X-Requested-With", "XMLHttpRequest")
+            .build()
+        return client.newCall(req).execute().use { res ->
+            if (!res.isSuccessful) return null
+            val body = res.bodyString()
+            val obj = json.decodeFromString<JsonObject>(body)
+            val algorithm = obj["algorithm"]?.jsonPrimitive?.content ?: return null
+            val challenge = obj["challenge"]?.jsonPrimitive?.content ?: return null
+            val salt = obj["salt"]?.jsonPrimitive?.content ?: return null
+            val signature = obj["signature"]?.jsonPrimitive?.content ?: return null
+            val maxnumber = obj["maxnumber"]?.jsonPrimitive?.content?.toIntOrNull() ?: 100000
+            val number = solveAltcha(challenge, salt, algorithm, maxnumber) ?: return null
+            val payload = buildJsonObject {
+                put("algorithm", algorithm)
+                put("challenge", challenge)
+                put("salt", salt)
+                put("signature", signature)
+                put("number", number)
+            }
+            val jsonStr = json.encodeToString(JsonObject.serializer(), payload)
+            Base64.encodeToString(jsonStr.toByteArray(), Base64.NO_WRAP)
+        }
+    }
+
+    private fun solveAltcha(challenge: String, salt: String, algorithm: String, maxnumber: Int): Int? {
+        val md = try {
+            MessageDigest.getInstance(algorithm)
+        } catch (_: Exception) {
+            return null
+        }
+        for (i in 0..maxnumber) {
+            val hash = md.digest((salt + i.toString()).toByteArray())
+            val hex = hash.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+            if (hex == challenge) return i
+            md.reset()
+        }
+        return null
     }
 
     private fun thumbUrl(img: Element): String? {

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -87,24 +87,14 @@ class Serienstream :
     override fun latestUpdatesParse(response: Response): AnimesPage {
         val document = response.useAsJsoup()
         val elements = document.select(latestUpdatesSelector())
-        val animes = elements.parallelMapNotNullBlocking { element ->
-            val link = element.selectFirst("td a[href*=\"/serie/\"]") ?: return@parallelMapNotNullBlocking null
+        val animes = elements.mapNotNull { element ->
+            val link = element.selectFirst("td a[href*=\"/serie/\"]") ?: return@mapNotNull null
             val href = link.attr("href")
             val serieHref = if (href.contains("/staffel")) href.substringBefore("/staffel") else href.substringBefore("/episode")
-            val anime = SAnime.create().apply {
+            SAnime.create().apply {
                 url = serieHref
                 title = link.text().trim()
             }
-            try {
-                val doc = client.newCall(GET(baseUrl + serieHref)).execute().useAsJsoup()
-                val img = doc.selectFirst("div.show-cover-mobile img")
-                    ?: doc.selectFirst("div.col-5 picture img")
-                    ?: doc.selectFirst("img[data-src*=\"/media/images/channel/\"]")
-                    ?: doc.selectFirst("picture img")
-                anime.thumbnail_url = img?.let { thumbUrl(it) }
-            } catch (_: Exception) {
-            }
-            anime
         }
         return AnimesPage(animes, false)
     }

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
+import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
 import keiyoushi.utils.bodyString
@@ -130,7 +131,8 @@ class Serienstream :
                 val jo = elem.jsonObject
                 val link = jo["url"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
                 val title = jo["name"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
-                animeFromSearch(title, link)
+                val thumb = jo["image"]?.jsonPrimitive?.content ?: jo["cover"]?.jsonPrimitive?.content ?: jo["thumbnail"]?.jsonPrimitive?.content
+                animeFromSearch(title, link, thumb?.let { UrlUtils.fixUrl(it, baseUrl) })
             }
             AnimesPage(animes, false)
         } catch (_: Exception) {
@@ -140,7 +142,8 @@ class Serienstream :
                     val jo = elem.jsonObject
                     val link = jo["link"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
                     val title = jo["title"]?.jsonPrimitive?.content ?: return@parallelMapNotNullBlocking null
-                    animeFromSearch(title, link)
+                    val thumb = jo["image"]?.jsonPrimitive?.content ?: jo["cover"]?.jsonPrimitive?.content ?: jo["thumbnail"]?.jsonPrimitive?.content
+                    animeFromSearch(title, link, thumb?.let { UrlUtils.fixUrl(it, baseUrl) })
                 }
                 AnimesPage(animes, false)
             } catch (_: Exception) {
@@ -149,20 +152,14 @@ class Serienstream :
         }
     }
 
-    private fun animeFromSearch(title: String, link: String): SAnime {
-        val anime = SAnime.create()
-        anime.title = title.replace("<em>", "").replace("</em>", "")
-        anime.url = link
-        try {
-            val doc = client.newCall(GET(baseUrl + link)).execute().useAsJsoup()
-            val img = doc.selectFirst("div.show-cover-mobile img")
-                ?: doc.selectFirst("div.col-5 picture img")
-                ?: doc.selectFirst("img[data-src*=\"/media/images/channel/\"]")
-                ?: doc.selectFirst("picture img")
-            anime.thumbnail_url = img?.let { thumbUrl(it) }
-        } catch (_: Exception) {
-        }
-        return anime
+    private fun animeFromSearch(
+        title: String,
+        link: String,
+        thumbnailUrl: String? = null,
+    ): SAnime = SAnime.create().apply {
+        this.title = title.replace("<em>", "").replace("</em>", "")
+        url = link
+        thumbnail_url = thumbnailUrl
     }
 
     override fun searchAnimeFromElement(element: Element) = throw UnsupportedOperationException()

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -341,22 +341,22 @@ class Serienstream :
             }
 
             when {
-                hosterUrl.contains("voe", true) && (selection.isEmpty() || selection.contains(SConstants.NAME_VOE)) -> voeExtractor.videosFromUrl(hosterUrl, "($language) ")
+                hosterUrl.contains("voe", true) && (selection.isEmpty() || selection.contains(SConstants.NAME_VOE)) -> voeExtractor.videosFromUrl(hosterUrl, language)
                 hosterUrl.contains("dood", true) || hosterUrl.contains("myvidplay", true) -> {
                     if (selection.isEmpty() || selection.contains(SConstants.NAME_DOOD)) {
-                        doodExtractor.videoFromUrl(hosterUrl, "Doodstream $language")?.let(::listOf) ?: emptyList()
+                        doodExtractor.videoFromUrl(hosterUrl, language)?.let(::listOf) ?: emptyList()
                     } else {
                         emptyList()
                     }
                 }
                 hosterUrl.contains("streamtape", true) -> {
                     if (selection.isEmpty() || selection.contains(SConstants.NAME_STAPE)) {
-                        streamTapeExtractor.videoFromUrl(hosterUrl, "Streamtape $language")?.let(::listOf) ?: emptyList()
+                        streamTapeExtractor.videoFromUrl(hosterUrl, "$language - Streamtape")?.let(::listOf) ?: emptyList()
                     } else {
                         emptyList()
                     }
                 }
-                provider.equals("VOE", true) -> voeExtractor.videosFromUrl(hosterUrl, "($language) ")
+                provider.equals("VOE", true) -> voeExtractor.videosFromUrl(hosterUrl, language)
                 else -> emptyList()
             }
         }
@@ -477,9 +477,15 @@ class Serienstream :
 
     override fun List<Video>.sort(): List<Video> {
         val hoster = preferredHoster.takeIf { it.isNotBlank() }
+        val hosterName = when (hoster) {
+            SConstants.URL_VOE -> SConstants.NAME_VOE
+            SConstants.URL_DOOD -> SConstants.NAME_DOOD
+            SConstants.URL_STAPE -> SConstants.NAME_STAPE
+            else -> hoster
+        }
         val lang = preferredLang
         return sortedWith(
-            compareByDescending<Video> { hoster != null && it.url.contains(hoster, true) }
+            compareByDescending<Video> { hosterName != null && (it.url.contains(hoster ?: "", true) || it.quality.contains(hosterName, true)) }
                 .thenByDescending { it.quality.contains(lang, true) },
         )
     }

--- a/src/fr/anisama/build.gradle
+++ b/src/fr/anisama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniSama'
     extClass = '.AniSama'
-    extVersionCode = 25
+    extVersionCode = 26
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
+++ b/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
@@ -230,7 +230,7 @@ class AniSama :
         val server = preferences.server
         return sortedWith(
             compareBy(
-                { it.quality.contains(server) },
+                { it.quality.contains(server, ignoreCase = true) },
                 { it.quality.contains(language) },
                 { it.quality.contains(quality) },
             ),

--- a/src/fr/empirestreaming/build.gradle
+++ b/src/fr/empirestreaming/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'EmpireStreaming'
     extClass = '.EmpireStreaming'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 apply plugin: "kei.plugins.extension.legacy"
 

--- a/src/fr/empirestreaming/src/eu/kanade/tachiyomi/animeextension/fr/empirestreaming/EmpireStreaming.kt
+++ b/src/fr/empirestreaming/src/eu/kanade/tachiyomi/animeextension/fr/empirestreaming/EmpireStreaming.kt
@@ -179,7 +179,7 @@ class EmpireStreaming :
         val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
         return sortedWith(
             compareBy(
-                { it.quality.contains(hoster) },
+                { it.quality.contains(hoster, ignoreCase = true) },
                 { it.quality.contains(quality) },
             ),
         ).reversed()

--- a/src/fr/vostfree/build.gradle
+++ b/src/fr/vostfree/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Vostfree'
     extClass = '.Vostfree'
-    extVersionCode = 38
+    extVersionCode = 39
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/fr/vostfree/src/eu/kanade/tachiyomi/animeextension/fr/vostfree/Vostfree.kt
+++ b/src/fr/vostfree/src/eu/kanade/tachiyomi/animeextension/fr/vostfree/Vostfree.kt
@@ -187,7 +187,7 @@ class Vostfree :
         val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
 
         return sortedWith(
-            compareBy { it.quality.contains(quality) },
+            compareBy { it.quality.contains(quality, ignoreCase = true) },
         ).reversed()
     }
 

--- a/src/tr/turkanime/build.gradle
+++ b/src/tr/turkanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Türk Anime TV'
     extClass = '.TurkAnime'
-    extVersionCode = 49
+    extVersionCode = 50
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/tr/turkanime/src/eu/kanade/tachiyomi/animeextension/tr/turkanime/TurkAnime.kt
+++ b/src/tr/turkanime/src/eu/kanade/tachiyomi/animeextension/tr/turkanime/TurkAnime.kt
@@ -398,7 +398,7 @@ class TurkAnime :
         return sortedWith(
             compareBy(
                 { it.quality.contains(quality) }, // preferred quality first
-                { it.quality.substringBefore(":") }, // then group by fansub
+                { it.quality.substringBefore(" - VOE").substringBefore(":") }, // then group by fansub (VOE uses "Name - VOE", others "Name:")
                 // then group by quality
                 { Regex("""(\d+)p""").find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
             ),


### PR DESCRIPTION
- Change baseUrl
- Update popular selector to a.show-card and parse new thumbnail/title
- Fix latest to use /neue-episoden table parsing
- Replace search endpoint /ajax/search with /api/search/suggest and handle new JSON
- Update anime details selectors for new layout (h1, cover image, genres, description, cast)
- Rewrite episode list parsing for season pills and episode-table rows
- Rewrite video extraction to use POST to /r with CSRF handling for new redirect gate and support VOE/Doodstream/Streamtape

Fixes #28

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update the Serienstream extension for the site redesign and restore reliable anime discovery, episode parsing, and streaming playback.

Bug Fixes:
- Restore Serienstream compatibility with the redesigned site, including updated catalog, latest-release, search, details, episode, and video extraction flows.

Enhancements:
- Modernize hoster, language, and preference handling for the redesigned streaming layout and redirect gate.
- Update the extension version code for the compatibility changes.

Build:
- Bump the Serienstream extension version code from 32 to 34.

## Summary by Sourcery

Update the Serienstream extension for the site redesign and reliable content discovery, episode parsing, and streaming playback.

Bug Fixes:
- Restore Serienstream compatibility with the redesigned site across catalog browsing, latest releases, search, anime details, episode listings, and video playback.

Enhancements:
- Modernize hoster and language selection, preferences, and streaming-provider handling for the redesigned layout and redirect flow.

Build:
- Bump the Serienstream extension version code from 32 to 33.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added subtitle extraction and normalization for supported videos, including HLS and MP4 playback.
  - Video entries now display clearer quality labels and closed-caption availability.
  - Updated Serienstream browsing, search, episode listings, metadata, playback providers, redirects, and challenge handling.

- **Bug Fixes**
  - Improved subtitle error handling and line-ending normalization.
  - Server, hoster, and quality preferences now match regardless of capitalization.
  - Improved video grouping and sorting across supported sources.
  - Updated compatibility with the latest Serienstream site version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->