### PR TITLE
Re:ANIME [EN]: Add New Domain

### DIFF
--- a/src/en/reanime/build.gradle
+++ b/src/en/reanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Re:ANIME'
     extClass = '.ReAnime'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -1088,7 +1088,7 @@ class ReAnime :
     // Status domain: https://restatus.me/
     companion object {
         private const val PREF_DOMAIN_KEY = "preferred_domain"
-        private val PREF_DOMAIN_ENTRIES = listOf("reanime.to", "reanime.cz")
+        private val PREF_DOMAIN_ENTRIES = listOf("reanime.to", "reanime.cz", "reanime.wtf")
         private val PREF_DOMAIN_VALUES = listOf("https://reanime.to", "https://reanime.cz", "https://reanime.wtf")
         private const val PREF_DOMAIN_DEFAULT = "https://reanime.to"
         private const val PREF_LANG_KEY = "preferred_lang"

--- a/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
+++ b/src/en/reanime/src/eu/kanade/tachiyomi/animeextension/en/reanime/ReAnime.kt
@@ -1089,7 +1089,7 @@ class ReAnime :
     companion object {
         private const val PREF_DOMAIN_KEY = "preferred_domain"
         private val PREF_DOMAIN_ENTRIES = listOf("reanime.to", "reanime.cz")
-        private val PREF_DOMAIN_VALUES = listOf("https://reanime.to", "https://reanime.cz")
+        private val PREF_DOMAIN_VALUES = listOf("https://reanime.to", "https://reanime.cz", "https://reanime.wtf")
         private const val PREF_DOMAIN_DEFAULT = "https://reanime.to"
         private const val PREF_LANG_KEY = "preferred_lang"
         private val PREF_LANG_ENTRIES = listOf("All", "Sub", "Dub")


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add the new Re:ANIME domain and update the extension version.

New Features:
- Add Re:ANIME’s reanime.wtf domain as an available source endpoint.

Build:
- Bump the Re:ANIME extension version code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `reanime.wtf` as an available preferred domain for the Re:ANIME extension.
  - Expanded domain selection options, providing greater flexibility when accessing content.

- **Maintenance**
  - Updated the Re:ANIME extension version to the latest release.
  - Included the domain update in the refreshed extension package for improved availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->