### PR TITLE
Revert "Hanime1.me [ZH]: Fix parsing logic for details and episodes"

### DIFF
--- a/src/zh/hanime1/build.gradle
+++ b/src/zh/hanime1/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Hanime1.me'
     extClass = '.Hanime1'
-    extVersionCode = 7
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
+++ b/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
@@ -55,6 +55,7 @@ class Hanime1 :
     private val preferences by getPreferencesLazy()
 
     private var filterUpdateState = FilterUpdateState.NONE
+
     private val uploadDateFormat: SimpleDateFormat by lazy {
         SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
     }
@@ -62,18 +63,14 @@ class Hanime1 :
     override fun animeDetailsParse(response: Response): SAnime {
         val doc = response.useAsJsoup()
         return SAnime.create().apply {
-            genre = doc.select(".single-video-tag").not("[data-toggle]").eachText()
-                // Convert `# 博麗靈夢`, `1080p (1)` to `博麗靈夢`, `1080p`
-                .joinToString { it.removePrefix("# ").replace(REGEX_VIDEO_TAG_SUFFIX, "") }
+            genre = doc.select(".single-video-tag").not("[data-toggle]").eachText().joinToString()
             author = doc.select("#video-artist-name").text()
-            val realTitle = doc.select("#shareBtn-title").text().takeIf { it.isNotBlank() }
-                ?: doc.select("meta[property=og:title]").attr("content").takeIf { it.isNotBlank() }
-            // Leave the title empty when unavailable so the details page falls back to the title from the list page.
-            title = realTitle?.appendInvisibleChar() ?: ""
-            description = doc.select("meta[property=og:description]").attr("content")
-            thumbnail_url = doc.select("meta[property=og:image]").attr("content")
+            val realTitle = doc.select("div.video-description-panel > div:nth-child(2)").text()
+            title = realTitle.appendInvisibleChar()
+            description = doc.select("div.video-description-panel > div:nth-child(3)").text()
+            thumbnail_url = doc.select("video[poster]").attr("poster")
             val type = doc.select("a#video-artist-name + a").text().trim()
-            if ((type == "裏番" || type == "泡麵番") && realTitle != null) {
+            if (type == "裏番" || type == "泡麵番") {
                 // Use the series cover image for bangumi entries instead of the episode image.
                 runBlocking {
                     try {
@@ -97,13 +94,16 @@ class Hanime1 :
         val nodes = jsoup.select("#playlist-scroll").first()!!.select(">div")
         return nodes.mapIndexed { index, element ->
             SEpisode.create().apply {
-                val href = element.select(".thumb-container a").attr("href")
+                val href = element.select("a.overlay").attr("href")
                 setUrlWithoutDomain(href)
                 episode_number = (nodes.size - index).toFloat()
-                name = element.select(".video-title").text()
-                if (response.request.url.resolve(href) == response.request.url) {
-                    // current video, parse `觀看次數：362.5萬次 2025-12-26` to upload date
-                    date_upload = uploadDateFormat.tryParse(REGEX_UPLOAD_DATE.find(jsoup.select("#shareBtn-title + div").text())?.value)
+                name = element.select("div.card-mobile-title").text()
+                if (href == response.request.url.toString()) {
+                    // current video
+                    val timeStr =
+                        jsoup.select("div.video-description-panel > div:first-child").text()
+                            .split(" ").last()
+                    date_upload = uploadDateFormat.tryParse(timeStr)
                 }
             }
         }
@@ -134,12 +134,11 @@ class Hanime1 :
 
     override fun popularAnimeRequest(page: Int) = searchAnimeRequest(page, "", AnimeFilterList(HotFilter))
 
-    /**
-     * On the details page, the episode title is calculated as `SEpisode.name.removePrefix(SAnime.title)`.
-     * If [SEpisode.name] is identical to [SAnime.title], the episode title becomes empty. To avoid this issue,
-     * we use this method to append an invisible character to [SAnime.title].
-     */
-    private fun String.appendInvisibleChar(): String = "${this}\u200B"
+    private fun String.appendInvisibleChar(): String {
+        // The search result title will be same as one episode name of anime.
+        // Adding extra char makes them has different title
+        return "${this}\u200B"
+    }
 
     override fun searchAnimeParse(response: Response): AnimesPage {
         val jsoup = response.useAsJsoup()
@@ -185,6 +184,7 @@ class Hanime1 :
                 }
 
                 is AnimeFilter.Group<*> -> it.state
+
                 else -> listOf(it)
             }
         }.forEach {
@@ -360,8 +360,5 @@ class Hanime1 :
         const val PREF_KEY_CATEGORY_LIST = "PREF_KEY_CATEGORY_LIST"
 
         const val DEFAULT_QUALITY = "1080P"
-
-        private val REGEX_UPLOAD_DATE = Regex("""\d{4}-\d{2}-\d{2}""")
-        private val REGEX_VIDEO_TAG_SUFFIX = Regex(""" \(\d+\)$""")
     }
 }


### PR DESCRIPTION
Reverts yuzono/anime-extensions#667

## Summary by Sourcery

Revert the Hanime1.me parsing changes to restore the prior details and episode extraction behavior.

Enhancements:
- Restore the previous Hanime1.me detail and episode parsing behavior for titles, metadata, thumbnails, links, and upload dates.

Build:
- Revert the Hanime1.me extension version code from 7 to 6.

Chores:
- Remove parsing helpers introduced by the reverted changes.