### PR TITLE
fix(video): Use `copyLegacy()` to handle empty video URLs

### DIFF
--- a/core/src/main/kotlin/keiyoushi/utils/Source.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Source.kt
@@ -9,8 +9,11 @@ import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
+import eu.kanade.tachiyomi.animesource.model.Track
+import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import kotlinx.serialization.json.Json
+import okhttp3.Headers
 import okhttp3.Response
 import uy.kohesive.injekt.injectLazy
 import kotlin.getValue
@@ -52,3 +55,19 @@ abstract class Source :
     override fun videoListRequest(episode: SEpisode) = throw UnsupportedOperationException()
     override fun videoListParse(response: Response) = throw UnsupportedOperationException()
 }
+
+fun Video.copyLegacy(
+    url: String = this.videoUrl?.takeIf { it.isNotBlank() } ?: this.url,
+    quality: String = this.quality,
+    videoUrl: String? = this.videoUrl,
+    headers: Headers? = this.headers,
+    subtitleTracks: List<Track> = this.subtitleTracks,
+    audioTracks: List<Track> = this.audioTracks,
+): Video = Video(
+    url = url,
+    quality = quality,
+    videoUrl = videoUrl,
+    headers = headers,
+    subtitleTracks = subtitleTracks,
+    audioTracks = audioTracks,
+)

--- a/core/src/main/kotlin/keiyoushi/utils/Source.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Source.kt
@@ -57,7 +57,8 @@ abstract class Source :
 }
 
 fun Video.copyLegacy(
-    url: String = this.videoUrl?.takeIf { it.isNotBlank() } ?: this.url,
+    // This is quick fix for the bug in Anikku preview r8888 (caused by a bug upstream)
+    url: String = this.url.takeIf { it.isNotBlank() } ?: this.videoUrl?.takeIf { it.isNotBlank() } ?: "Video URL was empty",
     quality: String = this.quality,
     videoUrl: String? = this.videoUrl,
     headers: Headers? = this.headers,

--- a/lib-multisrc/dopeflix/build.gradle.kts
+++ b/lib-multisrc/dopeflix/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(kei.plugins.multisrc)
 }
 
-baseVersionCode = 24
+baseVersionCode = 25
 
 dependencies {
     api(project(":lib:dopeflixextractor"))

--- a/lib-multisrc/dopeflix/src/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlix.kt
+++ b/lib-multisrc/dopeflix/src/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlix.kt
@@ -21,6 +21,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
+import keiyoushi.utils.copyLegacy
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parallelFlatMap
@@ -382,11 +383,7 @@ abstract class DopeFlix(
 
             return embedLinks.parallelCatchingFlatMap(::extractVideo)
                 .map { video ->
-                    Video(
-                        url = video.url,
-                        quality = video.quality,
-                        videoUrl = video.videoUrl,
-                        headers = video.headers,
+                    video.copyLegacy(
                         subtitleTracks = subLangOrder(video.subtitleTracks),
                         audioTracks = subLangOrder(video.audioTracks),
                     )

--- a/lib/chillxextractor/src/aniyomi/lib/chillxextractor/ChillxExtractor.kt
+++ b/lib/chillxextractor/src/aniyomi/lib/chillxextractor/ChillxExtractor.kt
@@ -3,6 +3,7 @@ package aniyomi.lib.chillxextractor
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
+import keiyoushi.utils.copyLegacy
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 
@@ -40,12 +41,7 @@ class ChillxExtractor(private val client: OkHttpClient, private val headers: Hea
         )
 
         return videoList.map {
-            Video(
-                url = it.url,
-                quality = it.quality,
-                videoUrl = it.videoUrl,
-                headers = it.headers,
-                audioTracks = it.audioTracks,
+            it.copyLegacy(
                 subtitleTracks = playlistUtils.fixSubtitles(it.subtitleTracks),
             )
         }

--- a/lib/savefileextractor/src/aniyomi/lib/savefileextractor/SavefileExtractor.kt
+++ b/lib/savefileextractor/src/aniyomi/lib/savefileextractor/SavefileExtractor.kt
@@ -7,6 +7,7 @@ import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.copyLegacy
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -41,11 +42,7 @@ class SavefileExtractor(
 
         val subPref = preferences.getString(PREF_SUBTITLE_KEY, PREF_SUBTITLE_DEFAULT).orEmpty()
         return videoList.map {
-            Video(
-                url = it.url,
-                quality = it.quality,
-                videoUrl = it.videoUrl,
-                audioTracks = it.audioTracks,
+            it.copyLegacy(
                 subtitleTracks = it.subtitleTracks.filter { tracks -> tracks.lang.contains(subPref, true) },
             )
         }

--- a/src/all/javguru/build.gradle
+++ b/src/all/javguru/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jav Guru'
     extClass = '.JavGuru'
-    extVersionCode = 44
+    extVersionCode = 45
     isNsfw = true
 }
 

--- a/src/all/javguru/src/eu/kanade/tachiyomi/animeextension/all/javguru/JavGuru.kt
+++ b/src/all/javguru/src/eu/kanade/tachiyomi/animeextension/all/javguru/JavGuru.kt
@@ -21,6 +21,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.addListPreference
+import keiyoushi.utils.copyLegacy
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parallelMapNotNullBlocking
@@ -364,13 +365,8 @@ class JavGuru :
                     .set("Referer", "$baseUrl/")
                     .set("Origin", baseUrl)
                     .build()
-                Video(
-                    url = video.url,
-                    quality = video.quality,
-                    videoUrl = video.videoUrl,
+                video.copyLegacy(
                     headers = newHeaders,
-                    subtitleTracks = video.subtitleTracks,
-                    audioTracks = video.audioTracks,
                 )
             }
         }

--- a/src/all/streamingcommunity/build.gradle
+++ b/src/all/streamingcommunity/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'StreamingCommunity'
     extClass = '.StreamingCommunityFactory'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
@@ -31,6 +31,7 @@ import keiyoushi.lib.i18n.Intl
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.addEditTextPreference
 import keiyoushi.utils.addListPreference
+import keiyoushi.utils.copyLegacy
 import keiyoushi.utils.delegate
 import keiyoushi.utils.getPreferencesLazy
 import kotlinx.coroutines.async
@@ -396,10 +397,7 @@ class StreamingCommunity(override val lang: String, private val showType: String
      * the same rendition list would otherwise list each language twice.
      */
     private fun List<Video>.proxySubtitles(): List<Video> = map { video ->
-        Video(
-            videoUrl = video.videoUrl,
-            url = video.url,
-            quality = video.quality,
+        video.copyLegacy(
             headers = video.headers ?: headers,
             subtitleTracks = SubtitleServer.proxy(client, video.subtitleTracks, video.headers ?: headers),
             audioTracks = video.audioTracks.distinctBy(Track::url),

--- a/src/en/anineko/build.gradle
+++ b/src/en/anineko/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniNeko'
     extClass = '.AniNeko'
-    extVersionCode = 2
+    extVersionCode = 3
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/anineko/src/eu/kanade/tachiyomi/animeextension/en/anineko/AniNeko.kt
+++ b/src/en/anineko/src/eu/kanade/tachiyomi/animeextension/en/anineko/AniNeko.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import keiyoushi.utils.addListPreference
 import keiyoushi.utils.addSetPreference
+import keiyoushi.utils.copyLegacy
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.useAsJsoup
@@ -357,11 +358,8 @@ class AniNeko :
                 iframeUrl.contains("otakuhg.site") || iframeUrl.contains("otakuvid.online") -> {
                     val extractor = VidHideExtractor(client, headers)
                     extractor.videosFromUrl(iframeUrl) { quality -> "$versionType - $quality" }.map { video ->
-                        Video(
-                            url = video.url,
+                        video.copyLegacy(
                             quality = addServerName(serverName, video.quality),
-                            videoUrl = video.videoUrl,
-                            headers = video.headers,
                             subtitleTracks = video.subtitleTracks + subtitleTracks,
                         )
                     }
@@ -370,11 +368,8 @@ class AniNeko :
                 iframeUrl.contains("playmogo.com") || iframeUrl.contains("dood") -> {
                     val extractor = DoodExtractor(client)
                     extractor.videosFromUrl(iframeUrl, quality = versionType).map { video ->
-                        Video(
-                            url = video.url,
+                        video.copyLegacy(
                             quality = addServerName(serverName, video.quality),
-                            videoUrl = video.videoUrl,
-                            headers = video.headers,
                             subtitleTracks = video.subtitleTracks + subtitleTracks,
                         )
                     }

--- a/src/en/aniwaves/build.gradle
+++ b/src/en/aniwaves/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AniWaves.ru'
     extClass = '.AniWaves'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
 }
 

--- a/src/en/aniwaves/src/eu/kanade/tachiyomi/animeextension/en/aniwaves/AniWaves.kt
+++ b/src/en/aniwaves/src/eu/kanade/tachiyomi/animeextension/en/aniwaves/AniWaves.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.copyLegacy
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
@@ -480,12 +481,8 @@ class AniWaves :
     private fun extractFromDood(embedUrl: String, server: VideoData): List<Video> {
         val label = videoLabel(server)
         return doodExtractor.videosFromUrl(embedUrl, label).map { video ->
-            Video(
-                url = video.url,
+            video.copyLegacy(
                 quality = "$label - Doodstream 1080p",
-                videoUrl = video.videoUrl,
-                headers = video.headers,
-                subtitleTracks = video.subtitleTracks,
             )
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Restore legacy video-copy compatibility across affected sources and extractors to prevent empty video URLs in preview builds.

Bug Fixes:
- Restore compatibility with legacy `Video.copy()` behavior when video URLs are represented by either `url` or `videoUrl`.
- Update affected video sources and extractors to preserve video metadata while applying customized tracks, headers, or quality labels.

Enhancements:
- Centralize legacy `Video` copying in a reusable utility and migrate affected integrations to use it.

Build:
- Increment extension version codes for DopeFlix, Jav Guru, StreamingCommunity, AniNeko, and AniWaves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video playback compatibility across supported streaming sources.
  - Preserved video metadata, quality labels, and access settings when processing extracted videos.
  - Improved subtitle selection and proxying for configured languages.
  - Maintained subtitle and audio track ordering, including language-specific preferences.
  - Improved handling of videos with multiple subtitle and audio tracks.
- **Chores**
  - Updated several streaming extensions to newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->