### PR TITLE
MKissa [EN]: Fix stream crypto after site rebuild

### DIFF
--- a/src/en/mkissa/build.gradle
+++ b/src/en/mkissa/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MKissa'
     extClass = '.MKissa'
-    extVersionCode = 64
+    extVersionCode = 65
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
@@ -245,7 +245,10 @@ object MKissaBundle {
         return null
     }
 
-    /** Folds the `2935+-1459*2` arithmetic every integer is hidden behind; signs stack. */
+    /** Folds the `2935+-1459*2` arithmetic every integer is hidden behind; signs stack.
+     *  2025-09: the obfuscator started emitting negative factors (`2461*-4`), which the old
+     *  term scan split mid-product and misread as additions, zeroing every decoder offset.
+     */
     private fun fold(expression: String): Int {
         var total = 0
         for (term in TERM_REGEX.findAll(expression.replace(" ", "")).map(MatchResult::value)) {
@@ -283,6 +286,7 @@ object MKissaBundle {
 
     private val SEED_REGEX = Regex("""[A-Za-z0-9+/]{11}=""")
 
-    // Leading signs matched greedily; `fold` counts them.
-    private val TERM_REGEX = Regex("""[-+]*[^-+]+""")
+    // Leading signs matched greedily; `fold` counts them. Factors may be negative, so the
+    // product is kept inside one term (`2461*-4`) instead of splitting at every sign.
+    private val TERM_REGEX = Regex("""[-+]*\d+(?:\*[-+]*\d+)*""")
 }

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
@@ -258,20 +258,29 @@ object MKissaBundle {
                 if (body.startsWith('-')) sign = -sign
                 body = body.substring(1)
             }
-            var value = 1
-            for (factor in body.split('*')) {
-                // Factors carry their own stacked signs ("2*--4"); parity decides the sign.
-                var factorSign = 1
-                var digits = factor
-                while (digits.startsWith('+') || digits.startsWith('-')) {
-                    if (digits.startsWith('-')) factorSign = -factorSign
-                    digits = digits.substring(1)
-                }
-                value *= factorSign * (digits.toIntOrNull() ?: return 0)
+
+            // The term sign folds into the first factor, so Int.MIN_VALUE survives parsing.
+            var value = parseFactor(sign, body.substringBefore('*')) ?: return 0
+            val rest = body.substringAfter('*', "")
+            if (rest.isNotEmpty()) {
+                for (factor in rest.split('*')) value *= parseFactor(1, factor) ?: return 0
             }
-            total += sign * value
+            total += value
         }
         return total
+    }
+
+    /** Signs stack before the digits; parity decides the sign ("2*--4"). */
+    private fun parseFactor(sign: Int, factor: String): Int? {
+        var negative = sign < 0
+        var digits = factor
+        while (digits.startsWith('+') || digits.startsWith('-')) {
+            if (digits.startsWith('-')) negative = !negative
+            digits = digits.substring(1)
+        }
+        val magnitude = digits.toLongOrNull() ?: return null
+        val signed = if (negative) -magnitude else magnitude
+        return if (signed in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) signed.toInt() else null
     }
 
     private val BUILD_ID_REGEX = Regex("""!==\s*["']string["']\s*\?\s*["'](\d+)["']\s*:\s*["']["']""")

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
@@ -259,7 +259,16 @@ object MKissaBundle {
                 body = body.substring(1)
             }
             var value = 1
-            for (factor in body.split('*')) value *= factor.toIntOrNull() ?: return 0
+            for (factor in body.split('*')) {
+                // Factors carry their own stacked signs ("2*--4"); parity decides the sign.
+                var factorSign = 1
+                var digits = factor
+                while (digits.startsWith('+') || digits.startsWith('-')) {
+                    if (digits.startsWith('-')) factorSign = -factorSign
+                    digits = digits.substring(1)
+                }
+                value *= factorSign * (digits.toIntOrNull() ?: return 0)
+            }
             total += sign * value
         }
         return total

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -44,13 +44,14 @@ object MKissaCrypto {
     private data class MaskParams(val saltMul: Int, val saltAdd: Int, val fragMul: Int, val fragAdd: Int)
 
     private val MASK_PARAMS = listOf(
+        MaskParams(250, 54, 16, 217),
         MaskParams(211, 222, 200, 176),
         MaskParams(17, 31, 41, 7),
     )
 
     /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild.
-     *  2025-08: site rotated salts from 17/31/41/7 to 211/222/200/176 (see kd={saltMul:211,...} in chunk).
-     *  Keep old constants as fallback for a brief grace window.
+     *  2025-09: site rotated salts from 211/222/200/176 to 250/54/16/217 (see Fd={saltMul:250,...} in chunk).
+     *  Keep older constants as fallback for a brief grace window.
      */
     fun maskCandidates(buildId: String, seeds: List<String>): List<ByteArray> {
         if (buildId.isEmpty() || seeds.size != SEED_COUNT) return emptyList()
@@ -92,10 +93,10 @@ object MKissaCrypto {
     }
 
     /** `x-aa-boot`, checked by the bootstrap endpoint before it hands out `partB`.
-     *  2025-08: site changed bootPrefix from "aa-boot:" to "kNk1YgwkSI:" and message
-     *  from "buildId:group:host:epoch:lane" (":"-joined, buildId first) to
-     *  "epoch.group.host.buildId.lane" ("."-joined, epoch first, see kd={join:".",parts:[epoch,group,host,buildId,lane]}).
-     *  We keep the legacy format as fallback for the brief window after a site rebuild.
+     *  2025-09: site changed bootPrefix from "kNk1YgwkSI:" to "4X2PsZc2r:" and message
+     *  from "epoch.group.host.buildId.lane" to "group.host.lane.buildId.epoch"
+     *  (see Fd={bootPrefix:"4X2PsZc2r:",join:".",parts:[group,host,lane,buildId,epoch]}).
+     *  We keep the previous formats as fallback for the brief window after a site rebuild.
      */
     fun bootTokenNew(
         mask: ByteArray,
@@ -105,9 +106,23 @@ object MKissaCrypto {
         refererHost: String,
         lane: String,
     ): String {
-        val inner = hmac(mask, "kNk1YgwkSI:$buildId")
-        // kd.parts = ["epoch","group","host","buildId","lane"], kd.join = "."
+        val inner = hmac(mask, "4X2PsZc2r:$buildId")
+        // kd.parts = ["group","host","lane","buildId","epoch"], kd.join = "."
         // omitEmptyLane = false, so always include lane even if empty
+        val message = listOf(keyGroup, refererHost, lane, buildId, epoch.toString()).joinToString(".")
+        return hmac(inner, message).toHex()
+    }
+
+    /** 2025-08 scheme, kept for the grace window after a rebuild. */
+    fun bootTokenPrevious(
+        mask: ByteArray,
+        buildId: String,
+        epoch: Long,
+        keyGroup: String,
+        refererHost: String,
+        lane: String,
+    ): String {
+        val inner = hmac(mask, "kNk1YgwkSI:$buildId")
         val message = listOf(epoch.toString(), keyGroup, refererHost, buildId, lane).joinToString(".")
         return hmac(inner, message).toHex()
     }
@@ -138,6 +153,7 @@ object MKissaCrypto {
         lane: String,
     ): List<String> = listOf(
         bootTokenNew(mask, buildId, epoch, keyGroup, refererHost, lane),
+        bootTokenPrevious(mask, buildId, epoch, keyGroup, refererHost, lane),
         bootTokenLegacy(mask, buildId, epoch, keyGroup, refererHost, lane),
     )
 


### PR DESCRIPTION
## Changes

MKissa rebuilt its site on Aug 23 and rotated the client-crypto material again, which made every stream request fail key bootstrap with `Unable to obtain MKissa crypto material`.

Three things changed in the obfuscated bundle:

1. **Salt rotation**: mask salts went from `211/222/200/176` to `250/54/16/217` (added first; older constants kept as grace-window fallbacks).
2. **Boot token**: prefix changed from `kNk1YgwkSI:` to `4X2PsZc2r:` and the message parts reordered from `epoch.group.host.buildId.lane` to `group.host.lane.buildId.epoch`. The Aug scheme is kept as a fallback candidate alongside the legacy one.
3. **Bundle parser**: the obfuscator now emits negative factors (`2461*-4`). The old term regex split mid-product, so `fold` misread products as additions and returned 0 for every decoder offset — buildId/seeds could not be recovered at all. The term regex now keeps a product inside one term.

Everything else (stream construction, XOR combine, epoch windows, aaReq wire format, response decrypt with legacy fallback) is byte-identical in the new chunk.

## Verification

Extracted ground truth by executing the live chunk's own decoder chain (table rotation included) and compared against this patch's code:

- `MKissaBundle.parse` on the live chunk recovers exactly `buildId=140` + the four current seeds
- derived mask is byte-identical to the site's (`522db8a0…7ce7`)
- boot token for fixed inputs matches the site's HMAC chain output

Release APK builds cleanly at v14.65.

Fixes #815

Checklist:
- [x] Updated `extVersionCode` value to 65
- [x] I have tested the changes locally

## Summary by Sourcery

Update MKissa stream cryptography handling to recover bundle values and bootstrap stream keys from the rebuilt site.

Bug Fixes:
- Restore MKissa stream crypto compatibility after the latest site rebuild by supporting rotated mask salts, the new boot-token format, and obfuscated arithmetic containing negative factors.

Enhancements:
- Retain previous crypto salts and boot-token schemes as fallback candidates during rebuild transition windows.

Build:
- Bump the MKissa extension version code to 65.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of obfuscated calculations, including negative multiplication values and invalid factors.
  * Added compatibility with the previous boot-token format to help maintain content access during the site’s transition.

* **Maintenance**
  * Updated support for the latest site rotation and refreshed related configuration.
  * Increased the MKissa extension version to 65.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->