### PR TITLE
MKissa: fix crypto for 2025-08 site rebuild (v14.64)

### DIFF
--- a/src/en/mkissa/build.gradle
+++ b/src/en/mkissa/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MKissa'
     extClass = '.MKissa'
-    extVersionCode = 63
+    extVersionCode = 64
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
@@ -18,18 +18,7 @@ object MKissaBundle {
         // New obfuscation: buildId is a decoded string via the same table rotation as seeds,
         // e.g. `const Mm=zt(520,520)` where the call resolves to "132" after rotation.
         // We reuse the same table/bases/aliases machinery and brute-force the rotation.
-        val tables = readTables(js)
-        val bases = BASE_DECODER_REGEX.findAll(js).associate { m ->
-            m.groupValues[1] to Base(m.groupValues[4], fold(m.groupValues[3]))
-        }
-        val aliases = buildMap {
-            bases.keys.forEach { put(it, Alias(it, 0, 0)) }
-            ALIAS_DECODER_REGEX.findAll(js).forEach { m ->
-                val (name, firstParam, _, callee, arg, delta) = m.destructured
-                if (callee !in bases) return@forEach
-                put(name, Alias(callee, if (arg == firstParam) 0 else 1, if (delta.isEmpty()) 0 else fold(delta)))
-            }
-        }
+        val (tables, bases, aliases) = decodersFrom(js)
 
         val buildId = extractBuildIdNew(js, tables, bases, aliases) ?: return null
         val seeds = extractSeedsWithTables(js, tables, bases, aliases) ?: return null
@@ -52,12 +41,12 @@ object MKissaBundle {
                 Regex("""\b${Regex.escape(varName)}\s*=\s*$CALL_PATTERN""").containsMatchIn(js)
             }
 
-        val candidates = mutableListOf<Pair<String, IntRange>>()
+        val candidates = mutableListOf<String>()
 
         if (maskDefaultVar != null) {
             val assignRegex = Regex("""\b${Regex.escape(maskDefaultVar)}\s*=\s*($CALL_PATTERN)""")
             assignRegex.findAll(js).forEach { m ->
-                candidates.add(m.groupValues[1] to m.range)
+                candidates.add(m.groupValues[1])
             }
         }
 
@@ -71,7 +60,7 @@ object MKissaBundle {
                 val call = m.groupValues[1]
                 // Exclude the seed array itself which is `=[call+call, ...]`
                 if (!call.contains("+")) {
-                    candidates.add(call to (m.range.first + windowStart..m.range.last + windowStart))
+                    candidates.add(call)
                 }
             }
         }
@@ -81,12 +70,12 @@ object MKissaBundle {
             val assignRegex = Regex("""\b\w+\s*=\s*($CALL_PATTERN)\b""")
             assignRegex.findAll(js).forEach { m ->
                 val call = m.groupValues[1]
-                if (!call.contains("+")) candidates.add(call to m.range)
+                if (!call.contains("+")) candidates.add(call)
             }
         }
 
         // Try each candidate call with every rotation, looking for a numeric buildId
-        for ((call, _) in candidates) {
+        for (call in candidates) {
             // Find which table this call belongs to
             val aliasName = CALL_REGEX.find(call)?.groupValues?.get(1) ?: continue
             val alias = aliases[aliasName] ?: continue
@@ -95,7 +84,7 @@ object MKissaBundle {
 
             for (rotation in table.indices) {
                 val decoded = resolve(call, rotation, tables, bases, aliases) ?: continue
-                if (decoded.matches(Regex("""\d{2,10}"""))) {
+                if (decoded.matches(BUILD_ID_DIGITS_REGEX)) {
                     // Require that the same rotation also yields valid seeds, to avoid false positives
                     // (e.g. "211" salt value). Check that seeds resolve under this rotation.
                     val seedsOk = extractSeedsWithTables(js, tables, bases, aliases, forcedRotation = rotation) != null
@@ -114,11 +103,12 @@ object MKissaBundle {
             val table = tables[base.table] ?: continue
             for (rotation in table.indices) {
                 val decoded = resolve(call, rotation, tables, bases, aliases) ?: continue
-                if (decoded.matches(Regex("""\d{2,10}""")) && decoded.length in 2..8) {
+                if (decoded.matches(BUILD_ID_DIGITS_REGEX) && decoded.length in 2..8) {
                     // Heuristic: buildId is 2-8 digits, seeds are base64 12 chars with =
                     // Ensure this call is not part of the seed array (seed array calls are in a `=[...]` context)
                     val before = js.substring((match.range.first - 20).coerceAtLeast(0), match.range.first)
                     if (before.contains("sf=") || before.contains("kd=")) continue
+                    if (extractSeedsWithTables(js, tables, bases, aliases, forcedRotation = rotation) == null) continue
                     return decoded
                 }
             }
@@ -129,7 +119,7 @@ object MKissaBundle {
     private class Base(val table: String, val offset: Int)
     private class Alias(val base: String, val argIndex: Int, val delta: Int)
 
-    private fun extractSeeds(js: String): List<String>? {
+    private fun decodersFrom(js: String): Triple<Map<String, List<String>>, Map<String, Base>, Map<String, Alias>> {
         val tables = readTables(js)
         val bases = BASE_DECODER_REGEX.findAll(js).associate { m ->
             m.groupValues[1] to Base(m.groupValues[4], fold(m.groupValues[3]))
@@ -144,6 +134,11 @@ object MKissaBundle {
                 put(name, Alias(callee, if (arg == firstParam) 0 else 1, if (delta.isEmpty()) 0 else fold(delta)))
             }
         }
+        return Triple(tables, bases, aliases)
+    }
+
+    private fun extractSeeds(js: String): List<String>? {
+        val (tables, bases, aliases) = decodersFrom(js)
         return extractSeedsWithTables(js, tables, bases, aliases)
     }
 
@@ -268,6 +263,7 @@ object MKissaBundle {
     }
 
     private val BUILD_ID_REGEX = Regex("""!==\s*["']string["']\s*\?\s*["'](\d+)["']\s*:\s*["']["']""")
+    private val BUILD_ID_DIGITS_REGEX = Regex("""\d{2,10}""")
 
     // The obfuscator names functions with `$` too (`$l`, `Cr`), which `\w` excludes. The `${'$'}`
     // interpolation yields the literal dollar sign without starting a template.

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
@@ -10,9 +10,120 @@ object MKissaBundle {
     class BuildInfo(val buildId: String, val seeds: List<String>)
 
     fun parse(js: String): BuildInfo? {
-        val buildId = BUILD_ID_REGEX.find(js)?.groupValues?.get(1) ?: return null
-        val seeds = extractSeeds(js) ?: return null
+        // Legacy path: literal buildId like `!== "string" ? "12345" : ""`
+        BUILD_ID_REGEX.find(js)?.groupValues?.get(1)?.let { legacyId ->
+            extractSeeds(js)?.let { seeds -> return BuildInfo(legacyId, seeds) }
+        }
+
+        // New obfuscation: buildId is a decoded string via the same table rotation as seeds,
+        // e.g. `const Mm=zt(520,520)` where the call resolves to "132" after rotation.
+        // We reuse the same table/bases/aliases machinery and brute-force the rotation.
+        val tables = readTables(js)
+        val bases = BASE_DECODER_REGEX.findAll(js).associate { m ->
+            m.groupValues[1] to Base(m.groupValues[4], fold(m.groupValues[3]))
+        }
+        val aliases = buildMap {
+            bases.keys.forEach { put(it, Alias(it, 0, 0)) }
+            ALIAS_DECODER_REGEX.findAll(js).forEach { m ->
+                val (name, firstParam, _, callee, arg, delta) = m.destructured
+                if (callee !in bases) return@forEach
+                put(name, Alias(callee, if (arg == firstParam) 0 else 1, if (delta.isEmpty()) 0 else fold(delta)))
+            }
+        }
+
+        val buildId = extractBuildIdNew(js, tables, bases, aliases) ?: return null
+        val seeds = extractSeedsWithTables(js, tables, bases, aliases) ?: return null
         return BuildInfo(buildId, seeds)
+    }
+
+    private fun extractBuildIdNew(
+        js: String,
+        tables: Map<String, List<String>>,
+        bases: Map<String, Base>,
+        aliases: Map<String, Alias>,
+    ): String? {
+        // Strategy 1: look for the variable used as default param for the mask function F_(e=Mm).
+        // The mask function is the one that takes buildId as default and is later called as F_(_r).
+        // Its name is minified (F_, U_, etc.) but we can find `function F_(e=Mm)` pattern.
+        val maskDefaultVar = Regex("""function\s+($IDENT)\s*\(\s*\w+\s*=\s*(\w+)\s*[,)]""").findAll(js)
+            .mapNotNull { it.groupValues[2].takeIf(String::isNotEmpty) }
+            .firstOrNull { varName ->
+                // The variable should be assigned via a single decoder call near the seed array
+                Regex("""\b${Regex.escape(varName)}\s*=\s*$CALL_PATTERN""").containsMatchIn(js)
+            }
+
+        val candidates = mutableListOf<Pair<String, IntRange>>()
+
+        if (maskDefaultVar != null) {
+            val assignRegex = Regex("""\b${Regex.escape(maskDefaultVar)}\s*=\s*($CALL_PATTERN)""")
+            assignRegex.findAll(js).forEach { m ->
+                candidates.add(m.groupValues[1] to m.range)
+            }
+        }
+
+        // Fallback: look near `sf=` (seed array) for a preceding single-call assignment
+        val sfIndex = js.indexOf("sf=")
+        if (sfIndex != -1) {
+            val windowStart = (sfIndex - 2000).coerceAtLeast(0)
+            val window = js.substring(windowStart, sfIndex)
+            val assignRegex = Regex("""\b\w+\s*=\s*($CALL_PATTERN)\s*(?:,|;|\n)""")
+            assignRegex.findAll(window).forEach { m ->
+                val call = m.groupValues[1]
+                // Exclude the seed array itself which is `=[call+call, ...]`
+                if (!call.contains("+")) {
+                    candidates.add(call to (m.range.first + windowStart..m.range.last + windowStart))
+                }
+            }
+        }
+
+        // Last resort: any single CALL assignment that resolves to digits
+        if (candidates.isEmpty()) {
+            val assignRegex = Regex("""\b\w+\s*=\s*($CALL_PATTERN)\b""")
+            assignRegex.findAll(js).forEach { m ->
+                val call = m.groupValues[1]
+                if (!call.contains("+")) candidates.add(call to m.range)
+            }
+        }
+
+        // Try each candidate call with every rotation, looking for a numeric buildId
+        for ((call, _) in candidates) {
+            // Find which table this call belongs to
+            val aliasName = CALL_REGEX.find(call)?.groupValues?.get(1) ?: continue
+            val alias = aliases[aliasName] ?: continue
+            val base = bases[alias.base] ?: continue
+            val table = tables[base.table] ?: continue
+
+            for (rotation in table.indices) {
+                val decoded = resolve(call, rotation, tables, bases, aliases) ?: continue
+                if (decoded.matches(Regex("""\d{2,10}"""))) {
+                    // Require that the same rotation also yields valid seeds, to avoid false positives
+                    // (e.g. "211" salt value). Check that seeds resolve under this rotation.
+                    val seedsOk = extractSeedsWithTables(js, tables, bases, aliases, forcedRotation = rotation) != null
+                    if (seedsOk) return decoded
+                }
+            }
+        }
+
+        // Final fallback: brute-force any CALL that decodes to digits, even if not an assignment
+        for (match in CALL_REGEX.findAll(js)) {
+            val call = match.value
+            if (call.contains("+")) continue
+            val aliasName = match.groupValues[1]
+            val alias = aliases[aliasName] ?: continue
+            val base = bases[alias.base] ?: continue
+            val table = tables[base.table] ?: continue
+            for (rotation in table.indices) {
+                val decoded = resolve(call, rotation, tables, bases, aliases) ?: continue
+                if (decoded.matches(Regex("""\d{2,10}""")) && decoded.length in 2..8) {
+                    // Heuristic: buildId is 2-8 digits, seeds are base64 12 chars with =
+                    // Ensure this call is not part of the seed array (seed array calls are in a `=[...]` context)
+                    val before = js.substring((match.range.first - 20).coerceAtLeast(0), match.range.first)
+                    if (before.contains("sf=") || before.contains("kd=")) continue
+                    return decoded
+                }
+            }
+        }
+        return null
     }
 
     private class Base(val table: String, val offset: Int)
@@ -33,7 +144,16 @@ object MKissaBundle {
                 put(name, Alias(callee, if (arg == firstParam) 0 else 1, if (delta.isEmpty()) 0 else fold(delta)))
             }
         }
+        return extractSeedsWithTables(js, tables, bases, aliases)
+    }
 
+    private fun extractSeedsWithTables(
+        js: String,
+        tables: Map<String, List<String>>,
+        bases: Map<String, Base>,
+        aliases: Map<String, Alias>,
+        forcedRotation: Int? = null,
+    ): List<String>? {
         for (match in SEED_ARRAY_REGEX.findAll(js)) {
             val calls = CALL_REGEX.findAll(match.groupValues[1]).map(MatchResult::value).toList()
             if (calls.size != MKissaCrypto.SEED_COUNT * 2) continue
@@ -42,6 +162,11 @@ object MKissaBundle {
                 ?.let { aliases[it.groupValues[1]] }
                 ?.let { tables[bases[it.base]?.table] }
                 ?: continue
+
+            if (forcedRotation != null) {
+                seedsAt(calls, forcedRotation, tables, bases, aliases)?.let { return it }
+                continue
+            }
 
             val matches = table.indices.mapNotNull { rotation ->
                 seedsAt(calls, rotation, tables, bases, aliases)

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -41,29 +41,47 @@ object MKissaCrypto {
         .digest(value.toByteArray(Charsets.UTF_8))
         .toHex()
 
-    /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild. */
+    /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild.
+     *  2025-08: site rotated salts from 17/31/41/7 to 211/222/200/176 (see kd={saltMul:211,...} in chunk).
+     *  Keep old constants as fallback for a brief grace window.
+     */
     fun deriveMask(buildId: String, seeds: List<String>): ByteArray? {
         if (buildId.isEmpty() || seeds.size != SEED_COUNT) return null
 
-        val stream = ByteArray(KEY_SIZE) { i ->
-            (buildId[i % buildId.length].code xor ((i * 17 + 31) and 0xFF)).toByte()
-        }
+        // Try new salts first (current site: 211/222/200/176), then legacy 17/31/41/7
+        for (params in listOf(
+            intArrayOf(211, 222, 200, 176),
+            intArrayOf(17, 31, 41, 7),
+        )) {
+            val saltMul = params[0]
+            val saltAdd = params[1]
+            val fragMul = params[2]
+            val fragAdd = params[3]
 
-        val mask = ByteArray(KEY_SIZE)
-        seeds.forEachIndexed { index, seed ->
-            val bytes = runCatching { Base64.decode(seed, Base64.DEFAULT) }.getOrNull() ?: return null
-            if (bytes.size < SEED_SIZE) return null
-
-            val base = index * SEED_SIZE
-            for (offset in 0 until SEED_SIZE) {
-                mask[base + offset] = (
-                    (bytes[offset].toInt() and 0xFF) xor
-                        (stream[base + offset].toInt() and 0xFF) xor
-                        ((index * 41 + offset * 7) and 0xFF)
-                    ).toByte()
+            val stream = ByteArray(KEY_SIZE) { i ->
+                (buildId[i % buildId.length].code xor ((i * saltMul + saltAdd) and 0xFF)).toByte()
             }
+
+            val mask = ByteArray(KEY_SIZE)
+            var ok = true
+            seeds.forEachIndexed { index, seed ->
+                val bytes = runCatching { Base64.decode(seed, Base64.DEFAULT) }.getOrNull()
+                if (bytes == null || bytes.size < SEED_SIZE) {
+                    ok = false
+                    return@forEachIndexed
+                }
+                val base = index * SEED_SIZE
+                for (offset in 0 until SEED_SIZE) {
+                    mask[base + offset] = (
+                        (bytes[offset].toInt() and 0xFF) xor
+                            (stream[base + offset].toInt() and 0xFF) xor
+                            ((index * fragMul + offset * fragAdd) and 0xFF)
+                        ).toByte()
+                }
+            }
+            if (ok && mask.any { it != 0.toByte() }) return mask
         }
-        return mask
+        return null
     }
 
     fun deriveKey(mask: ByteArray, partB: ByteArray): SecretKeySpec {
@@ -73,8 +91,37 @@ object MKissaCrypto {
         return SecretKeySpec(keyBytes, KEY_TYPE)
     }
 
-    /** `x-aa-boot`, checked by the bootstrap endpoint before it hands out `partB`. */
+    /** `x-aa-boot`, checked by the bootstrap endpoint before it hands out `partB`.
+     *  2025-08: site changed bootPrefix from "aa-boot:" to "kNk1YgwkSI:" and message
+     *  from "buildId:group:host:epoch:lane" (":"-joined, buildId first) to
+     *  "epoch.group.host.buildId.lane" ("."-joined, epoch first, see kd={join:".",parts:[epoch,group,host,buildId,lane]}).
+     *  We keep the legacy format as fallback for the brief window after a site rebuild.
+     */
     fun bootToken(
+        mask: ByteArray,
+        buildId: String,
+        epoch: Long,
+        keyGroup: String,
+        refererHost: String,
+        lane: String,
+    ): String = bootTokenNew(mask, buildId, epoch, keyGroup, refererHost, lane)
+
+    fun bootTokenNew(
+        mask: ByteArray,
+        buildId: String,
+        epoch: Long,
+        keyGroup: String,
+        refererHost: String,
+        lane: String,
+    ): String {
+        val inner = hmac(mask, "kNk1YgwkSI:$buildId")
+        // kd.parts = ["epoch","group","host","buildId","lane"], kd.join = "."
+        // omitEmptyLane = false, so always include lane even if empty
+        val message = listOf(epoch.toString(), keyGroup, refererHost, buildId, lane).joinToString(".")
+        return hmac(inner, message).toHex()
+    }
+
+    fun bootTokenLegacy(
         mask: ByteArray,
         buildId: String,
         epoch: Long,
@@ -90,6 +137,18 @@ object MKissaCrypto {
         }
         return hmac(inner, message).toHex()
     }
+
+    fun bootTokenCandidates(
+        mask: ByteArray,
+        buildId: String,
+        epoch: Long,
+        keyGroup: String,
+        refererHost: String,
+        lane: String,
+    ): List<String> = listOf(
+        bootTokenNew(mask, buildId, epoch, keyGroup, refererHost, lane),
+        bootTokenLegacy(mask, buildId, epoch, keyGroup, refererHost, lane),
+    )
 
     /** Oldest first: during the grace window the server still mints `partB` for the previous. */
     fun epochCandidates(now: Long = System.currentTimeMillis()): List<Long> {

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -41,25 +41,23 @@ object MKissaCrypto {
         .digest(value.toByteArray(Charsets.UTF_8))
         .toHex()
 
+    private data class MaskParams(val saltMul: Int, val saltAdd: Int, val fragMul: Int, val fragAdd: Int)
+
+    private val MASK_PARAMS = listOf(
+        MaskParams(211, 222, 200, 176),
+        MaskParams(17, 31, 41, 7),
+    )
+
     /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild.
      *  2025-08: site rotated salts from 17/31/41/7 to 211/222/200/176 (see kd={saltMul:211,...} in chunk).
      *  Keep old constants as fallback for a brief grace window.
      */
-    fun deriveMask(buildId: String, seeds: List<String>): ByteArray? {
-        if (buildId.isEmpty() || seeds.size != SEED_COUNT) return null
-
-        // Try new salts first (current site: 211/222/200/176), then legacy 17/31/41/7
-        for (params in listOf(
-            intArrayOf(211, 222, 200, 176),
-            intArrayOf(17, 31, 41, 7),
-        )) {
-            val saltMul = params[0]
-            val saltAdd = params[1]
-            val fragMul = params[2]
-            val fragAdd = params[3]
-
+    fun maskCandidates(buildId: String, seeds: List<String>): List<ByteArray> {
+        if (buildId.isEmpty() || seeds.size != SEED_COUNT) return emptyList()
+        val candidates = mutableListOf<ByteArray>()
+        for (params in MASK_PARAMS) {
             val stream = ByteArray(KEY_SIZE) { i ->
-                (buildId[i % buildId.length].code xor ((i * saltMul + saltAdd) and 0xFF)).toByte()
+                (buildId[i % buildId.length].code xor ((i * params.saltMul + params.saltAdd) and 0xFF)).toByte()
             }
 
             val mask = ByteArray(KEY_SIZE)
@@ -75,14 +73,16 @@ object MKissaCrypto {
                     mask[base + offset] = (
                         (bytes[offset].toInt() and 0xFF) xor
                             (stream[base + offset].toInt() and 0xFF) xor
-                            ((index * fragMul + offset * fragAdd) and 0xFF)
+                            ((index * params.fragMul + offset * params.fragAdd) and 0xFF)
                         ).toByte()
                 }
             }
-            if (ok && mask.any { it != 0.toByte() }) return mask
+            if (ok && mask.any { it != 0.toByte() }) candidates.add(mask)
         }
-        return null
+        return candidates
     }
+
+    fun deriveMask(buildId: String, seeds: List<String>): ByteArray? = maskCandidates(buildId, seeds).firstOrNull()
 
     fun deriveKey(mask: ByteArray, partB: ByteArray): SecretKeySpec {
         val keyBytes = ByteArray(KEY_SIZE) { i ->
@@ -97,15 +97,6 @@ object MKissaCrypto {
      *  "epoch.group.host.buildId.lane" ("."-joined, epoch first, see kd={join:".",parts:[epoch,group,host,buildId,lane]}).
      *  We keep the legacy format as fallback for the brief window after a site rebuild.
      */
-    fun bootToken(
-        mask: ByteArray,
-        buildId: String,
-        epoch: Long,
-        keyGroup: String,
-        refererHost: String,
-        lane: String,
-    ): String = bootTokenNew(mask, buildId, epoch, keyGroup, refererHost, lane)
-
     fun bootTokenNew(
         mask: ByteArray,
         buildId: String,

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
@@ -122,31 +122,33 @@ class MKissaKeyManager(
     private class BootstrapResult(
         val bootstrap: AaCryptoBootstrap?,
         val stale: Boolean,
+        val mask: ByteArray? = null,
     )
 
     /** Re-scraping starts at the Cloudflare-gated HTML, so cheaper causes are ruled out first. */
     private suspend fun handshake(): Handshake? {
         val cached = cachedBuild()
-        val mask = cached?.let { MKissaCrypto.deriveMask(it.buildId, it.seeds) }
+        val cachedMasks = cached?.let { MKissaCrypto.maskCandidates(it.buildId, it.seeds) }
 
-        if (cached != null && mask != null) {
-            val first = bootstrap(cached.buildId, mask, MKissaCrypto.epochCandidates())
-            first.bootstrap?.let { return Handshake(cached, mask, it) }
+        if (cached != null && cachedMasks != null && cachedMasks.isNotEmpty()) {
+            val first = bootstrap(cached.buildId, cachedMasks, MKissaCrypto.epochCandidates())
+            first.bootstrap?.let { return Handshake(cached, first.mask!!, it) }
             if (!first.stale) return null
 
             // A clock off by more than the grace window looks exactly like a stale build.
-            bootstrap(cached.buildId, mask, MKissaCrypto.skewedEpochCandidates()).bootstrap
-                ?.let { return Handshake(cached, mask, it) }
+            val second = bootstrap(cached.buildId, cachedMasks, MKissaCrypto.skewedEpochCandidates())
+            second.bootstrap?.let { return Handshake(cached, second.mask!!, it) }
         }
 
         val fresh = resolveBuild() ?: return null
-        val freshMask = MKissaCrypto.deriveMask(fresh.buildId, fresh.seeds) ?: return null
-        return bootstrap(fresh.buildId, freshMask, MKissaCrypto.epochCandidates())
-            .bootstrap?.let { Handshake(fresh, freshMask, it) }
+        val freshMasks = MKissaCrypto.maskCandidates(fresh.buildId, fresh.seeds)
+        if (freshMasks.isEmpty()) return null
+        val freshResult = bootstrap(fresh.buildId, freshMasks, MKissaCrypto.epochCandidates())
+        return freshResult.bootstrap?.let { Handshake(fresh, freshResult.mask!!, it) }
     }
 
     /** `GET /client-crypto/v1/bootstrap?buildId=&k=`, gated by an HMAC of the client mask. */
-    private suspend fun bootstrap(buildId: String, mask: ByteArray, epochs: List<Long>): BootstrapResult {
+    private suspend fun bootstrap(buildId: String, masks: List<ByteArray>, epochs: List<Long>): BootstrapResult {
         val host = siteUrl.toHttpUrl().host
         val url = "${apiUrl.trimEnd('/')}$BOOTSTRAP_PATH".toHttpUrl().newBuilder()
             .addQueryParameter("buildId", buildId)
@@ -154,35 +156,36 @@ class MKissaKeyManager(
             .build()
 
         var sawStale = false
-        for (epoch in epochs) {
-            var epochStale = false
-            var epochSucceeded = false
-            for (bootToken in MKissaCrypto.bootTokenCandidates(mask, buildId, epoch, KEY_GROUP, host, ANIME_LANE)) {
-                val requestHeaders = headers.newBuilder()
-                    .set("x-build-id", buildId)
-                    .set("x-aa-boot", bootToken)
-                    .set("Origin", siteUrl)
-                    .set("Referer", "$siteUrl/")
-                    .build()
+        for (mask in masks) {
+            for (epoch in epochs) {
+                var epochStale = false
+                for (bootToken in MKissaCrypto.bootTokenCandidates(mask, buildId, epoch, KEY_GROUP, host, ANIME_LANE)) {
+                    val requestHeaders = headers.newBuilder()
+                        .set("x-build-id", buildId)
+                        .set("x-aa-boot", bootToken)
+                        .set("Origin", siteUrl)
+                        .set("Referer", "$siteUrl/")
+                        .build()
 
-                val response = runCatching { client.newCall(GET(url, requestHeaders)).await() }.getOrNull()
-                    ?: return BootstrapResult(null, stale = false)
+                    val response = runCatching { client.newCall(GET(url, requestHeaders)).await() }.getOrNull()
+                        ?: return BootstrapResult(null, stale = false)
 
-                if (!response.isSuccessful) {
-                    response.close()
-                    if (response.code in STALE_CODES) epochStale = true
-                    continue
+                    if (!response.isSuccessful) {
+                        response.close()
+                        if (response.code in STALE_CODES) epochStale = true
+                        continue
+                    }
+
+                    val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
+                        ?: continue
+
+                    // A partB from another lane would silently derive the wrong key.
+                    if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
+
+                    return BootstrapResult(bootstrap, stale = false, mask = mask)
                 }
-
-                val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
-                    ?: return BootstrapResult(null, stale = false)
-
-                // A partB from another lane would silently derive the wrong key.
-                if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
-
-                return BootstrapResult(bootstrap, stale = false)
+                if (epochStale) sawStale = true
             }
-            if (epochStale) sawStale = true
         }
         return BootstrapResult(null, stale = sawStale)
     }

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
@@ -155,29 +155,34 @@ class MKissaKeyManager(
 
         var sawStale = false
         for (epoch in epochs) {
-            val requestHeaders = headers.newBuilder()
-                .set("x-build-id", buildId)
-                .set("x-aa-boot", MKissaCrypto.bootToken(mask, buildId, epoch, KEY_GROUP, host, ANIME_LANE))
-                .set("Origin", siteUrl)
-                .set("Referer", "$siteUrl/")
-                .build()
+            var epochStale = false
+            var epochSucceeded = false
+            for (bootToken in MKissaCrypto.bootTokenCandidates(mask, buildId, epoch, KEY_GROUP, host, ANIME_LANE)) {
+                val requestHeaders = headers.newBuilder()
+                    .set("x-build-id", buildId)
+                    .set("x-aa-boot", bootToken)
+                    .set("Origin", siteUrl)
+                    .set("Referer", "$siteUrl/")
+                    .build()
 
-            val response = runCatching { client.newCall(GET(url, requestHeaders)).await() }.getOrNull()
-                ?: return BootstrapResult(null, stale = false)
+                val response = runCatching { client.newCall(GET(url, requestHeaders)).await() }.getOrNull()
+                    ?: return BootstrapResult(null, stale = false)
 
-            if (!response.isSuccessful) {
-                response.close()
-                if (response.code in STALE_CODES) sawStale = true
-                continue
+                if (!response.isSuccessful) {
+                    response.close()
+                    if (response.code in STALE_CODES) epochStale = true
+                    continue
+                }
+
+                val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
+                    ?: return BootstrapResult(null, stale = false)
+
+                // A partB from another lane would silently derive the wrong key.
+                if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
+
+                return BootstrapResult(bootstrap, stale = false)
             }
-
-            val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
-                ?: return BootstrapResult(null, stale = false)
-
-            // A partB from another lane would silently derive the wrong key.
-            if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
-
-            return BootstrapResult(bootstrap, stale = false)
+            if (epochStale) sawStale = true
         }
         return BootstrapResult(null, stale = sawStale)
     }


### PR DESCRIPTION
Closes https://yuzono-tracker.7he.dev/report/471

Fixes MKissa playback broken with crypto error after 2025-08 site rebuild.

**Site changes (chunk `https://cdn.mkissa.net/all/mk/_app/immutable/chunks/9ow_8gVi.js`):**
- `buildId` now decoded via string table rotation (`Mm=zt(520,520)->132`) not literal `!== "string" ? "123"`; updated `MKissaBundle` to brute-force table rotation and resolve numeric `\d{2,10}` near `sf=` (`MKissaBundle.kt:12`).
- `kd` salts rotated: `17/31/41/7 → 211/222/200/176`; `MKissaCrypto.deriveMask` now tries new salts first then legacy (`MKissaCrypto.kt:48`).
- `bootPrefix` `aa-boot:` → `kNk1YgwkSI:`, message `buildId:group:host:epoch:lane` (`:`) → `epoch.group.host.buildId.lane` (`.`, `kd.parts`, `omitEmptyLane=false`); `MKissaCrypto.bootToken` now generates both candidates and `MKissaKeyManager.bootstrap` tries both per epoch (`MKissaCrypto.kt:89`, `MKissaKeyManager.kt:149`).

**Verification:**
- Live bootstrap `GET https://api.mkissa.net/client-crypto/v1/bootstrap?buildId=132&k=k7` with new mask `6aa0b4aa1e202139...` + `kNk1YgwkSI:132` + `2955.mkissa.mkissa.to.132.k7` → `200 {epoch:2955, partB:tEuTmAcsz9klSWRTC...}` (old `e527d672...` → `403 invalid_boot_token`).
- `buildAaReq` (`72f44da39d430234...`, `AES-GCM`) → `tobeparsed AYfYuOiq...` decrypts to `sourceUrls` (Ok, Mp4, Fm-Hls, Yt-mp4) for One Piece `ReooPAxPMsHM4KPMY` ep 1174.
- `./gradlew :src:en:mkissa:assembleDebug` / `assembleRelease` → `BUILD SUCCESSFUL`, apks `aniyomi-en.mkissa-v14.64-debug.apk` (550K) / `release.apk` (299K).
- Bump `extVersionCode 63→64` (`src/en/mkissa/build.gradle:4`).

Diff 4 files, 232+/43- (mkissa only), isolated clone `../anime-extensions-mkissa` `--depth 1 --single-branch` on `mkissa-fix` (`e7a465e, afe48fa`).

## Summary by Sourcery

Update MKissa’s crypto integration for the 2025-08 site rebuild while preserving backward compatibility with the previous protocol.

Bug Fixes:
- Restore MKissa playback after the 2025-08 site rebuild by supporting its updated build ID decoding, crypto salts, and bootstrap token format.
- Retain compatibility with legacy site cryptography during the transition between rebuild formats.

Enhancements:
- Improve MKissa bundle parsing to resolve obfuscated numeric build IDs while validating them against the extracted seed data.
- Try current and legacy bootstrap token formats and crypto parameters across candidate epochs.

Build:
- Bump the MKissa extension version code from 63 to 64.

## Summary by Sourcery

Restore MKissa playback for the 2025-08 site rebuild while maintaining compatibility with the previous cryptographic protocol.

Bug Fixes:
- Restore MKissa playback after the 2025-08 site rebuild by supporting the updated build ID decoding, crypto parameters, and bootstrap token protocol.
- Preserve compatibility with legacy MKissa cryptography during the transition to the rebuilt site.

Enhancements:
- Improve MKissa bundle parsing to resolve obfuscated numeric build IDs and validate them against the associated seed data.
- Try current and legacy crypto and bootstrap formats across candidate epochs when establishing playback keys.

Build:
- Bump the MKissa extension version code from 63 to 64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for newer obfuscated build identifiers.
  * Added compatibility with updated authentication token formats while retaining legacy support.
  * Improved handling of multiple authentication options during connection setup.

* **Bug Fixes**
  * Improved compatibility with updated service security and validation behavior.
  * Preserved accurate handling of stale, invalid, and successful responses.

* **Chores**
  * Updated the extension version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->