### PR TITLE
fix(missav): HLS download reliability and quality options

### DIFF
--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/AutoDetector.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/AutoDetector.kt
@@ -106,7 +106,7 @@ object AutoDetector {
      *         Empty list if no junk is detected.
      */
     fun detectInterleavedSkips(data: ByteArray): List<IntRange> {
-        if (data.isEmpty()) return emptyList()
+        if (data.isEmpty() || isMpegTsPacketAligned(data)) return emptyList()
 
         val regions = mutableListOf<IntRange>()
 
@@ -124,6 +124,19 @@ object AutoDetector {
         }
 
         return mergeRegions(regions)
+    }
+
+    /**
+     * Returns true when the complete buffer is an intact MPEG-TS packet grid.
+     * A full-grid check avoids treating JPEG-like bytes inside normal TS
+     * payloads as injected disguise blocks.
+     */
+    private fun isMpegTsPacketAligned(data: ByteArray): Boolean {
+        if (data.size < MPEG_TS_PACKET_SIZE * 3 || data.size % MPEG_TS_PACKET_SIZE != 0) return false
+        for (offset in data.indices step MPEG_TS_PACKET_SIZE) {
+            if (data[offset] != MPEG_TS_SYNC) return false
+        }
+        return true
     }
 
     /**

--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8HttpServer.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8HttpServer.kt
@@ -104,7 +104,7 @@ class M3u8HttpServer(
         val headers = extractHeadersFromSession(session, fallbackReferer, fallbackUserAgent, fallbackOrigin)
 
         Log.d(tag, "Processing M3U8 request")
-        Log.d(tag, "Headers: $headers")
+        Log.d(tag, "Extracted upstream header names: ${headers.keys}")
 
         if (url.isNullOrBlank()) {
             Log.w(tag, "Missing URL parameter in M3U8 request")
@@ -216,7 +216,6 @@ class M3u8HttpServer(
         session.headers.forEach { (key, value) ->
             when (key.lowercase()) {
                 "user-agent", "referer", "origin", "accept", "accept-language",
-                "accept-encoding",
                 -> {
                     headers[key.lowercase()] = value
                 }
@@ -322,13 +321,35 @@ class M3u8HttpServer(
         }
         val request = requestBuilder.build()
 
-        client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                Log.e(tag, "Failed to fetch segment, HTTP code: ${response.code}")
-                throw UpstreamStatusException(response.code, url, "Failed to fetch segment")
+        try {
+            fetchSegmentBytes(client, request, url)
+        } catch (primary: UpstreamStatusException) {
+            throw primary
+        } catch (primary: Exception) {
+            Log.w(
+                tag,
+                "Primary segment client failed: ${primary.javaClass.simpleName}; " +
+                    if (fallbackClient != null) "attempting fallback" else "no fallback configured",
+            )
+            val fb = fallbackClient ?: throw UpstreamStatusException(503, url, "Primary segment client failed", primary)
+
+            try {
+                fetchSegmentBytes(fb, request, url)
+            } catch (fallback: UpstreamStatusException) {
+                throw fallback
+            } catch (fallback: Exception) {
+                Log.e(tag, "Segment fallback client threw: ${fallback.javaClass.simpleName}", fallback)
+                throw UpstreamStatusException(503, url, "Both primary and fallback segment clients failed", primary)
             }
-            response.body.bytes()
         }
+    }
+
+    private fun fetchSegmentBytes(client: OkHttpClient, request: Request, url: String): ByteArray = client.newCall(request).execute().use { response ->
+        if (!response.isSuccessful) {
+            Log.e(tag, "Failed to fetch segment, HTTP code: ${response.code}")
+            throw UpstreamStatusException(response.code, url, "Failed to fetch segment")
+        }
+        response.body.bytes()
     }
 
     private fun stripInterleavedJunk(fullData: ByteArray): ByteArray {
@@ -534,7 +555,7 @@ class M3u8HttpServer(
                                     url = resolvedKeyUrl,
                                     iv = iv?.let { it.normalizeHlsIv() } ?: segmentSequence.toHlsIv(),
                                 )
-                                Log.d(tag, "AES-128 detected, intercepting key at proxy: $resolvedKeyUrl (iv=${currentKey!!.iv})")
+                                Log.d(tag, "AES-128 detected, intercepting key at proxy")
                             }
                         }
                         "NONE" -> {

--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8HttpServer.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8HttpServer.kt
@@ -76,7 +76,9 @@ class M3u8HttpServer(
         val uri = session.uri
         val method = session.method
 
-        Log.d(tag, "Received request: $method $uri from ${session.remoteIpAddress}")
+        if (!uri.startsWith("/segment")) {
+            Log.d(tag, "Received request: $method ${uri.substringBefore('?')}")
+        }
 
         val response = when {
             uri.startsWith("/m3u8") -> handleM3u8Request(session)
@@ -96,9 +98,10 @@ class M3u8HttpServer(
         val url = session.parameters["url"]?.first()
         val fallbackReferer = session.parameters["referer"]?.first()
         val fallbackUserAgent = session.parameters["useragent"]?.first()
-        val headers = extractHeadersFromSession(session, fallbackReferer, fallbackUserAgent)
+        val fallbackOrigin = session.parameters["origin"]?.first()
+        val headers = extractHeadersFromSession(session, fallbackReferer, fallbackUserAgent, fallbackOrigin)
 
-        Log.d(tag, "Processing M3U8 request for URL: $url")
+        Log.d(tag, "Processing M3U8 request")
         Log.d(tag, "Headers: $headers")
 
         if (url.isNullOrBlank()) {
@@ -107,15 +110,20 @@ class M3u8HttpServer(
         }
 
         return try {
-            Log.d(tag, "Starting M3U8 processing for: $url")
+            Log.d(tag, "Starting M3U8 processing")
             val processedContent = runBlocking { processM3u8Content(url, headers) }
             Log.d(tag, "M3U8 processing completed successfully, content length: ${processedContent.length}")
-            newFixedLengthResponse(Status.OK, "application/vnd.apple.mpegurl", processedContent)
+            val playlistBytes = processedContent.toByteArray()
+            newChunkedResponse(
+                Status.OK,
+                "application/vnd.apple.mpegurl",
+                ByteArrayInputStream(playlistBytes),
+            )
         } catch (e: UpstreamStatusException) {
-            Log.w(tag, "Upstream HTTP ${e.code} for $url: ${e.message}")
+            Log.w(tag, "Upstream HTTP ${e.code} for M3U8 request")
             passThroughStatus(e)
         } catch (e: Exception) {
-            Log.e(tag, "Error processing M3U8: ${e.message}", e)
+            Log.e(tag, "Error processing M3U8: ${e.javaClass.simpleName}")
             newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
         }
     }
@@ -126,30 +134,25 @@ class M3u8HttpServer(
         val iv = session.parameters["iv"]?.first()
         val fallbackReferer = session.parameters["referer"]?.first()
         val fallbackUserAgent = session.parameters["useragent"]?.first()
-        val headers = extractHeadersFromSession(session, fallbackReferer, fallbackUserAgent)
-
-        Log.d(tag, "Processing segment request for URL: $url (key=${keyUrl != null}, iv=${iv != null})")
-        Log.d(tag, "Headers: $headers")
+        val fallbackOrigin = session.parameters["origin"]?.first()
+        val headers = extractHeadersFromSession(session, fallbackReferer, fallbackUserAgent, fallbackOrigin)
 
         if (url.isNullOrBlank()) {
             Log.w(tag, "Missing URL parameter in segment request")
             return newFixedLengthResponse(Status.BAD_REQUEST, MIME_PLAINTEXT, "Missing url parameter")
         }
 
-        val hasAes = keyUrl != null && iv != null
         return try {
-            Log.d(tag, "Starting segment processing for: $url (aes=$hasAes)")
             val segmentData = runBlocking {
                 processSegmentUrl(url, headers, keyUrl, iv)
             }
-            Log.d(tag, "Segment processing completed successfully, data size: ${segmentData.size} bytes")
             val inputStream = ByteArrayInputStream(segmentData)
             newChunkedResponse(Status.OK, "video/mp2t", inputStream)
         } catch (e: UpstreamStatusException) {
-            Log.w(tag, "Upstream segment HTTP ${e.code} for $url: ${e.message}")
+            Log.w(tag, "Upstream segment HTTP ${e.code}")
             passThroughStatus(e)
         } catch (e: Exception) {
-            Log.e(tag, "Error processing segment: ${e.message}", e)
+            Log.e(tag, "Error processing segment request: ${e.javaClass.simpleName}")
             newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
         }
     }
@@ -204,13 +207,14 @@ class M3u8HttpServer(
         session: IHTTPSession,
         fallbackReferer: String? = null,
         fallbackUserAgent: String? = null,
+        fallbackOrigin: String? = null,
     ): Map<String, String> {
         val headers = mutableMapOf<String, String>()
 
         session.headers.forEach { (key, value) ->
             when (key.lowercase()) {
                 "user-agent", "referer", "origin", "accept", "accept-language",
-                "accept-encoding", "connection", "cache-control", "pragma",
+                "accept-encoding",
                 -> {
                     headers[key.lowercase()] = value
                 }
@@ -223,8 +227,11 @@ class M3u8HttpServer(
         if (!fallbackReferer.isNullOrBlank()) {
             headers["referer"] = fallbackReferer
         }
+        if (!fallbackOrigin.isNullOrBlank()) {
+            headers["origin"] = fallbackOrigin
+        }
 
-        Log.d(tag, "Extracted headers (referer=${headers["referer"]?.take(80) ?: "none"}, ua=${headers["user-agent"]?.take(40) ?: "none"})")
+        Log.d(tag, "Extracted upstream headers")
         return headers
     }
 
@@ -253,19 +260,20 @@ class M3u8HttpServer(
      */
     private suspend fun processM3u8Content(url: String, headers: Map<String, String> = emptyMap()): String = withContext(Dispatchers.IO) {
         try {
-            Log.d(tag, "Fetching M3U8 content from: $url with headers: $headers")
+            Log.d(tag, "Fetching M3U8 content")
             val m3u8Content = fetchM3u8Content(url, headers)
             Log.d(tag, "Original M3U8 content length: ${m3u8Content.length}")
 
             val referer = headers["referer"]
             val userAgent = headers["user-agent"]
-            val modifiedContent = modifyM3u8Content(m3u8Content, url, port, referer, userAgent)
+            val origin = headers["origin"]
+            val modifiedContent = modifyM3u8Content(m3u8Content, url, port, referer, userAgent, origin)
             Log.d(tag, "Modified M3U8 content length: ${modifiedContent.length}")
             Log.d(tag, "M3U8 processing completed successfully")
 
             modifiedContent
         } catch (e: UpstreamStatusException) {
-            Log.w(tag, "Upstream ${e.code} propagating from processM3u8Content for $url")
+            Log.w(tag, "Upstream ${e.code} propagating from M3U8 processing")
             throw e
         } catch (e: Exception) {
             Log.e(tag, "Error processing M3U8 URL: ${e.message}", e)
@@ -288,31 +296,24 @@ class M3u8HttpServer(
         iv: String? = null,
     ): ByteArray = withContext(Dispatchers.IO) {
         try {
-            Log.d(tag, "Fetching segment from: $url with headers: $headers (aes=${keyUrl != null})")
             val rawSegment = fetchSegmentBytes(url, headers)
             val plaintext = if (keyUrl != null && iv != null) {
                 val keyBytes = fetchSegmentBytes(keyUrl, headers)
-                decryptAes128Cbc(rawSegment, keyBytes, iv).also {
-                    Log.d(tag, "AES-128 decrypted segment: ${rawSegment.size} → ${it.size} bytes")
-                }
+                decryptAes128Cbc(rawSegment, keyBytes, iv)
             } else {
                 rawSegment
             }
-            val stripped = stripInterleavedJunk(plaintext)
-            Log.d(tag, "Segment processing completed, final size: ${stripped.size} bytes")
-            stripped
+            stripInterleavedJunk(plaintext)
         } catch (e: UpstreamStatusException) {
-            Log.w(tag, "Segment fetch upstream ${e.code} for $url")
+            Log.w(tag, "Segment fetch upstream HTTP ${e.code}")
             throw e
         } catch (e: Exception) {
-            Log.e(tag, "Error processing segment URL: ${e.message}", e)
+            Log.e(tag, "Error processing segment: ${e.javaClass.simpleName}")
             throw UpstreamStatusException(503, url, "Error processing segment: ${e.message}", e)
         }
     }
 
     private suspend fun fetchSegmentBytes(url: String, headers: Map<String, String>): ByteArray = withContext(Dispatchers.IO) {
-        Log.d(tag, "Making HTTP request to fetch segment with headers: $headers")
-
         val requestBuilder = Request.Builder().url(url)
         headers.forEach { (key, value) ->
             requestBuilder.addHeader(key, value)
@@ -320,7 +321,6 @@ class M3u8HttpServer(
         val request = requestBuilder.build()
 
         client.newCall(request).execute().use { response ->
-            Log.d(tag, "Segment HTTP response code: ${response.code}")
             if (!response.isSuccessful) {
                 Log.e(tag, "Failed to fetch segment, HTTP code: ${response.code}")
                 throw UpstreamStatusException(response.code, url, "Failed to fetch segment")
@@ -390,7 +390,7 @@ class M3u8HttpServer(
     }
 
     private suspend fun fetchM3u8Content(url: String, headers: Map<String, String> = emptyMap()): String = withContext(Dispatchers.IO) {
-        Log.d(tag, "Making HTTP request to fetch M3U8 content with headers: $headers")
+        Log.d(tag, "Making HTTP request to fetch M3U8 content")
 
         val requestBuilder = Request.Builder().url(url)
         headers.forEach { (key, value) ->
@@ -423,7 +423,11 @@ class M3u8HttpServer(
             // a typed exception here (lib stays agnostic of cloudflareinterceptor).
             // Use the fallback client when supplied — header-gated CDNs may
             // return 200 once the WebView detour is bypassed.
-            Log.w(tag, "Primary client failed for $url: ${primary.javaClass.simpleName}: ${primary.message}; ${if (fallbackClient != null) "attempting fallback" else "no fallback configured"}")
+            Log.w(
+                tag,
+                "Primary M3U8 client failed: ${primary.javaClass.simpleName}; " +
+                    if (fallbackClient != null) "attempting fallback" else "no fallback configured",
+            )
             val fb = fallbackClient ?: throw UpstreamStatusException(503, url, "Primary client failed: ${primary.message}", primary)
 
             try {
@@ -472,6 +476,7 @@ class M3u8HttpServer(
         m3u8Url: String,
         referer: String? = null,
         userAgent: String? = null,
+        origin: String? = null,
     ): String {
         val sb = StringBuilder("http://localhost:$port/m3u8?url=")
             .append(URLEncoder.encode(m3u8Url, Charsets.UTF_8.name()))
@@ -480,6 +485,9 @@ class M3u8HttpServer(
         }
         if (!userAgent.isNullOrBlank()) {
             sb.append("&useragent=").append(URLEncoder.encode(userAgent, Charsets.UTF_8.name()))
+        }
+        if (!origin.isNullOrBlank()) {
+            sb.append("&origin=").append(URLEncoder.encode(origin, Charsets.UTF_8.name()))
         }
         return sb.toString()
     }
@@ -490,8 +498,9 @@ class M3u8HttpServer(
         serverPort: Int,
         referer: String? = null,
         userAgent: String? = null,
+        origin: String? = null,
     ): String {
-        Log.d(tag, "Modifying M3U8 content for server port: $serverPort (referer=${referer?.take(80) ?: "none"})")
+        Log.d(tag, "Modifying M3U8 content for server port: $serverPort")
         val lines = content.lines()
         val modifiedLines = mutableListOf<String>()
         var segmentCount = 0
@@ -545,10 +554,10 @@ class M3u8HttpServer(
                         val encodedUrl = URLEncoder.encode(resolvedUrl, Charsets.UTF_8.name())
                         // Forward the caller's referer / UA to sub-playlists so
                         // the redirect chain keeps browser-fingerprint headers.
-                        modifiedLines.add(buildChildM3u8Url(serverPort, resolvedUrl, referer, userAgent))
+                        modifiedLines.add(buildChildM3u8Url(serverPort, resolvedUrl, referer, userAgent, origin))
                     } else {
                         modifiedLines.add(
-                            createLocalSegmentUrl(serverPort, resolvedUrl, currentKey, referer, userAgent),
+                            createLocalSegmentUrl(serverPort, resolvedUrl, currentKey, referer, userAgent, origin),
                         )
                         segmentCount++
                     }
@@ -566,6 +575,7 @@ class M3u8HttpServer(
         m3u8Url: String,
         referer: String?,
         userAgent: String?,
+        origin: String?,
     ): String {
         val sb = StringBuilder("http://localhost:$serverPort/m3u8?url=")
             .append(URLEncoder.encode(m3u8Url, Charsets.UTF_8.name()))
@@ -574,6 +584,9 @@ class M3u8HttpServer(
         }
         if (!userAgent.isNullOrBlank()) {
             sb.append("&useragent=").append(URLEncoder.encode(userAgent, Charsets.UTF_8.name()))
+        }
+        if (!origin.isNullOrBlank()) {
+            sb.append("&origin=").append(URLEncoder.encode(origin, Charsets.UTF_8.name()))
         }
         return sb.toString()
     }
@@ -594,6 +607,7 @@ class M3u8HttpServer(
         key: HlsKey?,
         referer: String? = null,
         userAgent: String? = null,
+        origin: String? = null,
     ): String {
         val encodedUrl = URLEncoder.encode(segmentUrl, Charsets.UTF_8.name())
         return buildString {
@@ -611,6 +625,10 @@ class M3u8HttpServer(
             if (!userAgent.isNullOrBlank()) {
                 append("&useragent=")
                 append(URLEncoder.encode(userAgent, Charsets.UTF_8.name()))
+            }
+            if (!origin.isNullOrBlank()) {
+                append("&origin=")
+                append(URLEncoder.encode(origin, Charsets.UTF_8.name()))
             }
         }
     }

--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8HttpServer.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8HttpServer.kt
@@ -90,7 +90,9 @@ class M3u8HttpServer(
             }
         }
 
-        Log.d(tag, "Response status: ${response.status}")
+        if (!uri.startsWith("/segment")) {
+            Log.d(tag, "Response status: ${response.status}")
+        }
         return response
     }
 
@@ -123,7 +125,7 @@ class M3u8HttpServer(
             Log.w(tag, "Upstream HTTP ${e.code} for M3U8 request")
             passThroughStatus(e)
         } catch (e: Exception) {
-            Log.e(tag, "Error processing M3U8: ${e.javaClass.simpleName}")
+            Log.e(tag, "Error processing M3U8: ${e.javaClass.simpleName}", e)
             newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
         }
     }
@@ -152,7 +154,7 @@ class M3u8HttpServer(
             Log.w(tag, "Upstream segment HTTP ${e.code}")
             passThroughStatus(e)
         } catch (e: Exception) {
-            Log.e(tag, "Error processing segment request: ${e.javaClass.simpleName}")
+            Log.e(tag, "Error processing segment request: ${e.javaClass.simpleName}", e)
             newFixedLengthResponse(Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Error: ${e.message}")
         }
     }
@@ -308,7 +310,7 @@ class M3u8HttpServer(
             Log.w(tag, "Segment fetch upstream HTTP ${e.code}")
             throw e
         } catch (e: Exception) {
-            Log.e(tag, "Error processing segment: ${e.javaClass.simpleName}")
+            Log.e(tag, "Error processing segment: ${e.javaClass.simpleName}", e)
             throw UpstreamStatusException(503, url, "Error processing segment: ${e.message}", e)
         }
     }

--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8Integration.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8Integration.kt
@@ -43,14 +43,15 @@ class M3u8Integration(
     private fun processM3u8Video(originalVideo: Video): Video {
         val referer = originalVideo.headers?.get("Referer")
         val userAgent = originalVideo.headers?.get("User-Agent")
-        val processedUrl = serverManager.processM3u8Url(originalVideo.url, referer, userAgent)
+        val origin = originalVideo.headers?.get("Origin")
+        val processedUrl = serverManager.processM3u8Url(originalVideo.url, referer, userAgent, origin)
         return Video(
-            videoUrl = processedUrl ?: originalVideo.url,
-            url = originalVideo.url,
-            quality = originalVideo.quality,
-            subtitleTracks = originalVideo.subtitleTracks,
-            audioTracks = originalVideo.audioTracks,
-            headers = originalVideo.headers,
+            originalVideo.url,
+            originalVideo.quality,
+            processedUrl ?: originalVideo.url,
+            originalVideo.headers,
+            originalVideo.subtitleTracks,
+            originalVideo.audioTracks,
         )
     }
 

--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8Integration.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8Integration.kt
@@ -46,12 +46,12 @@ class M3u8Integration(
         val origin = originalVideo.headers?.get("Origin")
         val processedUrl = serverManager.processM3u8Url(originalVideo.url, referer, userAgent, origin)
         return Video(
-            originalVideo.url,
-            originalVideo.quality,
-            processedUrl ?: originalVideo.url,
-            originalVideo.headers,
-            originalVideo.subtitleTracks,
-            originalVideo.audioTracks,
+            url = originalVideo.url,
+            quality = originalVideo.quality,
+            videoUrl = processedUrl ?: originalVideo.url,
+            headers = originalVideo.headers,
+            subtitleTracks = originalVideo.subtitleTracks,
+            audioTracks = originalVideo.audioTracks,
         )
     }
 

--- a/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8ServerManager.kt
+++ b/lib/m3u8server/src/aniyomi/lib/m3u8server/M3u8ServerManager.kt
@@ -65,7 +65,12 @@ class M3u8ServerManager(
      * @param userAgent optional User-Agent to encode alongside the referer.
      * @return Processed M3U8 content as a local URL string
      */
-    fun processM3u8Url(m3u8Url: String, referer: String? = null, userAgent: String? = null): String? = server?.createLocalUrl(m3u8Url, referer, userAgent)
+    fun processM3u8Url(
+        m3u8Url: String,
+        referer: String? = null,
+        userAgent: String? = null,
+        origin: String? = null,
+    ): String? = server?.createLocalUrl(m3u8Url, referer, userAgent, origin)
 
     /**
      * Processes a segment through the server

--- a/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
+++ b/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
@@ -299,8 +299,8 @@ class MissAV :
 
         private const val PREF_QUALITY = "preferred_quality"
         private const val PREF_QUALITY_TITLE = "Preferred quality"
-        private val PREF_QUALITY_ENTRIES = listOf("720p", "480p", "360p")
-        private val PREF_QUALITY_VALUES = listOf("720", "480", "360")
+        private val PREF_QUALITY_ENTRIES = listOf("1080p", "720p", "480p", "360p")
+        private val PREF_QUALITY_VALUES = listOf("1080", "720", "480", "360")
         private val PREF_QUALITY_DEFAULT = PREF_QUALITY_VALUES.first()
 
         private const val PREF_UUID_KEY = "missav_uuid"

--- a/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
+++ b/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
@@ -248,8 +248,8 @@ class MissAV :
         val quality = preferences.getString(PREF_QUALITY, PREF_QUALITY_DEFAULT)!!
 
         return sortedWith(
-            compareBy { it.quality.contains(quality) },
-        ).reversed()
+            compareByDescending<Video> { it.quality.contains(quality) },
+        )
     }
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
+++ b/src/all/missav/src/eu/kanade/tachiyomi/animeextension/all/missav/MissAV.kt
@@ -248,7 +248,10 @@ class MissAV :
         val quality = preferences.getString(PREF_QUALITY, PREF_QUALITY_DEFAULT)!!
 
         return sortedWith(
-            compareByDescending<Video> { it.quality.contains(quality) },
+            compareByDescending<Video> { it.quality.contains(quality) }
+                .thenByDescending {
+                    resolutionRegex.find(it.quality)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+                },
         )
     }
 
@@ -306,6 +309,7 @@ class MissAV :
         private const val PREF_UUID_KEY = "missav_uuid"
 
         private val regexWhitespace = Regex("\\s+")
+        private val resolutionRegex = Regex("""(\d{3,4})p""")
         private val regexSpecialCharacters =
             Regex("([-.!~#$%^&*+_|/\\\\,?:;'“”‘’\"<>(){}\\[\\]。・～：—！？、―«»《》〘〙【】「」｜]|\\s-|-\\s|\\s\\.|\\.\\s)")
         private val regexNumberOnly = Regex("^\\d+$")


### PR DESCRIPTION
Fixes MissAV downloads that stall/restart at ~3% and unlocks 1080p.

## Changes

**m3u8server: serve playlists as chunked responses**
FFmpeg n7.1 treats a fixed-length HTTP EOF as `AVERROR_EOF` and, with
Animetail's hardcoded `-reconnect_at_eof 1`, reconnects forever at the
start of a download. Serving the playlist as a chunked response returns
a normal end-of-stream, so downloads proceed.

**m3u8server: skip junk-scanning for aligned MPEG-TS segments**
The interleaved JPEG/PNG/GIF disguise scanner could false-positive on
bytes inside a valid TS payload and delete real data, corrupting later
AAC/TS packets mid-download (observed at media time 00:04:35). When a
segment is a complete TS grid (size % 188 == 0 with 0x47 at every
packet boundary), scanning is skipped; genuinely disguised segments
still go through the existing scanner.

**m3u8server: propagate Origin, stop forwarding hop-by-hop headers**
Origin is now carried through the local proxy, and Connection /
Cache-Control / Pragma are no longer forwarded upstream so OkHttp can
manage connection reuse. Request logs are redacted (no URLs, headers,
or exception messages).

**missav: add 1080p to the quality preference**
The setting was capped at 720p even though the HLS parser already
listed 1080p. `1080p/720p/480p/360p` are now available, with the
existing automatic fallback to the highest available quality when a
title has no 1080p.

## Verification

- `assembleDebug` succeeds; `git diff --check` clean
- Download previously failed at ~3% now proceeds past 4% on-device
- 1080p option visible and usable in extension settings
- Built APK installed and verified on device (SHA-256 matches build output)

## Summary by Sourcery

Improve MissAV HLS download reliability and expose higher-quality video options.

New Features:
- Add 1080p to MissAV quality preferences while retaining automatic fallback to the highest available resolution.

Bug Fixes:
- Prevent HLS downloads from restarting at the beginning by serving rewritten playlists with normal chunked end-of-stream behavior.
- Avoid corrupting valid MPEG-TS segments by skipping disguise scanning for packet-aligned transport streams.
- Improve segment retrieval reliability with a fallback HTTP client when the primary client fails.

Enhancements:
- Preserve Origin headers through the local HLS proxy and stop forwarding hop-by-hop connection headers.
- Reduce sensitive request logging by omitting URLs, headers, and exception messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Forwarded video stream origin information when loading M3U8 playlists and segments.
  - Added fallback handling for certain upstream video request failures.
  - Added 1080p as a preferred video quality option.

- **Bug Fixes**
  - Improved handling of complete, packet-aligned MPEG-TS streams.
  - Improved playlist delivery for more reliable playback.
  - Improved video sorting by preferred quality and resolution.
  - Reduced unnecessary processing and request logging during streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->