### PR TITLE
Anime-Sama [FR]: restore missing video servers

### DIFF
--- a/lib/embed4meextractor/build.gradle.kts
+++ b/lib/embed4meextractor/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    alias(kei.plugins.library)
+}
+
+dependencies {
+    implementation(project(":lib:playlistutils"))
+}

--- a/lib/embed4meextractor/src/aniyomi/lib/embed4meextractor/Embed4MeExtractor.kt
+++ b/lib/embed4meextractor/src/aniyomi/lib/embed4meextractor/Embed4MeExtractor.kt
@@ -4,17 +4,17 @@ import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
-import keiyoushi.utils.UrlUtils
 import keiyoushi.utils.bodyString
 import keiyoushi.utils.commonEmptyHeaders
 import keiyoushi.utils.decodeHex
 import keiyoushi.utils.parallelCatchingFlatMap
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -162,42 +162,41 @@ class Embed4MeExtractor(
 
     private fun buildCandidates(jsonStr: String, embedOrigin: String): List<String>? {
         val root = try {
-            json.parseToJsonElement(jsonStr).jsonObject
+            json.parseToJsonElement(jsonStr)
         } catch (_: Exception) {
             return null
-        }
+        } as? JsonObject ?: return null
 
-        val streamingConfig = root["streamingConfig"]?.jsonObject
-        val order = streamingConfig?.get("order")?.jsonArray
-            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+        val streamingConfig = root["streamingConfig"].toJsonObject()
+        val order = (streamingConfig?.get("order") as? JsonArray)
+            ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
             ?: emptyList()
 
-        val adjustMap = streamingConfig?.get("adjust")?.jsonObject
-            ?.mapValues { (_, v) ->
-                val obj = v.jsonObject
-                Adjust(
-                    disabled = obj["disabled"]?.jsonPrimitive?.booleanOrNull ?: false,
-                    domain = obj["domain"]?.jsonPrimitive?.contentOrNull,
-                    params = obj["params"]?.jsonObject
-                        ?.mapValues { it.value.jsonPrimitive.contentOrNull ?: "" }
+        val adjustMap = (streamingConfig?.get("adjust") as? JsonObject)
+            ?.mapNotNull { entry ->
+                val obj = entry.value as? JsonObject ?: return@mapNotNull null
+                entry.key to Adjust(
+                    disabled = (obj["disabled"] as? JsonPrimitive)?.booleanOrNull ?: false,
+                    domain = (obj["domain"] as? JsonPrimitive)?.contentOrNull,
+                    params = (obj["params"] as? JsonObject)
+                        ?.mapValues { p -> (p.value as? JsonPrimitive)?.contentOrNull ?: "" }
                         ?.filterValues { it.isNotEmpty() }
                         ?: emptyMap(),
                 )
-            } ?: emptyMap()
+            }?.toMap() ?: emptyMap()
 
-        val pkObj = root["pk"]?.jsonObject
-            ?: root["PK"]?.jsonObject
+        val pkObj = (root["pk"] ?: root["PK"]).toJsonObject()
         val pk = pkObj?.let {
             Pk(
-                k = it["k"]?.jsonPrimitive?.contentOrNull,
-                kx = it["kx"]?.jsonPrimitive?.contentOrNull,
+                k = (it["k"] as? JsonPrimitive)?.contentOrNull,
+                kx = (it["kx"] as? JsonPrimitive)?.contentOrNull,
             )
         }
 
         // Source fields
         val sourceKeys = listOf("cf", "cfNative", "hlsVideoTiktok", "hlsVideoGoogle", "source")
         val sourceMap = sourceKeys.mapNotNull { key ->
-            val value = root[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            val value = (root[key] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
             if (value != null) key to value else null
         }.toMap()
 
@@ -205,7 +204,7 @@ class Embed4MeExtractor(
         if (namesInOrder.isEmpty() && sourceMap.isEmpty()) {
             // Fallback: any string value that looks like http
             val fallback = root.entries.mapNotNull { (k, v) ->
-                val s = v.jsonPrimitive.contentOrNull ?: return@mapNotNull null
+                val s = (v as? JsonPrimitive)?.contentOrNull ?: return@mapNotNull null
                 if (s.startsWith("http") && ("/hls/" in s || ".m3u8" in s || "/v4/" in s)) k to s else null
             }.toMap()
             if (fallback.isEmpty()) return emptyList()
@@ -213,6 +212,20 @@ class Embed4MeExtractor(
         }
 
         return buildUrlsFromMap(sourceMap, adjustMap, pk, embedOrigin, namesInOrder)
+    }
+
+    private fun JsonElement?.toJsonObject(): JsonObject? = when (this) {
+        is JsonObject -> this
+        is JsonPrimitive -> if (isString && content.startsWith("{")) {
+            try {
+                json.parseToJsonElement(content) as? JsonObject
+            } catch (_: Exception) {
+                null
+            }
+        } else {
+            null
+        }
+        else -> null
     }
 
     private fun buildUrlsFromMap(
@@ -243,13 +256,8 @@ class Embed4MeExtractor(
 
             // Resolve against embed origin if relative
             if (!url.startsWith("http")) {
-                url = UrlUtils.fixUrl(url, embedOrigin) ?: "$embedOrigin/$url".replace("//", "/").let {
-                    // ensure scheme preserved
-                    if (embedOrigin.startsWith("https")) it.replace("http:/", "https://") else it
-                }
-            } else {
-                // If URL is already absolute but contains /hls/ rewritten, ensure still resolved
-                // No-op
+                val base = embedOrigin.toHttpUrlOrNull() ?: continue
+                url = base.resolve(url)?.toString() ?: continue
             }
 
             // Append pk token for /v4/
@@ -257,9 +265,8 @@ class Embed4MeExtractor(
                 url = appendParams(url, mapOf("k" to pk.k!!, "kx" to pk.kx!!))
             }
 
-            // Fix url via UrlUtils for consistency
-            val fixed = UrlUtils.fixUrl(url, embedOrigin) ?: url
-            result.add(fixed)
+            val fixed = url.toHttpUrlOrNull() ?: continue
+            result.add(fixed.toString())
         }
         return result.distinct()
     }

--- a/lib/embed4meextractor/src/aniyomi/lib/embed4meextractor/Embed4MeExtractor.kt
+++ b/lib/embed4meextractor/src/aniyomi/lib/embed4meextractor/Embed4MeExtractor.kt
@@ -1,0 +1,301 @@
+package aniyomi.lib.embed4meextractor
+
+import aniyomi.lib.playlistutils.PlaylistUtils
+import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.utils.UrlUtils
+import keiyoushi.utils.bodyString
+import keiyoushi.utils.commonEmptyHeaders
+import keiyoushi.utils.decodeHex
+import keiyoushi.utils.parallelCatchingFlatMap
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class Embed4MeExtractor(
+    private val client: OkHttpClient,
+    private val headers: Headers = commonEmptyHeaders,
+) {
+    private val playlistUtils by lazy { PlaylistUtils(client, headers) }
+
+    private val json = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+
+    suspend fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
+        val id = extractId(url) ?: return emptyList()
+        val embedOrigin = extractOrigin(url)
+
+        val apiUrl = buildApiUrl(embedOrigin, id)
+        val apiHeaders = headers.newBuilder()
+            .set("Referer", "https://anime-sama.to/")
+            .set("Origin", embedOrigin)
+            .set("Accept", "*/*")
+            .build()
+
+        val raw = try {
+            client.newCall(GET(apiUrl, apiHeaders)).awaitSuccess().bodyString().trim()
+        } catch (_: Exception) {
+            return emptyList()
+        }
+        if (raw.isBlank()) return emptyList()
+
+        val jsonStr = decryptIfNeeded(raw) ?: return emptyList()
+        if (jsonStr.isBlank()) return emptyList()
+
+        val candidates = buildCandidates(jsonStr, embedOrigin) ?: return emptyList()
+        if (candidates.isEmpty()) return emptyList()
+
+        val hlsHeaders = headers.newBuilder()
+            .set("Referer", "https://anime-sama.to/")
+            .set("Origin", embedOrigin)
+            .build()
+
+        return candidates.parallelCatchingFlatMap { candidateUrl ->
+            try {
+                playlistUtils.extractFromHls(
+                    candidateUrl,
+                    referer = embedOrigin,
+                    masterHeaders = hlsHeaders,
+                    videoHeaders = hlsHeaders,
+                    videoNameGen = { quality ->
+                        val trimmed = prefix.trim()
+                        if (trimmed.isNotEmpty()) "$trimmed Embed4Me - $quality" else "Embed4Me - $quality"
+                    },
+                )
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+    }
+
+    private fun extractId(url: String): String? {
+        val fragment = url.substringAfter("#", "")
+        if (fragment.isBlank()) return null
+        return fragment.substringBefore("&")
+            .substringBefore("?")
+            .substringBefore("/")
+            .trim()
+            .takeIf { it.isNotBlank() }
+    }
+
+    private fun extractOrigin(url: String): String {
+        val withoutFragment = url.substringBefore("#")
+        return try {
+            val httpUrl = withoutFragment.toHttpUrl()
+            "${httpUrl.scheme}://${httpUrl.host}"
+        } catch (_: Exception) {
+            val base = withoutFragment.substringBefore("?").trimEnd('/')
+            if (base.startsWith("http")) {
+                val withoutPath = base.substringAfter("://").substringBefore("/")
+                val scheme = if (base.startsWith("https")) "https" else "http"
+                "$scheme://$withoutPath"
+            } else {
+                DEFAULT_ORIGIN
+            }
+        }.ifBlank { DEFAULT_ORIGIN }
+    }
+
+    private fun buildApiUrl(origin: String, id: String): String = try {
+        origin.toHttpUrl().newBuilder()
+            .addPathSegments("api/v1/video")
+            .addQueryParameter("id", id)
+            .addQueryParameter("w", "1920")
+            .addQueryParameter("h", "1080")
+            .addQueryParameter("r", "anime-sama.to")
+            .build().toString()
+    } catch (_: Exception) {
+        "$origin/api/v1/video?id=$id&w=1920&h=1080&r=anime-sama.to"
+    }
+
+    private fun decryptIfNeeded(raw: String): String? {
+        val trimmed = raw.trim().removeSurrounding("\"")
+        // Already JSON
+        if (trimmed.startsWith("{")) return trimmed
+        // Hex-encoded AES
+        return try {
+            if (trimmed.matches(Regex("^[0-9a-fA-F]+$")) && trimmed.length % 2 == 0) {
+                decryptHex(trimmed)
+            } else {
+                // Try to parse as JSON containing hex field
+                val element = try {
+                    json.parseToJsonElement(trimmed)
+                } catch (_: Exception) {
+                    null
+                }
+                val obj = element as? JsonObject
+                val hexField = obj?.get("data")?.jsonPrimitive?.contentOrNull
+                    ?: obj?.get("payload")?.jsonPrimitive?.contentOrNull
+                    ?: obj?.get("result")?.jsonPrimitive?.contentOrNull
+                if (!hexField.isNullOrBlank() && hexField.matches(Regex("^[0-9a-fA-F]+$"))) {
+                    decryptHex(hexField)
+                } else {
+                    null
+                }
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun decryptHex(hex: String): String {
+        val encrypted = hex.decodeHex()
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        val keySpec = SecretKeySpec(KEY.toByteArray(Charsets.UTF_8), "AES")
+        val ivSpec = IvParameterSpec(IV.toByteArray(Charsets.UTF_8))
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec)
+        return String(cipher.doFinal(encrypted), Charsets.UTF_8)
+    }
+
+    private fun buildCandidates(jsonStr: String, embedOrigin: String): List<String>? {
+        val root = try {
+            json.parseToJsonElement(jsonStr).jsonObject
+        } catch (_: Exception) {
+            return null
+        }
+
+        val streamingConfig = root["streamingConfig"]?.jsonObject
+        val order = streamingConfig?.get("order")?.jsonArray
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+            ?: emptyList()
+
+        val adjustMap = streamingConfig?.get("adjust")?.jsonObject
+            ?.mapValues { (_, v) ->
+                val obj = v.jsonObject
+                Adjust(
+                    disabled = obj["disabled"]?.jsonPrimitive?.booleanOrNull ?: false,
+                    domain = obj["domain"]?.jsonPrimitive?.contentOrNull,
+                    params = obj["params"]?.jsonObject
+                        ?.mapValues { it.value.jsonPrimitive.contentOrNull ?: "" }
+                        ?.filterValues { it.isNotEmpty() }
+                        ?: emptyMap(),
+                )
+            } ?: emptyMap()
+
+        val pkObj = root["pk"]?.jsonObject
+            ?: root["PK"]?.jsonObject
+        val pk = pkObj?.let {
+            Pk(
+                k = it["k"]?.jsonPrimitive?.contentOrNull,
+                kx = it["kx"]?.jsonPrimitive?.contentOrNull,
+            )
+        }
+
+        // Source fields
+        val sourceKeys = listOf("cf", "cfNative", "hlsVideoTiktok", "hlsVideoGoogle", "source")
+        val sourceMap = sourceKeys.mapNotNull { key ->
+            val value = root[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            if (value != null) key to value else null
+        }.toMap()
+
+        val namesInOrder = if (order.isNotEmpty()) order else sourceMap.keys.toList()
+        if (namesInOrder.isEmpty() && sourceMap.isEmpty()) {
+            // Fallback: any string value that looks like http
+            val fallback = root.entries.mapNotNull { (k, v) ->
+                val s = v.jsonPrimitive.contentOrNull ?: return@mapNotNull null
+                if (s.startsWith("http") && ("/hls/" in s || ".m3u8" in s || "/v4/" in s)) k to s else null
+            }.toMap()
+            if (fallback.isEmpty()) return emptyList()
+            return buildUrlsFromMap(fallback, adjustMap, pk, embedOrigin, fallback.keys.toList())
+        }
+
+        return buildUrlsFromMap(sourceMap, adjustMap, pk, embedOrigin, namesInOrder)
+    }
+
+    private fun buildUrlsFromMap(
+        sourceMap: Map<String, String>,
+        adjustMap: Map<String, Adjust>,
+        pk: Pk?,
+        embedOrigin: String,
+        order: List<String>,
+    ): List<String> {
+        val result = mutableListOf<String>()
+        for (name in order) {
+            val rawUrl = sourceMap[name] ?: continue
+            if (rawUrl.isBlank()) continue
+            val adj = adjustMap[name]
+            if (adj?.disabled == true) continue
+
+            var url = rawUrl
+
+            // Apply params
+            if (adj != null && adj.params.isNotEmpty()) {
+                url = appendParams(url, adj.params)
+            }
+
+            // Rewrite /hls/ -> /hlsmod/<domain>/
+            if (adj?.domain != null && "/hls/" in url) {
+                url = url.replace("/hls/", "/hlsmod/${adj.domain}/")
+            }
+
+            // Resolve against embed origin if relative
+            if (!url.startsWith("http")) {
+                url = UrlUtils.fixUrl(url, embedOrigin) ?: "$embedOrigin/$url".replace("//", "/").let {
+                    // ensure scheme preserved
+                    if (embedOrigin.startsWith("https")) it.replace("http:/", "https://") else it
+                }
+            } else {
+                // If URL is already absolute but contains /hls/ rewritten, ensure still resolved
+                // No-op
+            }
+
+            // Append pk token for /v4/
+            if ("/v4/" in url && pk != null && !pk.k.isNullOrBlank() && !pk.kx.isNullOrBlank()) {
+                url = appendParams(url, mapOf("k" to pk.k!!, "kx" to pk.kx!!))
+            }
+
+            // Fix url via UrlUtils for consistency
+            val fixed = UrlUtils.fixUrl(url, embedOrigin) ?: url
+            result.add(fixed)
+        }
+        return result.distinct()
+    }
+
+    private fun appendParams(url: String, params: Map<String, String>): String {
+        if (params.isEmpty()) return url
+        return try {
+            val httpUrl = url.toHttpUrlOrNull()
+            if (httpUrl != null) {
+                val builder = httpUrl.newBuilder()
+                params.forEach { (k, v) -> builder.addQueryParameter(k, v) }
+                builder.build().toString()
+            } else {
+                val sep = if ("?" in url) "&" else "?"
+                url + sep + params.entries.joinToString("&") { "${it.key}=${it.value}" }
+            }
+        } catch (_: Exception) {
+            val sep = if ("?" in url) "&" else "?"
+            url + sep + params.entries.joinToString("&") { "${it.key}=${it.value}" }
+        }
+    }
+
+    private data class Adjust(
+        val disabled: Boolean = false,
+        val domain: String? = null,
+        val params: Map<String, String> = emptyMap(),
+    )
+
+    private data class Pk(
+        val k: String? = null,
+        val kx: String? = null,
+    )
+
+    companion object {
+        private const val DEFAULT_ORIGIN = "https://lpayer.embed4me.com"
+        private const val KEY = "kiemtienmua911ca"
+        private const val IV = "1234567890oiuytr"
+    }
+}

--- a/lib/uqloadextractor/build.gradle.kts
+++ b/lib/uqloadextractor/build.gradle.kts
@@ -3,5 +3,6 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":lib:playlistutils"))
     implementation(project(":lib:unpacker"))
 }

--- a/lib/uqloadextractor/build.gradle.kts
+++ b/lib/uqloadextractor/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     alias(kei.plugins.library)
 }
+
+dependencies {
+    implementation(project(":lib:unpacker"))
+}

--- a/lib/uqloadextractor/src/aniyomi/lib/uqloadextractor/UqloadExtractor.kt
+++ b/lib/uqloadextractor/src/aniyomi/lib/uqloadextractor/UqloadExtractor.kt
@@ -1,5 +1,6 @@
 package aniyomi.lib.uqloadextractor
 
+import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
@@ -10,6 +11,8 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 
 class UqloadExtractor(private val client: OkHttpClient) {
+
+    private val playlistUtils by lazy { PlaylistUtils(client) }
 
     companion object {
         const val BASE_URL = "https://uqload.is/"
@@ -31,7 +34,7 @@ class UqloadExtractor(private val client: OkHttpClient) {
                 .takeIf(String::isNotBlank)
                 ?.takeIf { it.startsWith("http") }
             if (videoUrl != null) {
-                return listOf(Video(videoUrl, quality, videoUrl, videoHeaders))
+                return videosFromSource(videoUrl, quality, fixedUrl, videoHeaders)
             }
         }
 
@@ -41,14 +44,40 @@ class UqloadExtractor(private val client: OkHttpClient) {
             ?.let(::autoUnpacker)
             ?: return emptyList()
 
-        return packedSourceRegex.findAll(packed).mapNotNull { match ->
+        val sources = packedSourceRegex.findAll(packed).mapNotNull { match ->
             val link = match.groupValues[1]
-            val videoUrl = when {
+            when {
                 link.startsWith("http") -> link
                 link.startsWith("//") -> "https:$link"
                 else -> BASE_URL.dropLast(1) + link
-            }.takeIf { it.toHttpUrlOrNull() != null } ?: return@mapNotNull null
-            Video(videoUrl, quality, videoUrl, videoHeaders)
-        }.distinctBy { it.url }.toList()
+            }.takeIf { it.toHttpUrlOrNull() != null }
+        }.distinct().toList()
+
+        return sources.flatMap { videosFromSource(it, quality, fixedUrl, videoHeaders) }
+            .distinctBy { it.url }
+    }
+
+    /**
+     * Multi-quality streams are served as a single `_,l,n,h,.urlset/master.m3u8` playlist, so the
+     * variants have to be extracted to expose anything more than one unlabelled entry. Falls back
+     * to the master playlist itself when it cannot be read.
+     */
+    private fun videosFromSource(
+        videoUrl: String,
+        quality: String,
+        referer: String,
+        videoHeaders: Headers,
+    ): List<Video> {
+        if (!videoUrl.contains(".m3u8")) {
+            return listOf(Video(videoUrl, quality, videoUrl, videoHeaders))
+        }
+
+        return playlistUtils.extractFromHls(
+            videoUrl,
+            referer = referer,
+            // A single-stream playlist has no resolution to report and is named "Video";
+            // keep the plain label there so those entries read as they did before.
+            videoNameGen = { variant -> if (variant == "Video") quality else "$quality - $variant" },
+        ).ifEmpty { listOf(Video(videoUrl, quality, videoUrl, videoHeaders)) }
     }
 }

--- a/lib/uqloadextractor/src/aniyomi/lib/uqloadextractor/UqloadExtractor.kt
+++ b/lib/uqloadextractor/src/aniyomi/lib/uqloadextractor/UqloadExtractor.kt
@@ -45,6 +45,7 @@ class UqloadExtractor(private val client: OkHttpClient) {
             val link = match.groupValues[1]
             val videoUrl = when {
                 link.startsWith("http") -> link
+                link.startsWith("//") -> "https:$link"
                 else -> BASE_URL.dropLast(1) + link
             }.takeIf { it.toHttpUrlOrNull() != null } ?: return@mapNotNull null
             Video(videoUrl, quality, videoUrl, videoHeaders)

--- a/lib/uqloadextractor/src/aniyomi/lib/uqloadextractor/UqloadExtractor.kt
+++ b/lib/uqloadextractor/src/aniyomi/lib/uqloadextractor/UqloadExtractor.kt
@@ -3,8 +3,10 @@ package aniyomi.lib.uqloadextractor
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
+import keiyoushi.lib.autoUnpacker
 import keiyoushi.utils.useAsJsoup
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 
 class UqloadExtractor(private val client: OkHttpClient) {
@@ -13,22 +15,39 @@ class UqloadExtractor(private val client: OkHttpClient) {
         const val BASE_URL = "https://uqload.is/"
 
         private val hostRegex by lazy { Regex("""https?://(?:www\.)?[^/]+/""") }
+        private val packedSourceRegex by lazy { Regex(""""((?:https?:/)?/[^"]*(?:\.m3u8|\.mp4)[^"]*)"""") }
     }
 
     suspend fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
         val fixedUrl = if (url.startsWith(BASE_URL, true)) url else url.replace(hostRegex, BASE_URL)
         val doc = client.newCall(GET(fixedUrl)).awaitSuccess().useAsJsoup()
-        val script = doc.selectFirst("script:containsData(sources:)")?.data()
-            ?: return emptyList()
 
-        val videoUrl = script.substringAfter("sources: [\"").substringBefore('"')
-            .takeIf(String::isNotBlank)
-            ?.takeIf { it.startsWith("http") }
-            ?: return emptyList()
-
-        val videoHeaders = Headers.headersOf("Referer", BASE_URL)
         val quality = if (prefix.isNotBlank()) "${prefix.trim()} Uqload" else "Uqload"
+        val videoHeaders = Headers.headersOf("Referer", fixedUrl)
 
-        return listOf(Video(videoUrl, quality, videoUrl, videoHeaders))
+        val script = doc.selectFirst("script:containsData(sources:)")?.data()
+        if (script != null) {
+            val videoUrl = script.substringAfter("sources: [\"").substringBefore('"')
+                .takeIf(String::isNotBlank)
+                ?.takeIf { it.startsWith("http") }
+            if (videoUrl != null) {
+                return listOf(Video(videoUrl, quality, videoUrl, videoHeaders))
+            }
+        }
+
+        val packed = doc.select("script")
+            .find { it.html().contains("eval(function(p,a,c,k,e,d)") }
+            ?.html()
+            ?.let(::autoUnpacker)
+            ?: return emptyList()
+
+        return packedSourceRegex.findAll(packed).mapNotNull { match ->
+            val link = match.groupValues[1]
+            val videoUrl = when {
+                link.startsWith("http") -> link
+                else -> BASE_URL.dropLast(1) + link
+            }.takeIf { it.toHttpUrlOrNull() != null } ?: return@mapNotNull null
+            Video(videoUrl, quality, videoUrl, videoHeaders)
+        }.distinctBy { it.url }.toList()
     }
 }

--- a/src/fr/animesama/build.gradle
+++ b/src/fr/animesama/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime-Sama'
     extClass = '.AnimeSama'
-    extVersionCode = 29
+    extVersionCode = 30
 }
 
 apply plugin: "kei.plugins.extension.legacy"
@@ -11,4 +11,9 @@ dependencies {
     implementation(project(':lib:vkextractor'))
     implementation(project(':lib:sendvidextractor'))
     implementation(project(':lib:vidmolyextractor'))
+    implementation(project(':lib:vidhideextractor'))
+    implementation(project(':lib:uqloadextractor'))
+    implementation(project(':lib:youruploadextractor'))
+    implementation(project(':lib:universalextractor'))
+    implementation(project(':lib:embed4meextractor'))
 }

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -218,7 +218,7 @@ class AnimeSama :
             // Guard against empty voice name (should not happen after filter, but fallback)
             val safePrefix = if (prefix.trim() == "()") "" else prefix
             list.filter { it.isNotEmpty() }.map { it to safePrefix }
-        }.filter { it.second.isNotEmpty() || voiceNames.isEmpty() }
+        }
         if (allPairs.isEmpty()) return emptyList()
 
         // Partition known hosts (parallel) vs fallback (sequential WebView)
@@ -234,8 +234,9 @@ class AnimeSama :
                 url.contains("embed4me")
         }
 
-        val knownVideos = knownPairs.parallelCatchingFlatMap { (playerUrl, prefix) ->
-            with(playerUrl) {
+        val knownResults = knownPairs.parallelCatchingFlatMap { pair ->
+            val (playerUrl, prefix) = pair
+            val vids = with(playerUrl) {
                 when {
                     contains("sibnet.ru") -> sibnetExtractor.videosFromUrl(playerUrl, prefix)
 
@@ -253,30 +254,24 @@ class AnimeSama :
 
                     contains(".mp4") -> listOf(Video(playerUrl, "$prefix Direct", playerUrl, headers))
 
-                    contains("embed4me") -> {
-                        val vids = try {
-                            embed4MeExtractor.videosFromUrl(playerUrl, prefix)
-                        } catch (_: Exception) {
-                            emptyList()
-                        }
-                        if (vids.isNotEmpty()) {
-                            vids
-                        } else {
-                            try {
-                                universalExtractor.videosFromUrl(playerUrl, headers, prefix = prefix.trim())
-                            } catch (_: Exception) {
-                                emptyList()
-                            }
-                        }
+                    contains("embed4me") -> try {
+                        embed4MeExtractor.videosFromUrl(playerUrl, prefix)
+                    } catch (_: Exception) {
+                        emptyList()
                     }
 
                     else -> emptyList()
                 }
             }
+            listOf(pair to vids)
         }
+        val knownVideos = knownResults.flatMap { (_, vids) -> vids }
 
         // UniversalExtractor uses WebView on main looper with CountDownLatch — must be sequential
-        val fallbackVideos = unknownPairs.flatMap { (playerUrl, prefix) ->
+        val fallbackPairs = unknownPairs + knownResults.mapNotNull { (pair, vids) ->
+            if (vids.isEmpty()) pair else null
+        }
+        val fallbackVideos = fallbackPairs.flatMap { (playerUrl, prefix) ->
             try {
                 universalExtractor.videosFromUrl(playerUrl, headers, prefix = prefix.trim())
             } catch (_: Exception) {

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -5,10 +5,15 @@ import android.webkit.URLUtil
 import android.widget.Toast
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
+import aniyomi.lib.embed4meextractor.Embed4MeExtractor
 import aniyomi.lib.sendvidextractor.SendvidExtractor
 import aniyomi.lib.sibnetextractor.SibnetExtractor
+import aniyomi.lib.universalextractor.UniversalExtractor
+import aniyomi.lib.uqloadextractor.UqloadExtractor
+import aniyomi.lib.vidhideextractor.VidHideExtractor
 import aniyomi.lib.vidmolyextractor.VidMolyExtractor
 import aniyomi.lib.vkextractor.VkExtractor
+import aniyomi.lib.youruploadextractor.YourUploadExtractor
 import app.cash.quickjs.QuickJs
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -195,29 +200,91 @@ class AnimeSama :
     private val vkExtractor by lazy { VkExtractor(client, headers) }
     private val sendvidExtractor by lazy { SendvidExtractor(client, headers) }
     private val vidmolyExtractor by lazy { VidMolyExtractor(client, headers) }
+    private val vidHideExtractor by lazy { VidHideExtractor(client, headers) }
+    private val uqloadExtractor by lazy { UqloadExtractor(client) }
+    private val yourUploadExtractor by lazy { YourUploadExtractor(client) }
+    private val embed4MeExtractor by lazy { Embed4MeExtractor(client, headers) }
+    private val universalExtractor by lazy { UniversalExtractor(client) }
 
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
         val playerUrls = episode.url.parseAs<List<List<String>>>()
         val voiceNames = episode.scanlator?.split(", ") ?: emptyList()
-        val videos = playerUrls.filter { it.isNotEmpty() }.flatMapIndexed { i, it ->
+
+        // Filter empty voice groups first to keep voice index aligned with scanlator
+        // (playersToEpisodes stores outer=voice, scanlator skips empty voices)
+        val filteredPlayerUrls = playerUrls.filter { it.isNotEmpty() }
+        val allPairs = filteredPlayerUrls.flatMapIndexed { i, list ->
             val prefix = "(${voiceNames.getOrElse(i) { "" }}) "
-            it.parallelCatchingFlatMap { playerUrl ->
-                with(playerUrl) {
-                    when {
-                        contains("sibnet.ru") -> sibnetExtractor.videosFromUrl(playerUrl, prefix)
+            // Guard against empty voice name (should not happen after filter, but fallback)
+            val safePrefix = if (prefix.trim() == "()") "" else prefix
+            list.filter { it.isNotEmpty() }.map { it to safePrefix }
+        }.filter { it.second.isNotEmpty() || voiceNames.isEmpty() }
+        if (allPairs.isEmpty()) return emptyList()
 
-                        contains("vk.") -> vkExtractor.videosFromUrl(playerUrl, prefix)
+        // Partition known hosts (parallel) vs fallback (sequential WebView)
+        val (knownPairs, unknownPairs) = allPairs.partition { (url, _) ->
+            url.contains("sibnet.ru") ||
+                url.contains("vidmoly") || url.contains("ansembed") ||
+                url.contains("vk.") || url.contains("vkvideo") ||
+                url.contains("sendvid.com") ||
+                VIDHIDE_DOMAINS.any { url.contains(it, ignoreCase = true) } ||
+                url.contains("uqload") ||
+                url.contains("yourupload") ||
+                url.contains(".mp4") ||
+                url.contains("embed4me")
+        }
 
-                        contains("sendvid.com") -> sendvidExtractor.videosFromUrl(playerUrl, prefix)
+        val knownVideos = knownPairs.parallelCatchingFlatMap { (playerUrl, prefix) ->
+            with(playerUrl) {
+                when {
+                    contains("sibnet.ru") -> sibnetExtractor.videosFromUrl(playerUrl, prefix)
 
-                        contains("vidmoly") -> vidmolyExtractor.videosFromUrl(playerUrl, prefix.trim())
+                    contains("vk.") || contains("vkvideo") -> vkExtractor.videosFromUrl(playerUrl, prefix)
 
-                        else -> emptyList()
+                    contains("sendvid.com") -> sendvidExtractor.videosFromUrl(playerUrl, prefix)
+
+                    contains("vidmoly") || contains("ansembed") -> vidmolyExtractor.videosFromUrl(playerUrl, prefix.trim())
+
+                    VIDHIDE_DOMAINS.any { contains(it, ignoreCase = true) } -> vidHideExtractor.videosFromUrl(playerUrl, videoNameGen = { quality -> "${prefix.trim()} VidHide - $quality" })
+
+                    contains("uqload") -> uqloadExtractor.videosFromUrl(playerUrl, prefix)
+
+                    contains("yourupload") -> yourUploadExtractor.videoFromUrl(playerUrl, headers, prefix = prefix)
+
+                    contains(".mp4") -> listOf(Video(playerUrl, "$prefix Direct", playerUrl, headers))
+
+                    contains("embed4me") -> {
+                        val vids = try {
+                            embed4MeExtractor.videosFromUrl(playerUrl, prefix)
+                        } catch (_: Exception) {
+                            emptyList()
+                        }
+                        if (vids.isNotEmpty()) {
+                            vids
+                        } else {
+                            try {
+                                universalExtractor.videosFromUrl(playerUrl, headers, prefix = prefix.trim())
+                            } catch (_: Exception) {
+                                emptyList()
+                            }
+                        }
                     }
+
+                    else -> emptyList()
                 }
             }
-        }.sort()
-        return videos
+        }
+
+        // UniversalExtractor uses WebView on main looper with CountDownLatch — must be sequential
+        val fallbackVideos = unknownPairs.flatMap { (playerUrl, prefix) ->
+            try {
+                universalExtractor.videosFromUrl(playerUrl, headers, prefix = prefix.trim())
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+
+        return (knownVideos + fallbackVideos).sort()
     }
 
     // ============================ Utils =============================
@@ -434,9 +501,18 @@ class AnimeSama :
             "Sibnet" to "sibnet",
             "VK" to "vk",
             "VidMoly" to "vidmoly",
+            "VidHide" to "vidhide",
+            "Uqload" to "uqload",
+            "YourUpload" to "yourupload",
+            "Myvi" to "myvi",
+            "Oneupload" to "oneupload",
+            "Direct" to "direct",
+            "Embed4Me" to "embed4me",
         )
         private val PLAYERS = playersMap.keys.toTypedArray()
         private val PLAYERS_VALUES = playersMap.values.toTypedArray()
+
+        private val VIDHIDE_DOMAINS = listOf("smoothpre", "movearnpre", "minochinos", "morencius")
 
         private const val PREF_VOICES_KEY = "voices_preference"
         private const val PREF_VOICES_DEFAULT = "vostfr"

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -270,11 +270,16 @@ class AnimeSama :
                     else -> emptyList()
                 }
             }
-            // One embed can expose the same stream through several urls: VidHide pages ship
-            // both a cdn master.m3u8 and a proxied /stream/ one, which shows up as duplicated
-            // entries with an identical label. Labels carry the quality, so this only drops
-            // same-label mirrors of one player, never a distinct quality.
-            listOf(pair to vids.distinctBy { it.quality })
+            // VidHide pages ship the same stream twice, as a cdn master.m3u8 and as a proxied
+            // /stream/ one, which shows up as duplicated entries with an identical label that
+            // the url-aware dedupe below cannot collapse. Restricted to those hosts: other
+            // players can return distinct files under one label, and must not lose them.
+            val dedupedVids = if (VIDHIDE_DOMAINS.any { playerUrl.contains(it, ignoreCase = true) }) {
+                vids.distinctBy { it.quality }
+            } else {
+                vids
+            }
+            listOf(pair to dedupedVids)
         }
         val knownVideos = knownResults.flatMap { (_, vids) -> vids }
 

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -279,7 +279,9 @@ class AnimeSama :
             }
         }
 
-        return (knownVideos + fallbackVideos).distinctBy { it.quality }.sort()
+        return (knownVideos + fallbackVideos)
+            .distinctBy { it.quality to it.url.substringBefore("?") }
+            .sort()
     }
 
     // ============================ Utils =============================

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -37,6 +37,7 @@ import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonString
 import keiyoushi.utils.useAsJsoup
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -69,15 +70,21 @@ class AnimeSama :
                 val newUrl = response.header("Location") ?: break
                 val newUrlHttp = request.url.resolve(newUrl) ?: break
                 val redirectedDomain = newUrlHttp.run { "$scheme://$host" }
-                if (redirectedDomain != baseUrl) {
+                // This client is shared with the video extractors, and hosts like uqload.is
+                // permanently redirect to another domain. Only a redirect on the source's own
+                // domain is a domain migration; anything else must not touch baseUrl/headers.
+                val isSourceDomain = request.url.host == baseUrl.toHttpUrlOrNull()?.host
+                if (isSourceDomain && redirectedDomain != baseUrl) {
                     updateDomain(redirectedDomain)
                 }
                 response.close()
                 request = request.newBuilder()
                     .url(newUrlHttp)
                     .apply {
-                        header("Origin", redirectedDomain)
-                        header("Referer", "$redirectedDomain/")
+                        if (isSourceDomain) {
+                            header("Origin", redirectedDomain)
+                            header("Referer", "$redirectedDomain/")
+                        }
                     }
                     .build()
                 response = chain.proceed(request)
@@ -263,7 +270,11 @@ class AnimeSama :
                     else -> emptyList()
                 }
             }
-            listOf(pair to vids)
+            // One embed can expose the same stream through several urls: VidHide pages ship
+            // both a cdn master.m3u8 and a proxied /stream/ one, which shows up as duplicated
+            // entries with an identical label. Labels carry the quality, so this only drops
+            // same-label mirrors of one player, never a distinct quality.
+            listOf(pair to vids.distinctBy { it.quality })
         }
         val knownVideos = knownResults.flatMap { (_, vids) -> vids }
 

--- a/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
+++ b/src/fr/animesama/src/eu/kanade/tachiyomi/animeextension/fr/animesama/AnimeSama.kt
@@ -218,7 +218,7 @@ class AnimeSama :
             // Guard against empty voice name (should not happen after filter, but fallback)
             val safePrefix = if (prefix.trim() == "()") "" else prefix
             list.filter { it.isNotEmpty() }.map { it to safePrefix }
-        }
+        }.distinctBy { it.first }
         if (allPairs.isEmpty()) return emptyList()
 
         // Partition known hosts (parallel) vs fallback (sequential WebView)
@@ -279,7 +279,7 @@ class AnimeSama :
             }
         }
 
-        return (knownVideos + fallbackVideos).sort()
+        return (knownVideos + fallbackVideos).distinctBy { it.quality }.sort()
     }
 
     // ============================ Utils =============================


### PR DESCRIPTION
## Summary

`getVideoList` dispatched player URLs through a `when` chain recognising only sibnet, vk, sendvid and vidmoly, returning `emptyList()` for everything else. Anime-Sama has since moved most of its catalogue onto hosts the extension had never heard of, so users saw a single server (or none) where the site offers several. A survey of 169 season folders found 2922 `ansembed.net` links (VidMoly mirror), 1717 `lpayer.embed4me.com` links (new Lecteur 1 SPA), 807 `myvi.*`, 249 VidHide clones, 121 uqload and more — all dropped on the floor.

### What changed

**Stage 1 — wire up known hosts** (`src/fr/animesama/.../AnimeSama.kt`, `build.gradle`):

- `contains("ansembed")` joins the vidmoly branch — `VidMolyExtractor` rewrites any host to its own `BASE_URL`, so the mirror needs no other handling
- `contains("vkvideo")` joins the `vk.` branch — `VkExtractor` rebuilds URLs against its internal `VK_URL`
- New branch for the VidHide clones (`smoothpre`, `movearnpre`, `minochinos`, `morencius`) → `VidHideExtractor(client, headers)`, which fetches embeds as-is with no host rewriting
- New `uqload` branch → `UqloadExtractor(client)` (rewrites any host to `uqload.is`)
- New `yourupload` branch → `YourUploadExtractor.videoFromUrl(url, headers)`
- New `.mp4` branch → direct `Video` with source headers
- `else -> emptyList()` replaced by `UniversalExtractor`, as in ~30 other extensions — covers `myvi.*` / `oneupload.to` without new libs and makes any future host swap survivable
- `playersMap` extended so every new server is selectable in "Lecteur par défaut" (the sort ranks by `quality.contains(player)`)

**Stage 2 — new `lib/embed4meextractor` for Lecteur 1** (`lpayer.embed4me.com`), reverse-engineered from the site's obfuscated bundle:

1. Video id is the URL fragment, truncated at `&`
2. `GET /api/v1/video?id=<id>&w=&h=&r=` returns hex-encoded AES-128-CBC; key `kiemtienmua911ca` / IV `1234567890oiuytr` are both derived from `location.protocol` alone (verified by reproducing the bundle's derivation functions exactly — they decode to these strings for `https:`)
3. Decrypted JSON carries `streamingConfig` (`order`, `adjust{disabled,domain,params}`) plus sources (`cf`, `cfNative`, `hlsVideoTiktok`, `hlsVideoGoogle`, `source`). Candidates are built in `order`, skipping disabled entries, appending `params`, rewriting `/hls/` → `/hlsmod/<adjust.domain>/`, resolved against the embed origin
4. `pk{k,kx}` from the response is appended to `/v4/` segment URLs
5. On any failure the extension falls back to `UniversalExtractor`, which runs the page's own JS in a WebView

**Stage 3 — correctness/perf fixes found while wiring this up:**

- Fixed voice-prefix misalignment producing `() ...` labels: `episode.url` keeps one slot per voice while `scanlator` skips empty ones, so indexing scanlator names against the raw list was off after the first empty voice; empty groups are now filtered before zipping
- Known extractors run in parallel but `UniversalExtractor` is now called **sequentially**: it blocks on a `CountDownLatch` for up to 10s and drives a WebView pinned to the main looper, which is not safe under `parallelCatchingFlatMap` (see the warning in `PelisPlus.kt`); the embed4me branch also degrades to a single sequential universal attempt rather than fanning out

### Verification

- `./gradlew :src:fr:animesama:assembleDebug` passes (spotless runs via `preBuild`); APK `aniyomi-fr.animesama-v14.30-debug.apk`
- Host survey re-run against the final `when` chain: ansembed→VidMoly, vkvideo→VK, all four VidHide clones, uqload, yourupload, direct mp4, myvi/oneupload via universal — no unintentional fallback
- embed4me flow proven end-to-end off-device: live API payloads decrypt to clean JSON (Among Us S1 returns `hlsVideoTiktok` + `streamingConfig`; Wistoria S1 VA likewise)
- Note: some embed4me videos are rotted upstream — the API itself hands out expired CDN signatures (`v=...` static since Dec 2025; Akamai answers `failure-expired`) or `Video not found or deleted` (Wistoria S2 `8egfe`). For those titles the player's own code aborts with "Video is not ready yet" too; nothing client-side can fix that subset

### Test plan (on device)

| Server | Series / season | Expect |
| --- | --- | --- |
| ansembed → VidMoly | Monster → Kai (VOSTFR), Lecteur 2 | plays, labelled VidMoly |
| VidHide (minochinos) | Ascendance of a Bookworm → Saison 2 | plays |
| VidHide (Smoothpre) | Ao Ashi → Saison 1 | plays |
| VidHide (movearnpre) | Akira → Film | plays |
| VidHide (morencius) | Bleach → Saison 2-4 | plays |
| uqload | Azur Lane → Saison 2 HS | plays |
| oneupload (via fallback) | Bleach → Saison 2 | plays, may take ~10s |
| myvi (via fallback) | Ascendance of a Bookworm → OAV | plays, may take ~10s |
| direct mp4 | Ao Ashi → Saison 1 | plays |
| vkvideo.ru | Fairy Tail → Saison 1 HS | plays |
| yourupload | Dungeon Meshi → Saison 1 | plays |
| embed4me (Lecteur 1) | Among Us → Saison 1; Monster → Kai | plays where CDN token still valid |
| negative control: sibnet | Monster → Saison 1 | still plays |
| negative control: prefs | Settings → "Lecteur par défaut" | new servers listed and honoured |

extVersionCode bumped 29 → 30.

Fixes #739

## Summary by Sourcery

Restore Anime-Sama's missing video-server coverage and make stream extraction resilient to future host changes.

New Features:
- Restore playback support for Anime-Sama video servers including VidHide variants, Uqload, YourUpload, direct MP4, VKVideo, and additional VidMoly mirrors.
- Add Embed4Me extraction for Lecteur 1 streams, including playlist source discovery and fallback handling.

Bug Fixes:
- Preserve voice-name alignment when episodes contain empty voice groups.
- Prevent video-host redirects from incorrectly changing Anime-Sama's source domain and request headers.
- Add fallback extraction for previously unsupported hosts such as Myvi and Oneupload.

Enhancements:
- Improve Uqload extraction by supporting packed pages and exposing available HLS quality variants.
- Run WebView-based universal extraction sequentially to avoid unsafe concurrent execution.
- Expose the newly supported servers in the default-player preferences and deduplicate duplicate stream results.

Build:
- Add the Embed4Me extractor library and wire new extractor dependencies into Anime-Sama.
- Bump the Anime-Sama extension version from 29 to 30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Embed4Me, VidHide, Uqload, and YourUpload videos.
  - Added universal fallback handling for unsupported video hosts.
  - Added support for direct MP4 links and HLS playlists.
  - Added provider and direct/embed playback options in Anime-Sama preferences.

- **Improvements**
  - Improved playback reliability with validation, retries, and fallback extraction.
  - Preserved voice and language labels while removing duplicate sources.
  - Improved resolution of relative and embedded video links.
  - Organized results by quality for easier playback selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->