### PR TITLE
Fix MoviesMod domain, NPE and video extraction (#488)

### DIFF
--- a/src/en/moviesmod/build.gradle
+++ b/src/en/moviesmod/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MoviesMod'
     extClass = '.MoviesMod'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/moviesmod/build.gradle
+++ b/src/en/moviesmod/build.gradle
@@ -1,7 +1,11 @@
 ext {
     extName = 'MoviesMod'
     extClass = '.MoviesMod'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply plugin: "kei.plugins.extension.legacy"
+
+dependencies {
+    implementation(project(':lib:playlistutils'))
+}

--- a/src/en/moviesmod/build.gradle
+++ b/src/en/moviesmod/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MoviesMod'
     extClass = '.MoviesMod'
-    extVersionCode = 3
+    extVersionCode = 2
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -254,6 +254,7 @@ class MoviesMod :
                     val finalUrl = runCatching {
                         val headRequest = GET(href, headers).newBuilder().head().build()
                         client.newCall(headRequest).execute().use { resp ->
+                            if (!resp.isSuccessful) return@use null
                             resp.request.url.queryParameter("url") ?: resp.request.url.toString()
                         }
                     }.getOrNull() ?: href

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -59,10 +59,11 @@ class MoviesMod :
                             .newCall(GET("$baseUrl/")).await().use { resp ->
                                 when (resp.code) {
                                     301, 302, 307, 308 -> {
-                                        val origin = resp.headers["location"]
+                                        val target = resp.headers["location"]
                                             ?.let { resp.request.url.resolve(it) }
-                                            ?.let { "${it.scheme}://${it.host}" }
-                                        if (origin != null) {
+                                            ?.takeIf { it.host.contains("moviesmod") }
+                                        val origin = target?.let { "${it.scheme}://${it.host}" }
+                                        if (origin != null && resp.code in setOf(301, 308)) {
                                             preferences.edit().putString(PREF_DOMAIN_KEY, origin).apply()
                                         }
                                         origin ?: baseUrl
@@ -80,7 +81,8 @@ class MoviesMod :
                         client.newCall(GET(MMODLIST_URL, headers)).execute().use { resp ->
                             val body = resp.body.string()
                             // mmodlist returns 200 with meta refresh: url=https://moviesmod.zone
-                            Regex("""https://moviesmod\.[a-z.]+""").find(body)?.value?.trimEnd('/')
+                            // Trim trailing dot that can come from sentence punctuation
+                            Regex("""https://moviesmod\.[a-z0-9.-]+""").find(body)?.value?.trimEnd('/', '.')
                         }
                     }.getOrNull()
 

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -37,7 +37,13 @@ class MoviesMod :
     override val name = "Movies Mod"
 
     override val baseUrl by lazy {
-        preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
+        val stored = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
+        if (stored == "https://moviesmod.red") {
+            preferences.edit().putString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT).apply()
+            PREF_DOMAIN_DEFAULT
+        } else {
+            stored
+        }
     }
 
     private val currentBaseUrl by lazy {
@@ -163,7 +169,9 @@ class MoviesMod :
                 }.getOrNull() ?: return@parallelMapNotNullBlocking null
 
                 val links = episodePageDocument.select("div.timed-content-client_show_0_5_0 a")
-                    .ifEmpty { episodePageDocument.select("a[href]") }
+                    .ifEmpty {
+                        episodePageDocument.select("a[href*=?sid=], a[href*=r?key=]")
+                    }
 
                 links.mapIndexedNotNull { index, linkElement ->
                     val episode = if (isSerie) {
@@ -210,9 +218,8 @@ class MoviesMod :
     private fun extractChildUrl(mainUrl: String): String {
         return runCatching {
             val urlParam = mainUrl.toHttpUrl().queryParameter("url") ?: return mainUrl
-            // Use DEFAULT first, fallback to NO_PADDING for compatibility
             runCatching { String(Base64.decode(urlParam, Base64.DEFAULT)) }
-                .getOrElse { String(Base64.decode(urlParam, Base64.NO_PADDING)) }
+                .getOrElse { String(Base64.decode(urlParam, Base64.URL_SAFE)) }
         }.getOrDefault(mainUrl)
     }
 
@@ -245,7 +252,8 @@ class MoviesMod :
             when {
                 href.contains("cdn.video-gen.xyz") || href.contains("video-seed.dev") -> {
                     val finalUrl = runCatching {
-                        client.newCall(GET(href, headers)).execute().use { resp ->
+                        val headRequest = GET(href, headers).newBuilder().head().build()
+                        client.newCall(headRequest).execute().use { resp ->
                             resp.request.url.queryParameter("url") ?: resp.request.url.toString()
                         }
                     }.getOrNull() ?: href

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -38,7 +38,7 @@ class MoviesMod :
 
     override val baseUrl by lazy {
         val stored = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
-        if (stored == "https://moviesmod.red") {
+        if (stored == "https://moviesmod.red" || stored == "https://moviesmod.army") {
             preferences.edit().putString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT).apply()
             PREF_DOMAIN_DEFAULT
         } else {
@@ -50,20 +50,39 @@ class MoviesMod :
         runCatching {
             runBlocking {
                 withContext(Dispatchers.Default) {
-                    client.newBuilder()
-                        .followRedirects(false)
-                        .build()
-                        .newCall(GET("$baseUrl/")).await().use { resp ->
-                            when (resp.code) {
-                                301 -> {
-                                    (resp.headers["location"]?.substringBeforeLast("/") ?: baseUrl).also {
-                                        preferences.edit().putString(PREF_DOMAIN_KEY, it).apply()
+                    // Try baseUrl first, handling HTTP redirects
+                    val resolvedFromBase = runCatching {
+                        client.newBuilder()
+                            .followRedirects(false)
+                            .build()
+                            .newCall(GET("$baseUrl/")).await().use { resp ->
+                                when (resp.code) {
+                                    301, 302, 307, 308 -> {
+                                        (resp.headers["location"]?.substringBeforeLast("/") ?: baseUrl).also {
+                                            preferences.edit().putString(PREF_DOMAIN_KEY, it).apply()
+                                        }
                                     }
+                                    in 200..299 -> baseUrl
+                                    else -> null
                                 }
-
-                                else -> baseUrl
                             }
+                    }.getOrNull()
+
+                    if (resolvedFromBase != null) return@withContext resolvedFromBase
+
+                    // Fallback: resolve latest domain via mmodlist redirect which always points to current domain
+                    val latest = runCatching {
+                        client.newCall(GET(MMODLIST_URL, headers)).execute().use { resp ->
+                            val body = resp.body.string()
+                            // mmodlist returns 200 with meta refresh: url=https://moviesmod.zone
+                            Regex("""https://moviesmod\.[a-z.]+""").find(body)?.value?.trimEnd('/')
                         }
+                    }.getOrNull()
+
+                    latest?.let {
+                        preferences.edit().putString(PREF_DOMAIN_KEY, it).apply()
+                        it
+                    } ?: baseUrl
                 }
             }
         }.getOrDefault(baseUrl)
@@ -413,7 +432,8 @@ class MoviesMod :
 
         private const val PREF_DOMAIN_KEY = "pref_domain_new"
         private const val PREF_DOMAIN_TITLE = "Currently used domain"
-        private const val PREF_DOMAIN_DEFAULT = "https://moviesmod.army"
+        private const val PREF_DOMAIN_DEFAULT = "https://moviesmod.zone"
+        private const val MMODLIST_URL = "https://mmodlist.org/?type=hollywood"
         private const val PREF_DOMAIN_DIALOG_TITLE = PREF_DOMAIN_TITLE
 
         private const val PREF_QUALITY_KEY = "preferred_quality"

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -172,8 +172,8 @@ class MoviesMod :
         // Parallelize child-page fetches to avoid performance regression vs sequential Jsoup.connect
         val triples = episodeElements.toList().parallelMapNotNullBlocking { row ->
             runCatching {
-                val prevP = row.previousElementSibling()?.text()?.takeIf { it.isNotBlank() }
-                    ?: row.previousElementSiblings().firstOrNull()?.text().orEmpty()
+                val prevP = row.previousElementSiblings()
+                    .firstOrNull { it.text().isNotBlank() }?.text().orEmpty()
 
                 val quality = qualityRegex.find(prevP)?.value ?: "HD"
                 val defaultName = if (isSerie) {
@@ -182,7 +182,7 @@ class MoviesMod :
                     movieTitleRegex.find(prevP.replace("Download", "").trim())?.value ?: "Movie"
                 }
 
-                val episodePageUrl = row.selectFirst("a[href]")?.attr("href")?.takeUnless { it.isBlank() }
+                val episodePageUrl = row.selectFirst("a[href]")?.attr("abs:href")?.takeUnless { it.isBlank() }
                     ?: return@parallelMapNotNullBlocking null
 
                 val childUrl = extractChildUrl(episodePageUrl)
@@ -206,7 +206,7 @@ class MoviesMod :
                         0
                     }
 
-                    val url = linkElement.attr("href").takeUnless(String::isBlank)
+                    val url = linkElement.attr("abs:href").takeUnless(String::isBlank)
                         ?: return@mapIndexedNotNull null
 
                     Triple(

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -218,8 +218,8 @@ class MoviesMod :
     private fun extractChildUrl(mainUrl: String): String {
         return runCatching {
             val urlParam = mainUrl.toHttpUrl().queryParameter("url") ?: return mainUrl
-            runCatching { String(Base64.decode(urlParam, Base64.DEFAULT)) }
-                .getOrElse { String(Base64.decode(urlParam, Base64.URL_SAFE)) }
+            val flags = if (urlParam.contains("-") || urlParam.contains("_")) Base64.URL_SAFE else Base64.DEFAULT
+            String(Base64.decode(urlParam, flags))
         }.getOrDefault(mainUrl)
     }
 

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -58,9 +58,13 @@ class MoviesMod :
                             .newCall(GET("$baseUrl/")).await().use { resp ->
                                 when (resp.code) {
                                     301, 302, 307, 308 -> {
-                                        (resp.headers["location"]?.substringBeforeLast("/") ?: baseUrl).also {
-                                            preferences.edit().putString(PREF_DOMAIN_KEY, it).apply()
+                                        val origin = resp.headers["location"]
+                                            ?.let { resp.request.url.resolve(it) }
+                                            ?.let { "${it.scheme}://${it.host}" }
+                                        if (origin != null) {
+                                            preferences.edit().putString(PREF_DOMAIN_KEY, origin).apply()
                                         }
+                                        origin ?: baseUrl
                                     }
                                     in 200..299 -> baseUrl
                                     else -> null
@@ -189,7 +193,7 @@ class MoviesMod :
 
                 val links = episodePageDocument.select("div.timed-content-client_show_0_5_0 a")
                     .ifEmpty {
-                        episodePageDocument.select("a[href*=?sid=], a[href*=r?key=]")
+                        episodePageDocument.select("""a[href*="?sid="], a[href*="r?key="]""")
                     }
 
                 links.mapIndexedNotNull { index, linkElement ->
@@ -269,7 +273,8 @@ class MoviesMod :
             val size = SIZE_REGEX.find(btn.text())?.groupValues?.get(1)?.let { " - $it" } ?: ""
 
             when {
-                href.contains("cdn.video-gen.xyz") || href.contains("video-seed.dev") -> {
+                href.contains("cdn.video-gen.xyz") || href.contains("video-seed.dev") ||
+                    href.contains("r2.dev") || href.contains("instant.video-gen") -> {
                     val finalUrl = runCatching {
                         val headRequest = GET(href, headers).newBuilder().head().build()
                         client.newCall(headRequest).execute().use { resp ->
@@ -297,8 +302,11 @@ class MoviesMod :
                         )
                     }.getOrDefault(emptyList())
                 }
-                href.contains("/login") || href.contains("seedtg.xyz") -> emptyList()
-                else -> emptyList()
+                href.contains("/login") -> emptyList()
+                else -> {
+                    // Fallback for r2.dev, seedtg.xyz, tgcdn_bot and future hosts - expose as direct
+                    listOf(Video(href, "$quality - Direct$size", href))
+                }
             }
         }
     }

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -29,6 +29,7 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.injectLazy
+import java.util.concurrent.atomic.AtomicBoolean
 
 class MoviesMod :
     ParsedAnimeHttpSource(),
@@ -170,6 +171,7 @@ class MoviesMod :
         val isSerie = episodeElements.firstOrNull()?.selectFirst("a")?.text()?.equals("Episode Links", ignoreCase = true) == true
 
         // Parallelize child-page fetches to avoid performance regression vs sequential Jsoup.connect
+        val childPageLoaded = AtomicBoolean(false)
         val triples = episodeElements.toList().parallelMapNotNullBlocking { row ->
             runCatching {
                 val prevP = row.previousElementSiblings()
@@ -190,6 +192,7 @@ class MoviesMod :
                 val episodePageDocument = runCatching {
                     client.newCall(GET(childUrl, headers)).execute().asJsoup()
                 }.getOrNull() ?: return@parallelMapNotNullBlocking null
+                childPageLoaded.set(true)
 
                 val links = episodePageDocument.select("div.timed-content-client_show_0_5_0 a")
                     .ifEmpty {
@@ -234,7 +237,15 @@ class MoviesMod :
             }
         }
 
-        if (grouped.isEmpty()) throw Exception("Only Zip Pack Available")
+        if (grouped.isEmpty()) {
+            throw Exception(
+                if (childPageLoaded.get()) {
+                    "Only Zip Pack Available"
+                } else {
+                    "Failed to load episode pages. Site may have changed or is behind Cloudflare."
+                },
+            )
+        }
         return grouped.reversed()
     }
 

--- a/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
+++ b/src/en/moviesmod/src/eu/kanade/tachiyomi/animeextension/en/moviesmod/MoviesMod.kt
@@ -4,6 +4,7 @@ import android.util.Base64
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
+import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.SAnime
@@ -11,11 +12,11 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
+import keiyoushi.utils.parallelMapNotNullBlocking
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -23,14 +24,11 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MultipartBody
 import okhttp3.Request
 import okhttp3.Response
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.injectLazy
-import java.net.URL
 
 class MoviesMod :
     ParsedAnimeHttpSource(),
@@ -73,6 +71,8 @@ class MoviesMod :
 
     private val preferences by getPreferencesLazy()
 
+    private val playlistUtils by lazy { PlaylistUtils(client, headers) }
+
     // ============================== Popular ===============================
     override fun popularAnimeRequest(page: Int): Request = GET("$currentBaseUrl/page/$page/")
 
@@ -80,7 +80,8 @@ class MoviesMod :
 
     override fun popularAnimeFromElement(element: Element) = SAnime.create().apply {
         setUrlWithoutDomain(element.select("a").attr("abs:href"))
-        thumbnail_url = element.select("div.featured-thumbnail > img").attr("abs:src")
+        val img = element.selectFirst("div.featured-thumbnail > img")
+        thumbnail_url = img?.attr("abs:data-src")?.takeIf { it.isNotBlank() } ?: img?.attr("abs:src")
         title = element.select("a").attr("title")
             .replace("Download", "").trim()
     }
@@ -123,29 +124,48 @@ class MoviesMod :
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val doc = response.asJsoup()
+        // Original selector + fallback for site redesign / domain change
         val episodeElements = doc.select("p:has(a.maxbutton-episode-links,a.maxbutton-download-links)")
+            .ifEmpty { doc.select("p:has(a[class*=maxbutton])") }
             .asSequence()
+
+        if (!episodeElements.iterator().hasNext()) {
+            throw Exception("No episode links found. Site may have changed or is behind Cloudflare.")
+        }
 
         val qualityRegex = "\\d{3,4}p(?:\\s+\\w+)?".toRegex(RegexOption.IGNORE_CASE)
         val seasonRegex = "[ .]?S(?:eason)?[ .]?(\\d{1,2})[ .]?".toRegex(RegexOption.IGNORE_CASE)
         val movieTitleRegex = "^[^(]+\n?".toRegex(RegexOption.IGNORE_CASE)
 
-        val isSerie = episodeElements.first().selectFirst("a")!!.text() == "Episode Links"
+        // Safe check for series vs movie; avoid NPE on empty or missing text
+        val isSerie = episodeElements.firstOrNull()?.selectFirst("a")?.text()?.equals("Episode Links", ignoreCase = true) == true
 
-        val episodeList = episodeElements.map { row ->
-            val prevP = row.previousElementSibling()!!.text()
-            val quality = (qualityRegex.find(prevP)?.value ?: "HD")
-            val defaultName = if (isSerie) {
-                seasonRegex.find(prevP)?.value ?: "Season 1"
-            } else {
-                movieTitleRegex.find(prevP.replace("Download", "").trim())?.value ?: "Movie"
-            }
+        // Parallelize child-page fetches to avoid performance regression vs sequential Jsoup.connect
+        val triples = episodeElements.toList().parallelMapNotNullBlocking { row ->
+            runCatching {
+                val prevP = row.previousElementSibling()?.text()?.takeIf { it.isNotBlank() }
+                    ?: row.previousElementSiblings().firstOrNull()?.text().orEmpty()
 
-            val episodePageUrl = row.selectFirst("a[href]")?.attr("href")!!
-            val episodePageDocument = Jsoup.connect(extractChildUrl(episodePageUrl)).get()
+                val quality = qualityRegex.find(prevP)?.value ?: "HD"
+                val defaultName = if (isSerie) {
+                    seasonRegex.find(prevP)?.value ?: "Season 1"
+                } else {
+                    movieTitleRegex.find(prevP.replace("Download", "").trim())?.value ?: "Movie"
+                }
 
-            episodePageDocument.select("div.timed-content-client_show_0_5_0 a").asSequence()
-                .mapIndexedNotNull { index, linkElement ->
+                val episodePageUrl = row.selectFirst("a[href]")?.attr("href")?.takeUnless { it.isBlank() }
+                    ?: return@parallelMapNotNullBlocking null
+
+                val childUrl = extractChildUrl(episodePageUrl)
+
+                val episodePageDocument = runCatching {
+                    client.newCall(GET(childUrl, headers)).execute().asJsoup()
+                }.getOrNull() ?: return@parallelMapNotNullBlocking null
+
+                val links = episodePageDocument.select("div.timed-content-client_show_0_5_0 a")
+                    .ifEmpty { episodePageDocument.select("a[href]") }
+
+                links.mapIndexedNotNull { index, linkElement ->
                     val episode = if (isSerie) {
                         linkElement.text()
                             .replace("Episode", "", true)
@@ -161,10 +181,13 @@ class MoviesMod :
                     Triple(
                         Pair(defaultName, episode),
                         url,
-                        if (isSerie) quality else quality + " " + linkElement.text(),
+                        if (isSerie) quality else "$quality ${linkElement.text()}".trim(),
                     )
                 }
-        }.flatten().groupBy { it.first }.values.mapIndexed { index, items ->
+            }.getOrNull()
+        }.flatten()
+
+        val grouped = triples.groupBy { it.first }.values.mapIndexed { index, items ->
             val (itemName, episodeNum) = items.first().first
 
             SEpisode.create().apply {
@@ -180,24 +203,17 @@ class MoviesMod :
             }
         }
 
-        if (episodeList.isEmpty()) throw Exception("Only Zip Pack Available")
-        return episodeList.reversed()
+        if (grouped.isEmpty()) throw Exception("Only Zip Pack Available")
+        return grouped.reversed()
     }
 
     private fun extractChildUrl(mainUrl: String): String {
-        // Parse the URL
-        val parsedUrl = URL(mainUrl)
-
-        // Get query parameters
-        val queryParams = parsedUrl.query.split("&").associate {
-            val (key, value) = it.split("=")
-            key to value
-        }
-
-        // Decode the Base64 string
-        val decodedUrl = String(Base64.decode(queryParams["url"], 1))
-
-        return decodedUrl
+        return runCatching {
+            val urlParam = mainUrl.toHttpUrl().queryParameter("url") ?: return mainUrl
+            // Use DEFAULT first, fallback to NO_PADDING for compatibility
+            runCatching { String(Base64.decode(urlParam, Base64.DEFAULT)) }
+                .getOrElse { String(Base64.decode(urlParam, Base64.NO_PADDING)) }
+        }.getOrDefault(mainUrl)
     }
 
     override fun episodeListSelector(): String = "p:has(a.maxbutton-episode-links)"
@@ -208,24 +224,55 @@ class MoviesMod :
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
         val urlJson = json.decodeFromString<EpLinks>(episode.url)
 
-        val videoList = urlJson.urls.parallelCatchingFlatMap { eplink ->
-            val quality = eplink.quality
-            val url = getMediaUrl(eplink) ?: return@parallelCatchingFlatMap emptyList()
-            val videos = extractVideo(url, quality)
+        return urlJson.urls.parallelCatchingFlatMap { eplink ->
+            val mediaUrl = getMediaUrl(eplink) ?: return@parallelCatchingFlatMap emptyList()
+            extractVideos(mediaUrl, eplink.quality)
+        }
+    }
+
+    private fun extractVideos(fileUrl: String, quality: String): List<Video> {
+        val doc = runCatching { client.newCall(GET(fileUrl, headers)).execute().asJsoup() }.getOrNull()
+            ?: return emptyList()
+
+        val btns = doc.select("div.card-body a.btn")
+        if (btns.isEmpty()) return emptyList()
+
+        // Extract videos, handling HLS via PlaylistUtils where applicable
+        return btns.flatMap { btn ->
+            val href = btn.attr("abs:href").takeUnless { it.isBlank() } ?: return@flatMap emptyList()
+            val size = SIZE_REGEX.find(btn.text())?.groupValues?.get(1)?.let { " - $it" } ?: ""
+
             when {
-                videos.isEmpty() -> {
-                    extractGDriveLink(url, quality).ifEmpty {
-                        getDirectLink(url, "instant", "/mfile/")?.let {
-                            listOf(Video(it, "$quality - GDrive Instant link", it))
-                        } ?: emptyList()
+                href.contains("cdn.video-gen.xyz") || href.contains("video-seed.dev") -> {
+                    val finalUrl = runCatching {
+                        client.newCall(GET(href, headers)).execute().use { resp ->
+                            resp.request.url.queryParameter("url") ?: resp.request.url.toString()
+                        }
+                    }.getOrNull() ?: href
+
+                    if (finalUrl.contains(".m3u8")) {
+                        runCatching {
+                            playlistUtils.extractFromHls(
+                                finalUrl,
+                                videoNameGen = { q -> "$quality - $q$size" },
+                            )
+                        }.getOrDefault(listOf(Video(finalUrl, "$quality - HLS$size", finalUrl)))
+                    } else {
+                        listOf(Video(finalUrl, "$quality - Instant$size", finalUrl))
                     }
                 }
-
-                else -> videos
+                href.contains(".m3u8") -> {
+                    runCatching {
+                        playlistUtils.extractFromHls(
+                            href,
+                            videoNameGen = { q -> "$quality - $q$size" },
+                        )
+                    }.getOrDefault(emptyList())
+                }
+                href.contains("/login") || href.contains("seedtg.xyz") -> emptyList()
+                else -> emptyList()
             }
         }
-
-        return videoList
     }
 
     override fun videoFromElement(element: Element): Video = throw UnsupportedOperationException()
@@ -255,70 +302,6 @@ class MoviesMod :
         if (path == "/404") return null
 
         return "https://" + mediaResponse.request.url.host + path
-    }
-
-    private fun extractVideo(url: String, quality: String): List<Video> = (1..3).toList().flatMap { type ->
-        extractWorkerLinks(url, quality, type)
-    }
-
-    private fun extractWorkerLinks(mediaUrl: String, quality: String, type: Int): List<Video> {
-        val reqLink = mediaUrl.replace("/file/", "/wfile/") + "?type=$type"
-        val resp = client.newCall(GET(reqLink)).execute().asJsoup()
-        val sizeMatch = SIZE_REGEX.find(resp.select("div.card-header").text().trim())
-        val size = sizeMatch?.groups?.get(1)?.value?.let { " - $it" } ?: ""
-        return resp.select("div.card-body div.mb-4 > a").mapIndexed { index, linkElement ->
-            val link = linkElement.attr("href")
-            val decodedLink = if (link.contains("workers.dev")) {
-                link
-            } else {
-                String(Base64.decode(link.substringAfter("download?url="), Base64.DEFAULT))
-            }
-
-            Video(
-                url = decodedLink,
-                quality = "$quality - CF $type Worker ${index + 1}$size",
-                videoUrl = decodedLink,
-            )
-        }
-    }
-
-    private fun getDirectLink(url: String, action: String = "direct", newPath: String = "/file/"): String? {
-        val doc = client.newCall(GET(url, headers)).execute().asJsoup()
-        val script = doc.selectFirst("script:containsData(async function taskaction)")
-            ?.data()
-            ?: return url
-
-        val key = script.substringAfter("key\", \"").substringBefore('"')
-        val form = MultipartBody.Builder()
-            .setType(MultipartBody.FORM)
-            .addFormDataPart("action", action)
-            .addFormDataPart("key", key)
-            .addFormDataPart("action_token", "")
-            .build()
-
-        val headers = headersBuilder().set("x-token", url.toHttpUrl().host).build()
-
-        val req = client.newCall(POST(url.replace("/file/", newPath), headers, form)).execute()
-        return runCatching {
-            json.decodeFromString<DriveLeechDirect>(req.body.string()).url
-        }.getOrNull()
-    }
-
-    private fun extractGDriveLink(mediaUrl: String, quality: String): List<Video> {
-        val neoUrl = getDirectLink(mediaUrl) ?: mediaUrl
-        val response = client.newCall(GET(neoUrl)).execute().asJsoup()
-        val gdBtn = response.selectFirst("div.card-body a.btn")!!
-        val gdLink = gdBtn.attr("href")
-        val sizeMatch = SIZE_REGEX.find(gdBtn.text())
-        val size = sizeMatch?.groups?.get(1)?.value?.let { " - $it" } ?: ""
-        val gdResponse = client.newCall(GET(gdLink)).execute().asJsoup()
-        val link = gdResponse.select("form#download-form")
-        return if (link.isNullOrEmpty()) {
-            emptyList()
-        } else {
-            val realLink = link.attr("action")
-            listOf(Video(realLink, "$quality - Gdrive$size", realLink))
-        }
     }
 
     override fun List<Video>.sort(): List<Video> {
@@ -408,9 +391,6 @@ class MoviesMod :
         val url: String,
     )
 
-    @Serializable
-    data class DriveLeechDirect(val url: String? = null)
-
     private fun EpLinks.toJson(): String = json.encodeToString(this)
 
     private fun getDomainPrefSummary(): String = preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!.let {
@@ -424,7 +404,7 @@ class MoviesMod :
 
         private const val PREF_DOMAIN_KEY = "pref_domain_new"
         private const val PREF_DOMAIN_TITLE = "Currently used domain"
-        private const val PREF_DOMAIN_DEFAULT = "https://moviesmod.red"
+        private const val PREF_DOMAIN_DEFAULT = "https://moviesmod.army"
         private const val PREF_DOMAIN_DIALOG_TITLE = PREF_DOMAIN_TITLE
 
         private const val PREF_QUALITY_KEY = "preferred_quality"


### PR DESCRIPTION
Fixes #488

- Update default domain from `moviesmod.red` → `moviesmod.zone` (current latest; resolves via `https://mmodlist.org/?type=hollywood` which always redirects to latest MoviesMod domain)
- Fix thumbnail loading by preferring `data-src` with `src` fallback
- Fix NullPointerException in `extractChildUrl` by using `HttpUrl` and selecting `Base64.URL_SAFE` vs `DEFAULT` by content
- Migrate episode page fetching from `Jsoup.connect` to `client.newCall` with headers to avoid 429 and reuse app client
- Parallelize child-page fetches with `parallelMapNotNullBlocking` to avoid performance regression
- Use built-in `PlaylistUtils` for HLS extraction instead of manual boilerplate
- Harden `episodeListParse` (empty check, null-safe siblings, restricted fallback selector `a[href*=?sid=],a[href*=r?key=]`)
- Validate `HEAD` `isSuccessful` before publishing CDN URL
- Handle domain migration via `currentBaseUrl` with HTTP 301/302/307/308 and `mmodlist.org` meta-refresh fallback
- Bump versionCode to 2

Closes #488

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [x] Have made sure all the icons are in png format

## Summary by Sourcery

Stabilize MoviesMod by supporting domain changes, hardening episode parsing, and modernizing video extraction.

Bug Fixes:
- Update MoviesMod domain resolution and migration handling to keep requests working across current and redirected domains.
- Improve episode parsing and child-page loading to avoid null-pointer failures, throttling issues, and missed links.
- Improve video extraction reliability for direct, CDN, and HLS sources, including validation of resolved media URLs.

Enhancements:
- Use parallel episode-page processing and shared HTTP clients for more reliable performance.
- Prefer lazy-loaded thumbnails and add safer URL and Base64 handling.

Build:
- Bump the MoviesMod extension version code and add the PlaylistUtils dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved video playback with HLS streams, direct links, and faster link availability.
  - Added lazy-loaded thumbnails for smoother browsing.
  - Added support for updated domains and redirect-based links.
  - Added fallback support for restricted links.

- **Bug Fixes**
  - Improved episode and metadata parsing across varied page layouts.
  - Added safer handling for unavailable links, decoding errors, and failed page requests.
  - Filtered out unsupported or login-protected video links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->