### PR TITLE
fix(lib/m3u8server): change nanohttpd

### DIFF
--- a/lib/m3u8server/build.gradle.kts
+++ b/lib/m3u8server/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation("com.github.NanoHttpd.nanohttpd:nanohttpd:-SNAPSHOT")
+    implementation("com.github.komikku-app.nanohttpd:nanohttpd:gradle-upgrade-SNAPSHOT")
 }

--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -8,5 +8,5 @@ apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(":lib:unpacker"))
-    implementation("com.github.NanoHttpd.nanohttpd:nanohttpd:nanohttpd-project-2.3.1")
+    implementation("org.nanohttpd:nanohttpd:2.3.1")
 }

--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -8,5 +8,5 @@ apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(":lib:unpacker"))
-    implementation("org.nanohttpd:nanohttpd:2.3.1")
+    implementation("com.github.komikku-app.nanohttpd:nanohttpd:gradle-upgrade-SNAPSHOT")
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePaheHlsServer.kt
@@ -1,13 +1,17 @@
 package eu.kanade.tachiyomi.animeextension.en.animepahe
 
 import eu.kanade.tachiyomi.animesource.model.Video
-import fi.iki.elonen.NanoHTTPD
-import fi.iki.elonen.NanoHTTPD.Response.Status
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.nanohttpd.protocols.http.IHTTPSession
+import org.nanohttpd.protocols.http.NanoHTTPD
+import org.nanohttpd.protocols.http.response.Response
+import org.nanohttpd.protocols.http.response.Response.newChunkedResponse
+import org.nanohttpd.protocols.http.response.Response.newFixedLengthResponse
+import org.nanohttpd.protocols.http.response.Status
 import java.io.ByteArrayInputStream
 import java.io.FilterInputStream
 import java.io.IOException
@@ -70,7 +74,7 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
         }
     }
 
-    override fun serve(session: IHTTPSession): Response = when {
+    override fun handle(session: IHTTPSession): Response = when {
         session.uri.startsWith("/m3u8") -> handleM3u8Request(session)
         session.uri.startsWith("/segment") -> handleSegmentRequest(session)
         session.uri.startsWith("/mp4") -> handleMp4Request(session)
@@ -118,10 +122,8 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
             val status = Status.lookup(upstream.code) ?: Status.OK
             val stream = object : FilterInputStream(body.byteStream()) {
                 override fun close() {
-                    try {
+                    upstream.use { _ ->
                         super.close()
-                    } finally {
-                        upstream.close()
                     }
                 }
             }
@@ -241,7 +243,7 @@ object AnimePaheHlsServer : NanoHTTPD(0) {
         val baseHttpUrl = originalUrl.toHttpUrlOrNull()
         val modifiedLines = mutableListOf<String>()
         var mediaSequence = 0L
-        var segmentSequence = mediaSequence
+        var segmentSequence = 0L
         var currentKey: HlsKey? = null
 
         content.lines().forEach { line ->

--- a/src/en/reanime/build.gradle
+++ b/src/en/reanime/build.gradle
@@ -8,6 +8,6 @@ ext {
 apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
-    implementation("org.nanohttpd:nanohttpd:2.3.1")
+    implementation("com.github.komikku-app.nanohttpd:nanohttpd:gradle-upgrade-SNAPSHOT")
     implementation(project(":lib:playlistutils"))
 }

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/FlixProxyServer.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/FlixProxyServer.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.en.reanime
 
 import android.util.Log
-import fi.iki.elonen.NanoHTTPD
 import okhttp3.ConnectionPool
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -11,6 +10,12 @@ import okio.Buffer
 import okio.ForwardingSource
 import okio.Source
 import okio.buffer
+import org.nanohttpd.protocols.http.IHTTPSession
+import org.nanohttpd.protocols.http.NanoHTTPD
+import org.nanohttpd.protocols.http.response.Response
+import org.nanohttpd.protocols.http.response.Response.newChunkedResponse
+import org.nanohttpd.protocols.http.response.Response.newFixedLengthResponse
+import org.nanohttpd.protocols.http.response.Status
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
@@ -80,9 +85,9 @@ class FlixProxyServer(
         segmentUrl
     }
 
-    override fun serve(session: IHTTPSession): Response? {
+    override fun handle(session: IHTTPSession): Response {
         val params = session.parameters
-        val url = params["url"]?.firstOrNull() ?: return newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "Missing url")
+        val url = params["url"]?.firstOrNull() ?: return newFixedLengthResponse(Status.BAD_REQUEST, "text/plain", "Missing url")
         val wPayload = params["w_payload"]?.firstOrNull() ?: ""
 
         return try {
@@ -119,9 +124,9 @@ class FlixProxyServer(
         } catch (e: Exception) {
             // Return 503 for timeouts so the player retries the segment instead of failing completely
             val status = if (e is java.net.SocketTimeoutException) {
-                Response.Status.SERVICE_UNAVAILABLE
+                Status.SERVICE_UNAVAILABLE
             } else {
-                Response.Status.INTERNAL_ERROR
+                Status.INTERNAL_ERROR
             }
 
             newFixedLengthResponse(status, "text/plain", e.toString())
@@ -150,7 +155,7 @@ class FlixProxyServer(
             val code = response.code
             response.close()
             return newFixedLengthResponse(
-                Response.Status.lookup(code) ?: Response.Status.INTERNAL_ERROR,
+                Status.lookup(code) ?: Status.INTERNAL_ERROR,
                 "text/plain",
                 "CDN Error: $code",
             )
@@ -196,9 +201,9 @@ class FlixProxyServer(
         val inputStream = xorSource.buffer().inputStream()
 
         return if (outputLength > 0) {
-            newFixedLengthResponse(Response.Status.OK, "video/mp2t", inputStream, outputLength)
+            newFixedLengthResponse(Status.OK, "video/mp2t", inputStream, outputLength)
         } else {
-            newChunkedResponse(Response.Status.OK, "video/mp2t", inputStream)
+            newChunkedResponse(Status.OK, "video/mp2t", inputStream)
         }
     }
 
@@ -226,7 +231,7 @@ class FlixProxyServer(
             val errorBody = response.body.string()
             response.close()
             return newFixedLengthResponse(
-                Response.Status.lookup(response.code) ?: Response.Status.INTERNAL_ERROR,
+                Status.lookup(response.code) ?: Status.INTERNAL_ERROR,
                 "text/plain",
                 "Manifest Error: $errorBody",
             )
@@ -290,7 +295,7 @@ class FlixProxyServer(
         }
 
         // Use application/vnd.apple.mpegurl to match the CDN exactly
-        return newFixedLengthResponse(Response.Status.OK, "application/vnd.apple.mpegurl", modifiedText)
+        return newFixedLengthResponse(Status.OK, "application/vnd.apple.mpegurl", modifiedText)
     }
 
     companion object {

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -19,7 +19,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
-import fi.iki.elonen.NanoHTTPD
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
@@ -39,6 +38,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import org.nanohttpd.protocols.http.NanoHTTPD
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone.getTimeZone


### PR DESCRIPTION
Replace broken JitPack -SNAPSHOT coordinate
com.github.NanoHttpd.nanohttpd:nanohttpd:-SNAPSHOT with Maven Central
org.nanohttpd:nanohttpd:2.3.1 matching aniyomiorg/aniyomi
gradle/aniyomi.versions.toml (nanohttpd = "2.3.1") and
aniyomiorg/extensions-lib gradle/libs.versions.toml.

M3u8HttpServer.kt: migrate from org.nanohttpd.protocols.http.*
(JitPack modular) to fi.iki.elonen.NanoHTTPD (Maven Central)
and rename handle() -> serve() to match 2.3.1 API.

Also align src/en/animepahe from JitPack
com.github.NanoHttpd.nanohttpd:nanohttpd:nanohttpd-project-2.3.1
to org.nanohttpd:nanohttpd:2.3.1 so all extensions use the
same coordinate as reanime and aniyomi.Checklist:

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Standardize NanoHTTPD usage across video proxy servers and extensions while preserving compatible request handling.

Bug Fixes:
- Update the M3U8 and HLS proxy servers to use the project’s compatible NanoHTTPD snapshot and API.

Enhancements:
- Align NanoHTTPD dependencies and server implementations across the affected extensions.
- Correct HLS segment sequence initialization and streamline upstream response resource handling.

Build:
- Replace the previous NanoHTTPD coordinates with the shared Gradle-upgrade snapshot across the M3U8 server, AnimePahe, and ReAnime modules.