### PR TITLE
CI: Post test APK download links on PRs

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -115,14 +115,67 @@ jobs:
 
       - name: Upload APKs (${{ matrix.chunk.number }})
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: "github.repository == 'yuzono/anime-extensions'"
         with:
           name: "individual-apks-${{ matrix.chunk.number }}"
           path: "**/*.apk"
-          retention-days: 1
+          retention-days: 7
 
       - name: Clean up CI files
         run: rm signingkey.jks
+
+  comment_apk:
+    name: Post APK Download Link
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Post or Update PR Comment with nightly.link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = context.repo;
+            const runId = context.runId;
+            const prNumber = context.issue.number;
+            const commitSha = context.sha ? context.sha.substring(0, 7) : '';
+
+            const nightlyLink = `https://nightly.link/${repo.owner}/${repo.repo}/actions/runs/${runId}`;
+
+            const commentHeader = `### 📦 Test APK Artifacts Available`;
+            const commentBody = `${commentHeader}\n\n` +
+              `The extension APKs compiled for this PR (commit \`${commitSha}\`) can be downloaded directly:\n\n` +
+              `👉 **[Download APKs via nightly.link](${nightlyLink})**\n\n` +
+              `> *Extract the downloaded \`.zip\` and install the \`.apk\` on your Android device to test in Dantotsu / Aniyomi.*`;
+
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                ...repo,
+                issue_number: prNumber,
+              });
+
+              const botComment = comments.find(c =>
+                c.user.type === 'Bot' && c.body.includes(commentHeader)
+              );
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  ...repo,
+                  comment_id: botComment.id,
+                  body: commentBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  ...repo,
+                  issue_number: prNumber,
+                  body: commentBody,
+                });
+              }
+            } catch (error) {
+              console.log('Unable to post/update comment: ' + error.message);
+            }
 
   publish:
     name: Check extension repo


### PR DESCRIPTION
## Description
Enhances `.github/workflows/build_pull_request.yml` by adding an automated comment job that posts a direct download link using [nightly.link](https://nightly.link/) whenever a PR build succeeds.

### Key Changes:
- Adds a `comment_apk` job running after `build`.
- Generates a direct `nightly.link` URL to allow testers and maintainers to download and test compiled extension APKs without requiring Android Studio or manually digging through the Actions summary.
- Searches for and updates existing bot comments on new commits instead of creating duplicate comments.

## Summary by Sourcery

Make compiled APKs easier to download and test directly from pull requests.

New Features:
- Post or update a pull request comment with a direct nightly.link download link for successfully built APK artifacts.

Enhancements:
- Retain uploaded APK artifacts for seven days and make them available for all pull request builds.

CI:
- Add a post-build workflow job that manages a single bot comment with the current commit's APK download link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now include a comment with download links for generated APK artifacts.
  * APK artifacts remain available for 7 days instead of 1 day.

* **Improvements**
  * APK uploads are available for pull requests regardless of repository ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->