### PR TITLE
Re:ANIME [EN]: Add Direct Download & Exclude Preferences

### DIFF
--- a/src/en/reanime/build.gradle
+++ b/src/en/reanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Re:ANIME'
     extClass = '.ReAnime'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = true
 }
 

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/FlixcloudProgress.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/FlixcloudProgress.kt
@@ -1,0 +1,42 @@
+package eu.kanade.tachiyomi.animeextension.en.reanime
+
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+private val PROGRESS_STATUS_REGEX = Regex(""""status":\s*"(\w+)"""")
+
+/**
+ * Reads a FlixCloud download-progress SSE stream until a terminal status
+ * arrives, the stream ends, or the request's timeouts fire. Never throws
+ * and never blocks indefinitely: the caller is expected to pass a client
+ * with hard read/call timeouts, since non-terminal streams stay open.
+ */
+internal fun flixcloudProgressIsReady(
+    client: OkHttpClient,
+    progressUrl: String,
+    headers: Headers,
+): Boolean {
+    return try {
+        client.newCall(Request.Builder().url(progressUrl).headers(headers).build())
+            .execute()
+            .use { res ->
+                if (!res.isSuccessful) return false
+
+                // The progress endpoint is an SSE stream that stays open after
+                // sending an update; read line-by-line instead of buffering it all.
+                val source = res.body.source()
+                while (true) {
+                    val line = source.readUtf8Line() ?: break
+                    when (PROGRESS_STATUS_REGEX.find(line)?.groupValues?.get(1)) {
+                        "ready" -> return true
+                        "failed" -> return false
+                    }
+                }
+                false
+            }
+    } catch (_: Exception) {
+        // Timeout or connection failure while the file was still building
+        false
+    }
+}

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -77,22 +77,22 @@ class ReAnime :
     private val preferredServer: String
         get() = preferences.getString(PREF_SERVER_KEY, PREF_SERVER_DEFAULT) ?: PREF_SERVER_DEFAULT
 
+    private val excludedServers: Set<String>
+        get() = preferences.getStringSet(PREF_SERVER_EXCLUDE_KEY, PREF_SERVER_EXCLUDE_DEFAULT)
+            ?: PREF_SERVER_EXCLUDE_DEFAULT
+
     private val preferredAudio: String
         get() = preferences.getString(PREF_AUDIO_KEY, PREF_AUDIO_DEFAULT) ?: PREF_AUDIO_DEFAULT
+
+    private val excludedAudioTypes: Set<String>
+        get() = preferences.getStringSet(PREF_AUDIO_EXCLUDE_KEY, PREF_AUDIO_EXCLUDE_DEFAULT)
+            ?: PREF_AUDIO_EXCLUDE_DEFAULT
 
     private val hideFiller: Boolean
         get() = preferences.getBoolean(PREF_HIDE_FILLER_KEY, PREF_HIDE_FILLER_DEFAULT)
 
     private val includeDirectDownloads: Boolean
         get() = preferences.getBoolean(PREF_DOWNLOAD_KEY, PREF_DOWNLOAD_DEFAULT)
-
-    private val excludedServers: Set<String>
-        get() = preferences.getStringSet(PREF_SERVER_EXCLUDE_KEY, PREF_SERVER_EXCLUDE_DEFAULT)
-            ?: PREF_SERVER_EXCLUDE_DEFAULT
-
-    private val excludedAudioTypes: Set<String>
-        get() = preferences.getStringSet(PREF_AUDIO_EXCLUDE_KEY, PREF_AUDIO_EXCLUDE_DEFAULT)
-            ?: PREF_AUDIO_EXCLUDE_DEFAULT
 
     private fun apiHeaders(referer: String = "$baseUrl/home"): Headers = headers.newBuilder()
         .add("Accept", "application/json, text/plain, */*")

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -43,6 +43,7 @@ import org.nanohttpd.protocols.http.NanoHTTPD
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone.getTimeZone
+import java.util.concurrent.TimeUnit
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.seconds
 
@@ -89,6 +90,10 @@ class ReAnime :
     private val excludedServers: Set<String>
         get() = preferences.getStringSet(PREF_SERVER_EXCLUDE_KEY, PREF_SERVER_EXCLUDE_DEFAULT)
             ?: PREF_SERVER_EXCLUDE_DEFAULT
+
+    private val excludedAudioTypes: Set<String>
+        get() = preferences.getStringSet(PREF_AUDIO_EXCLUDE_KEY, PREF_AUDIO_EXCLUDE_DEFAULT)
+            ?: PREF_AUDIO_EXCLUDE_DEFAULT
 
     private fun apiHeaders(referer: String = "$baseUrl/home"): Headers = headers.newBuilder()
         .add("Accept", "application/json, text/plain, */*")
@@ -637,7 +642,22 @@ class ReAnime :
 
         if (!parsed.success || parsed.servers.isNullOrEmpty()) return emptyList()
 
+        // Skip excluded servers before doing any network work for them.
+        // HLS streams and downloads are excluded independently: blocking "HD-1"
+        // hides only its HLS videos, while "[Sub] HD-1 Download" stays available
+        // unless "HD-1 Download" is also selected.
+        val excluded = excludedServers
+        val excludedAudio = excludedAudioTypes
+        fun isExcluded(name: String?, suffix: String = ""): Boolean {
+            if (excluded.isEmpty()) return false
+            val n = name?.takeIf { it.isNotBlank() } ?: return false
+            return (n + suffix) in excluded
+        }
+        fun isAudioExcluded(dataType: String?): Boolean = excludedAudio.isNotEmpty() && audioTagOf(dataType) in excludedAudio
+
         val videos = parsed.servers.parallelCatchingFlatMap { server ->
+            if (isExcluded(server.serverName)) return@parallelCatchingFlatMap emptyList()
+            if (isAudioExcluded(server.dataType)) return@parallelCatchingFlatMap emptyList()
             val dataLink = server.dataLink ?: return@parallelCatchingFlatMap emptyList()
             val label = buildString {
                 append(audioTagOf(server.dataType))
@@ -650,11 +670,17 @@ class ReAnime :
 
         if (includeDirectDownloads) {
             parsed.servers
+                .filterNot { isExcluded(it.serverName, " Download") }
+                .filterNot { isAudioExcluded(it.dataType) }
                 .mapNotNull { server ->
                     val aid = server.dataLink?.let { EMBED_AID_REGEX.find(it)?.groupValues?.get(1) }
                         ?: return@mapNotNull null
-                    val serverName = server.serverName ?: return@mapNotNull null
-                    Triple(aid, serverName, audioTagOf(server.dataType))
+                    Triple(
+                        aid,
+                        server.serverName?.takeIf { it.isNotBlank() }
+                            ?: "Direct",
+                        audioTagOf(server.dataType),
+                    )
                 }
                 .distinctBy { it.first to it.second }
                 .forEach { (aid, serverName, audioTag) ->
@@ -662,8 +688,10 @@ class ReAnime :
                 }
         }
 
-        if (excludedServers.isNotEmpty()) {
-            videos.removeAll { video -> video.serverKey() in excludedServers }
+        if (excluded.isNotEmpty() || excludedAudio.isNotEmpty()) {
+            videos.removeAll { video ->
+                video.serverKey() in excluded || excludedAudio.any { video.quality.startsWith(it) }
+            }
         }
 
         val quality = preferredQuality
@@ -722,7 +750,7 @@ class ReAnime :
 
             var ready = false
             var attempts = 0
-            while (!ready && attempts < 3) {
+            while (!ready && attempts < 2) {
                 ready = pollDownloadReady(base, fileId, token, dlHeaders)
                 attempts++
             }
@@ -742,28 +770,24 @@ class ReAnime :
         }
     }
 
-    private fun pollDownloadReady(base: String, fileId: String, token: String, dlHeaders: Headers): Boolean {
-        return try {
-            client.newCall(
-                GET("$base/download/$fileId/progress?token=$token", dlHeaders),
-            ).execute().use { res ->
-                if (!res.isSuccessful) return false
-                // The progress endpoint is an SSE stream that stays open after
-                // sending an update; read line-by-line instead of buffering it all.
-                val source = res.body.source()
-                while (true) {
-                    val line = source.readUtf8Line() ?: break
-                    when (PROGRESS_STATUS_REGEX.find(line)?.groupValues?.get(1)) {
-                        "ready" -> return true
-                        "failed" -> return false
-                    }
-                }
-                false
-            }
-        } catch (_: Exception) {
-            false
-        }
+    /**
+     * Dedicated client for the SSE progress check with hard timeouts, so a
+     * stalled or endlessly-streaming progress endpoint can never block the
+     * video list for more than ~[PROGRESS_TIMEOUT_SECONDS] per attempt.
+     */
+    private val progressClient by lazy {
+        client.newBuilder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(PROGRESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .callTimeout((PROGRESS_TIMEOUT_SECONDS + 2L), TimeUnit.SECONDS)
+            .build()
     }
+
+    private fun pollDownloadReady(base: String, fileId: String, token: String, dlHeaders: Headers): Boolean = flixcloudProgressIsReady(
+        client = progressClient,
+        progressUrl = "$base/download/$fileId/progress?token=$token",
+        headers = dlHeaders,
+    )
 
     private val jsonParser = Json { ignoreUnknownKeys = true }
 
@@ -1021,7 +1045,7 @@ class ReAnime :
             entries = SERVER_EXCLUDE_ENTRIES.toTypedArray()
             entryValues = SERVER_EXCLUDE_ENTRIES.toTypedArray()
             setDefaultValue(PREF_SERVER_EXCLUDE_DEFAULT)
-            summary = "Hide videos from the selected servers"
+            summary = "Hide videos from the selected servers."
         }.also(screen::addPreference)
 
         screen.addListPreference(
@@ -1032,6 +1056,15 @@ class ReAnime :
             default = preferredAudio,
             summary = "%s",
         )
+
+        MultiSelectListPreference(screen.context).apply {
+            key = PREF_AUDIO_EXCLUDE_KEY
+            title = "Exclude Audio Types"
+            entries = AUDIO_EXCLUDE_ENTRIES.toTypedArray()
+            entryValues = AUDIO_EXCLUDE_VALUES.toTypedArray()
+            setDefaultValue(PREF_AUDIO_EXCLUDE_DEFAULT)
+            summary = "Hide videos of the selected audio types.\nNote: Hiding 'Sub' may hide dub 'Download' videos."
+        }.also(screen::addPreference)
 
         screen.addPreference(
             SwitchPreferenceCompat(screen.context).apply {
@@ -1094,6 +1127,11 @@ class ReAnime :
         private val PREF_SERVER_EXCLUDE_DEFAULT = emptySet<String>()
         private val SERVER_NAME_REGEX = Regex("""(HD-\d+)""")
 
+        private const val PREF_AUDIO_EXCLUDE_KEY = "excluded_audio_types"
+        private val AUDIO_EXCLUDE_ENTRIES = listOf("Sub", "Dub")
+        private val AUDIO_EXCLUDE_VALUES = listOf("[Sub]", "[Dub]")
+        private val PREF_AUDIO_EXCLUDE_DEFAULT = emptySet<String>()
+
         private val MONTHS = arrayOf("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December")
 
         private val BR_REGEX = Regex("""<br\s*/?>""", RegexOption.IGNORE_CASE)
@@ -1129,7 +1167,7 @@ class ReAnime :
         private val JWT_REGEX = Regex("""eyJ[\w-]+\.[\w-]+\.[\w-]+""")
         private val FETCH_BASE_REGEX = Regex("""https://fetch\d*\.flixcloud\.cc""")
         private val RESOLUTION_REGEX = Regex("""(\d{3,4}p)""")
-        private val PROGRESS_STATUS_REGEX = Regex(""""status":\s*"(\w+)"""")
+        private const val PROGRESS_TIMEOUT_SECONDS = 5L
 
         fun parseStatus(status: String?): Int = when (status) {
             "RELEASING", "Releasing" -> SAnime.ONGOING

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -683,9 +683,10 @@ class ReAnime :
                     )
                 }
                 .distinctBy { it.first to it.second }
-                .forEach { (aid, serverName, audioTag) ->
-                    extractDirectDownload(aid, serverName, audioTag)?.let(videos::add)
+                .parallelCatchingFlatMap { (aid, serverName, audioTag) ->
+                    extractDirectDownload(aid, serverName, audioTag)?.let(::listOf) ?: emptyList()
                 }
+                .let(videos::addAll)
         }
 
         if (excluded.isNotEmpty() || excludedAudio.isNotEmpty()) {
@@ -1063,7 +1064,7 @@ class ReAnime :
             entries = AUDIO_EXCLUDE_ENTRIES.toTypedArray()
             entryValues = AUDIO_EXCLUDE_VALUES.toTypedArray()
             setDefaultValue(PREF_AUDIO_EXCLUDE_DEFAULT)
-            summary = "Hide videos of the selected audio types.\nNote: Hiding 'Sub' may hide dub 'Download' videos."
+            summary = "Hide videos of the selected audio types."
         }.also(screen::addPreference)
 
         screen.addPreference(

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -24,6 +24,7 @@ import keiyoushi.utils.addListPreference
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
+import keiyoushi.utils.toJsonBody
 import keiyoushi.utils.tryParse
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -34,10 +35,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.nanohttpd.protocols.http.NanoHTTPD
 import java.text.SimpleDateFormat
@@ -682,7 +681,7 @@ class ReAnime :
                         audioTagOf(server.dataType),
                     )
                 }
-                .distinctBy { it.first to it.second }
+                .distinct()
                 .parallelCatchingFlatMap { (aid, serverName, audioTag) ->
                     extractDirectDownload(aid, serverName, audioTag)?.let(::listOf) ?: emptyList()
                 }
@@ -869,7 +868,7 @@ class ReAnime :
             val tokenDto = client.newCall(
                 Request.Builder()
                     .url("$decApi/dec-flixcloud?type=token")
-                    .post(tokenPayload.toRequestBody("application/json".toMediaType()))
+                    .post(tokenPayload.toJsonBody())
                     .headers(decHeaders)
                     .build(),
             ).execute().use { it.parseAs<DecFlixCloudTokenResponseDto>() }
@@ -898,7 +897,7 @@ class ReAnime :
             val streamDto = client.newCall(
                 Request.Builder()
                     .url("$decApi/dec-flixcloud?type=stream")
-                    .post(streamPayload.toRequestBody("application/json".toMediaType()))
+                    .post(streamPayload.toJsonBody())
                     .headers(decHeaders)
                     .build(),
             ).execute().use { it.parseAs<DecFlixCloudStreamResponseDto>() }

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.util.LruCache
 import androidx.annotation.RequiresApi
+import androidx.preference.MultiSelectListPreference
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import aniyomi.lib.playlistutils.PlaylistUtils
@@ -81,6 +82,13 @@ class ReAnime :
 
     private val hideFiller: Boolean
         get() = preferences.getBoolean(PREF_HIDE_FILLER_KEY, PREF_HIDE_FILLER_DEFAULT)
+
+    private val includeDirectDownloads: Boolean
+        get() = preferences.getBoolean(PREF_DOWNLOAD_KEY, PREF_DOWNLOAD_DEFAULT)
+
+    private val excludedServers: Set<String>
+        get() = preferences.getStringSet(PREF_SERVER_EXCLUDE_KEY, PREF_SERVER_EXCLUDE_DEFAULT)
+            ?: PREF_SERVER_EXCLUDE_DEFAULT
 
     private fun apiHeaders(referer: String = "$baseUrl/home"): Headers = headers.newBuilder()
         .add("Accept", "application/json, text/plain, */*")
@@ -629,31 +637,132 @@ class ReAnime :
 
         if (!parsed.success || parsed.servers.isNullOrEmpty()) return emptyList()
 
-        val audioTag = if (preferredAudio == "dub") "[Dub]" else "[Sub]"
-
         val videos = parsed.servers.parallelCatchingFlatMap { server ->
             val dataLink = server.dataLink ?: return@parallelCatchingFlatMap emptyList()
             val label = buildString {
-                when (server.dataType) {
-                    "sub" -> append("[Sub]")
-                    "dub" -> append("[Dub]")
-                    else -> server.dataType?.let { append("[$it]") }
-                }
+                append(audioTagOf(server.dataType))
                 server.serverName?.let { append(" $it") }
                 if (server.softsub) append(" [Softsub]")
-            }
+            }.trim()
 
             extractFromServer(dataLink, label, referer)
+        }.toMutableList()
+
+        if (includeDirectDownloads) {
+            parsed.servers
+                .mapNotNull { server ->
+                    val aid = server.dataLink?.let { EMBED_AID_REGEX.find(it)?.groupValues?.get(1) }
+                        ?: return@mapNotNull null
+                    val serverName = server.serverName ?: return@mapNotNull null
+                    Triple(aid, serverName, audioTagOf(server.dataType))
+                }
+                .distinctBy { it.first to it.second }
+                .forEach { (aid, serverName, audioTag) ->
+                    extractDirectDownload(aid, serverName, audioTag)?.let(videos::add)
+                }
+        }
+
+        if (excludedServers.isNotEmpty()) {
+            videos.removeAll { video -> video.serverKey() in excludedServers }
         }
 
         val quality = preferredQuality
         val qualitiesList = PREF_QUALITY_VALUES.reversed()
+        val audioTag = if (preferredAudio == "dub") "[Dub]" else "[Sub]"
         return videos.sortedWith(
             compareByDescending<Video> { it.quality.contains(quality) }
                 .thenByDescending { video -> qualitiesList.indexOfLast { video.quality.contains(it) } }
                 .thenByDescending { it.quality.contains(preferredServer, ignoreCase = true) }
                 .thenByDescending { it.quality.contains(audioTag) },
         )
+    }
+
+    private fun audioTagOf(dataType: String?): String = when (dataType) {
+        "sub" -> "[Sub]"
+        "dub" -> "[Dub]"
+        else -> dataType?.takeIf { it.isNotBlank() }?.let { "[$it]" } ?: ""
+    }
+
+    /**
+     * Identifies which server a video belongs to, e.g. "HD-1" or "HD-1 Download",
+     * so that exclusion matching doesn't hide "HD-1 Download" when only "HD-1"
+     * is excluded (a plain contains() would).
+     */
+    private fun Video.serverKey(): String? {
+        val base = SERVER_NAME_REGEX.find(quality)?.groupValues?.get(1) ?: return null
+        return if (quality.contains("Download", ignoreCase = true)) "$base Download" else base
+    }
+
+    /**
+     * Fetches the direct-download variant of a FlixCloud embed as an extra video.
+     *
+     * Flow: /d/{aid}/__data.json mints a short-lived IP-bound JWT ->
+     * the progress endpoint confirms the file is ready -> the file itself is
+     * a plain unencrypted Matroska stream (no XOR mask or fake image headers,
+     * unlike HLS segments), so they don't require any proxy.
+     */
+    private fun extractDirectDownload(aid: String, serverName: String, audioTag: String): Video? {
+        return try {
+            val dlHeaders = headers.newBuilder()
+                .add("Accept", "*/*")
+                .add("Referer", "$flixCloudUrl/")
+                .build()
+
+            val dataBody = client.newCall(
+                GET("$flixCloudUrl/d/$aid/__data.json", dlHeaders),
+            ).execute().use { res ->
+                if (!res.isSuccessful) return null
+                res.body.string()
+            }
+
+            val fileId = FILE_ID_REGEX.find(dataBody)?.value ?: return null
+            val token = JWT_REGEX.find(dataBody)?.value ?: return null
+            val base = FETCH_BASE_REGEX.find(dataBody)?.value ?: flixCloudUrl
+            val resolution = RESOLUTION_REGEX.find(dataBody)?.groupValues?.get(1)
+
+            var ready = false
+            var attempts = 0
+            while (!ready && attempts < 3) {
+                ready = pollDownloadReady(base, fileId, token, dlHeaders)
+                attempts++
+            }
+            if (!ready) return null
+
+            val fileUrl = "$base/download/$fileId?token=$token"
+            val label = buildString {
+                append(audioTag)
+                append(" ").append(serverName).append(" Download")
+                append(" - MKV")
+                resolution?.let { append(" ").append(it) }
+            }.trim()
+
+            Video(fileUrl, label, fileUrl, headers = dlHeaders)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun pollDownloadReady(base: String, fileId: String, token: String, dlHeaders: Headers): Boolean {
+        return try {
+            client.newCall(
+                GET("$base/download/$fileId/progress?token=$token", dlHeaders),
+            ).execute().use { res ->
+                if (!res.isSuccessful) return false
+                // The progress endpoint is an SSE stream that stays open after
+                // sending an update; read line-by-line instead of buffering it all.
+                val source = res.body.source()
+                while (true) {
+                    val line = source.readUtf8Line() ?: break
+                    when (PROGRESS_STATUS_REGEX.find(line)?.groupValues?.get(1)) {
+                        "ready" -> return true
+                        "failed" -> return false
+                    }
+                }
+                false
+            }
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private val jsonParser = Json { ignoreUnknownKeys = true }
@@ -906,6 +1015,15 @@ class ReAnime :
             summary = "%s",
         )
 
+        MultiSelectListPreference(screen.context).apply {
+            key = PREF_SERVER_EXCLUDE_KEY
+            title = "Exclude Servers"
+            entries = SERVER_EXCLUDE_ENTRIES.toTypedArray()
+            entryValues = SERVER_EXCLUDE_ENTRIES.toTypedArray()
+            setDefaultValue(PREF_SERVER_EXCLUDE_DEFAULT)
+            summary = "Hide videos from the selected servers"
+        }.also(screen::addPreference)
+
         screen.addListPreference(
             key = PREF_AUDIO_KEY,
             title = "Preferred Audio Type",
@@ -921,6 +1039,15 @@ class ReAnime :
                 title = "Hide Filler Episodes"
                 summary = "Hides episodes marked as filler from the episode list."
                 setDefaultValue(PREF_HIDE_FILLER_DEFAULT)
+            },
+        )
+
+        screen.addPreference(
+            SwitchPreferenceCompat(screen.context).apply {
+                key = PREF_DOWNLOAD_KEY
+                title = "Include Direct Downloads"
+                summary = "Adds the original MKV file of each server as an extra video entry."
+                setDefaultValue(PREF_DOWNLOAD_DEFAULT)
             },
         )
     }
@@ -942,8 +1069,8 @@ class ReAnime :
         private const val PREF_AUDIO_DEFAULT = "sub"
 
         private const val PREF_SERVER_KEY = "preferred_server"
-        private val PREF_SERVER_ENTRIES = listOf("HD-1", "HD-2")
-        private val PREF_SERVER_VALUES = listOf("HD-1", "HD-2")
+        private val PREF_SERVER_ENTRIES = listOf("HD-1", "HD-1 Download", "HD-2", "HD-2 Download")
+        private val PREF_SERVER_VALUES = listOf("HD-1", "HD-1 Download", "HD-2", "HD-2 Download")
         private const val PREF_SERVER_DEFAULT = "HD-1"
 
         private const val PREF_QUALITY_KEY = "preferred_quality"
@@ -958,6 +1085,15 @@ class ReAnime :
 
         private const val PREF_HIDE_FILLER_KEY = "hide_filler"
         private const val PREF_HIDE_FILLER_DEFAULT = false
+
+        private const val PREF_DOWNLOAD_KEY = "include_direct_downloads"
+        private const val PREF_DOWNLOAD_DEFAULT = true
+
+        private const val PREF_SERVER_EXCLUDE_KEY = "excluded_servers"
+        private val SERVER_EXCLUDE_ENTRIES = listOf("HD-1", "HD-1 Download", "HD-2", "HD-2 Download")
+        private val PREF_SERVER_EXCLUDE_DEFAULT = emptySet<String>()
+        private val SERVER_NAME_REGEX = Regex("""(HD-\d+)""")
+
         private val MONTHS = arrayOf("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December")
 
         private val BR_REGEX = Regex("""<br\s*/?>""", RegexOption.IGNORE_CASE)
@@ -987,6 +1123,13 @@ class ReAnime :
 
         private val HLS_SCRIPT_REGEX = Regex("""href="([^"]*hls\.js[^"]*)""")
         private val XOR_MASK_REGEX = Regex("""for\(var f=\[(\d{1,3}(?:,\d{1,3}){15})]""")
+
+        private val EMBED_AID_REGEX = Regex("""/e/([a-z0-9]+)""")
+        private val FILE_ID_REGEX = Regex("""[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}""")
+        private val JWT_REGEX = Regex("""eyJ[\w-]+\.[\w-]+\.[\w-]+""")
+        private val FETCH_BASE_REGEX = Regex("""https://fetch\d*\.flixcloud\.cc""")
+        private val RESOLUTION_REGEX = Regex("""(\d{3,4}p)""")
+        private val PROGRESS_STATUS_REGEX = Regex(""""status":\s*"(\w+)"""")
 
         fun parseStatus(status: String?): Int = when (status) {
             "RELEASING", "Releasing" -> SAnime.ONGOING


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Enable Re:ANIME users to access direct downloads while providing finer control over which servers and audio types appear.

New Features:
- Add direct MKV download entries for FlixCloud servers when enabled.
- Add preferences for excluding specific servers and audio types.

Enhancements:
- Improve video filtering so server and audio exclusions apply consistently to streaming and download entries.
- Add bounded progress polling for direct-download readiness and modernize JSON request-body construction.

Build:
- Increment the Re:ANIME extension version code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added settings to include direct downloads and exclude specific servers or audio types.
  - Added direct MKV download options when available.
  - Server choices now include download variants.
  - Video listings identify available audio types more clearly.

- **Bug Fixes**
  - Improved download availability, deduplication, and progress checks.
  - Improved reliability when checking video readiness, including timeout handling.
  - Corrected punctuation in server-exclusion settings.
  - Updated the Re:ANIME extension to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->