### PR TITLE
RouVideo: fix HLS playback and downloads

### DIFF
--- a/src/all/rouvideo/build.gradle
+++ b/src/all/rouvideo/build.gradle
@@ -1,13 +1,30 @@
 ext {
     extName = 'RouVideo'
     extClass = '.RouVideoFactory'
-    extVersionCode = 14
+    extVersionCode = 18
     isNsfw = true
 }
 
 apply plugin: "kei.plugins.extension.legacy"
 
+android {
+    sourceSets {
+        main {
+            java.exclude("test/**")
+            kotlin.exclude("test/**")
+        }
+    }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+}
+
 dependencies {
     implementation(project(":lib:playlistutils"))
+    implementation(project(":lib:m3u8server"))
     implementation(project(":lib:i18n"))
+    testImplementation(project(":core"))
+    testImplementation(libs.bundles.common)
+    testImplementation(libs.junit)
 }

--- a/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideo.kt
+++ b/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideo.kt
@@ -453,8 +453,10 @@ class RouVideo(
 
     // ============================ Video Links =============================
 
+    /** Fetches the episode page containing the encoded video data. */
     override fun videoListRequest(episode: SEpisode) = GET(getEpisodeUrl(episode), docHeaders)
 
+    /** Decodes the episode data, extracts HLS variants, and proxies them through the local m3u8 server. */
     override fun videoListParse(response: Response): List<Video> {
         val data = response.asJsoup().selectFirst("script#__NEXT_DATA__")?.data()
             ?: return emptyList()
@@ -478,6 +480,7 @@ class RouVideo(
 
     private val resolutionRegex = Regex("""Resolution: (\d+)p""")
     companion object {
+        /** Converts RouVideo API and CDN playlist endpoints to normalized HLS playlist URLs. */
         internal fun normalizePlaylistUrl(url: String): String {
             val httpUrl = VIDEO_ORIGIN.toHttpUrl().resolve(url)
                 ?: throw IllegalArgumentException("Invalid playlist URL")

--- a/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideo.kt
+++ b/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideo.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.all.rouvideo
 
+import aniyomi.lib.m3u8server.M3u8Integration
 import aniyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.animeextension.all.rouvideo.RouVideoDto.toAnimePage
 import eu.kanade.tachiyomi.animeextension.all.rouvideo.RouVideoFilter.ALL_VIDEOS
@@ -70,13 +71,14 @@ class RouVideo(
 
     private val videoHeaders by lazy {
         headers.newBuilder().apply {
-            add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
-            add("Host", apiUrl.toHttpUrl().host)
-            add("Referer", "$videoUrl/")
+            set("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
+            set("Origin", videoUrl)
+            set("Referer", "$videoUrl/")
         }.build()
     }
 
-    private val playlistUtils by lazy { PlaylistUtils(client) }
+    private val playlistUtils by lazy { PlaylistUtils(client, headers) }
+    private val m3u8Integration by lazy { M3u8Integration(client) }
 
     // ============================== Popular ===============================
 
@@ -451,16 +453,22 @@ class RouVideo(
 
     // ============================ Video Links =============================
 
-    override fun videoListRequest(episode: SEpisode) = GET("$apiUrl/$VIDEO_SLUG/${episode.url}", apiHeaders)
+    override fun videoListRequest(episode: SEpisode) = GET(getEpisodeUrl(episode), docHeaders)
 
     override fun videoListParse(response: Response): List<Video> {
-        val jsonStr = response.body.string()
-        val data = json.decodeFromString<RouVideoDto.VideoData>(jsonStr).video
+        val data = response.asJsoup().selectFirst("script#__NEXT_DATA__")?.data()
+            ?: return emptyList()
+        val ev = json.decodeFromString<RouVideoDto.VideoDetails>(data).props.pageProps.ev
+        val video = json.decodeFromString<RouVideoDto.DecodedVideo>(
+            RouVideoDto.decodeVideoData(ev.d, ev.k),
+        )
 
         return playlistUtils.extractFromHls(
-            playlistUrl = data.videoUrl,
+            playlistUrl = normalizePlaylistUrl(video.videoUrl),
             referer = "$videoUrl/",
-        )
+            masterHeaders = playlistUtils.generateMasterHeaders(headers, "$videoUrl/"),
+            videoHeaders = videoHeaders,
+        ).let(m3u8Integration::processVideoList)
     }
 
     // Sorts by quality
@@ -470,8 +478,26 @@ class RouVideo(
 
     private val resolutionRegex = Regex("""Resolution: (\d+)p""")
     companion object {
+        internal fun normalizePlaylistUrl(url: String): String {
+            val httpUrl = VIDEO_ORIGIN.toHttpUrl().resolve(url)
+                ?: throw IllegalArgumentException("Invalid playlist URL")
+            return httpUrl.newBuilder().apply {
+                if (
+                    httpUrl.host == VIDEO_ORIGIN.toHttpUrl().host &&
+                    httpUrl.pathSegments.getOrNull(0) == "api" &&
+                    httpUrl.pathSegments.getOrNull(1) == "hls"
+                ) {
+                    // The fragment is not sent upstream; it only lets M3u8Integration recognize this HLS API URL.
+                    fragment(".m3u8")
+                } else if (httpUrl.pathSegments.lastOrNull() == "index.jpg") {
+                    setPathSegment(httpUrl.pathSize - 1, "index.m3u8")
+                }
+            }.build().toString()
+        }
+
         internal fun resolutionDesc(resolution: String) = "Resolution: ${resolution}p"
 
+        private const val VIDEO_ORIGIN = "https://rou.video"
         private const val VIDEO_SLUG = "v"
         private const val CATEGORY_SLUG = "t"
 

--- a/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoDto.kt
+++ b/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoDto.kt
@@ -147,7 +147,11 @@ internal object RouVideoDto {
         val thumbVTTUrl: String? = null,
     )
 
-    internal fun decodeVideoData(data: String, k: Int): String = Base64.decode(data, Base64.DEFAULT)
+    /** Reverses RouVideo's additive Base64 encoding to recover the video data JSON. */
+    internal fun decodeVideoData(data: String, k: Int): String = decodeVideoData(Base64.decode(data, Base64.DEFAULT), k)
+
+    /** Reverses RouVideo's additive Base64 encoding from decoded bytes. */
+    internal fun decodeVideoData(data: ByteArray, k: Int): String = data
         .map { byte -> ((byte.toInt() and 0xFF) - k).toByte() }
         .toByteArray()
         .toString(Charsets.UTF_8)

--- a/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoDto.kt
+++ b/src/all/rouvideo/src/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoDto.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.all.rouvideo
 
+import android.util.Base64
 import eu.kanade.tachiyomi.animeextension.all.rouvideo.RouVideo.Companion.resolutionDesc
 import eu.kanade.tachiyomi.animeextension.all.rouvideo.RouVideoFilter.SORT_LIKE_KEY
 import eu.kanade.tachiyomi.animeextension.all.rouvideo.RouVideoFilter.SORT_VIEW_KEY
@@ -129,9 +130,27 @@ internal object RouVideoDto {
             data class PagePropsObject(
                 val video: Video,
                 val relatedVideos: List<Video>,
-            )
+                val ev: Ev,
+            ) {
+                @Serializable
+                data class Ev(
+                    val d: String,
+                    val k: Int,
+                )
+            }
         }
     }
+
+    @Serializable
+    data class DecodedVideo(
+        val videoUrl: String,
+        val thumbVTTUrl: String? = null,
+    )
+
+    internal fun decodeVideoData(data: String, k: Int): String = Base64.decode(data, Base64.DEFAULT)
+        .map { byte -> ((byte.toInt() and 0xFF) - k).toByte() }
+        .toByteArray()
+        .toString(Charsets.UTF_8)
 
     @Serializable
     data class Video(
@@ -228,17 +247,6 @@ internal object RouVideoDto {
         val parent: String,
         val level: Int, // usually 0
     )
-
-    @Serializable
-    data class VideoData(
-        val video: VideoObject,
-    ) {
-        @Serializable
-        data class VideoObject(
-            val thumbVTTUrl: String,
-            val videoUrl: String,
-        )
-    }
 
     /* Not available in details */
     @Serializable

--- a/src/all/rouvideo/src/test/kotlin/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoTest.kt
+++ b/src/all/rouvideo/src/test/kotlin/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoTest.kt
@@ -1,0 +1,61 @@
+package eu.kanade.tachiyomi.animeextension.all.rouvideo
+
+import java.util.Base64 as JavaBase64
+import aniyomi.lib.m3u8server.M3u8Integration
+import eu.kanade.tachiyomi.animesource.model.Video
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouVideoTest {
+    @Test
+    fun `decodes offset base64 video data`() {
+        val original = """{"videoUrl":"https://example.com/video.m3u8"}"""
+        val k = 13
+        val encoded = JavaBase64.getEncoder().encodeToString(
+            original.toByteArray(Charsets.UTF_8)
+                .map { byte -> (byte.toInt() + k).toByte() }
+                .toByteArray(),
+        )
+
+        assertEquals(original, RouVideoDto.decodeVideoData(encoded, k))
+    }
+
+    @Test
+    fun `normalizes relative hls endpoint against rouvideo origin`() {
+        assertEquals(
+            "https://rou.video/api/hls/example#.m3u8",
+            RouVideo.normalizePlaylistUrl("/api/hls/example"),
+        )
+    }
+
+    @Test
+    fun `preserves https while converting index jpg playlist urls`() {
+        assertEquals(
+            "https://cdn.example/hls/example/index.m3u8?token=abc",
+            RouVideo.normalizePlaylistUrl("https://cdn.example/hls/example/index.jpg?token=abc"),
+        )
+    }
+
+    @Test
+    fun `routes api hls videos through local m3u8 server`() {
+        val playlistUrl = RouVideo.normalizePlaylistUrl("/api/hls/example")
+        val integration = M3u8Integration(OkHttpClient())
+        try {
+            val video =
+                Video(
+                    url = playlistUrl,
+                    quality = "Video",
+                    videoUrl = playlistUrl,
+                )
+            val processedVideo = integration.processVideoList(listOf(video)).single()
+            val processedUrl = requireNotNull(processedVideo.videoUrl)
+
+            assertTrue(processedUrl.startsWith("http://localhost:"))
+            assertTrue(processedUrl.contains("/m3u8?url="))
+        } finally {
+            runCatching { integration.stopServer() }
+        }
+    }
+}

--- a/src/all/rouvideo/src/test/kotlin/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoTest.kt
+++ b/src/all/rouvideo/src/test/kotlin/eu/kanade/tachiyomi/animeextension/all/rouvideo/RouVideoTest.kt
@@ -1,14 +1,15 @@
 package eu.kanade.tachiyomi.animeextension.all.rouvideo
 
-import java.util.Base64 as JavaBase64
 import aniyomi.lib.m3u8server.M3u8Integration
 import eu.kanade.tachiyomi.animesource.model.Video
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Base64 as JavaBase64
 
 class RouVideoTest {
+    /** Verifies that additive Base64 video data is decoded back to its original JSON. */
     @Test
     fun `decodes offset base64 video data`() {
         val original = """{"videoUrl":"https://example.com/video.m3u8"}"""
@@ -19,9 +20,10 @@ class RouVideoTest {
                 .toByteArray(),
         )
 
-        assertEquals(original, RouVideoDto.decodeVideoData(encoded, k))
+        assertEquals(original, RouVideoDto.decodeVideoData(JavaBase64.getDecoder().decode(encoded), k))
     }
 
+    /** Verifies that a relative RouVideo HLS endpoint resolves against the RouVideo origin. */
     @Test
     fun `normalizes relative hls endpoint against rouvideo origin`() {
         assertEquals(
@@ -30,6 +32,7 @@ class RouVideoTest {
         )
     }
 
+    /** Verifies that an HTTPS CDN index image URL becomes an HTTPS HLS playlist URL. */
     @Test
     fun `preserves https while converting index jpg playlist urls`() {
         assertEquals(
@@ -38,6 +41,7 @@ class RouVideoTest {
         )
     }
 
+    /** Verifies that RouVideo API HLS URLs are routed through the local m3u8 server. */
     @Test
     fun `routes api hls videos through local m3u8 server`() {
         val playlistUrl = RouVideo.normalizePlaylistUrl("/api/hls/example")


### PR DESCRIPTION
## Summary

- Decode RouVideo's current `__NEXT_DATA__` `ev.d`/`ev.k` video payload before extracting the HLS playlist.
- Normalize the site's API and CDN playlist URLs, preserve the required query data, and pass the source headers through `PlaylistUtils` and `M3u8Integration`.
- Add focused regression coverage for payload decoding, URL normalization, and local HLS proxy routing.

## Related issue

Related to #26 (`RouVideo [Multi]: Field 'Video' Required`).

## Validation

- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64 ANDROID_HOME=/usr/lib/android-sdk ANDROID_SDK_ROOT=/usr/lib/android-sdk bash ./gradlew :src:all:rouvideo:test :src:all:rouvideo:assembleDebug` passed.
- Installed the resulting RouVideo v14.18 (versionCode 18) debug APK on an Android device and confirmed normal playback.
- Completed a device download validation; the final file was a valid Matroska video and the temporary download directory was removed.
- `git diff --check` passed, and the final four-file diff received an independent review with no blocking findings.

## Checklist

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions (not applicable; no multisrc extension changed)
- [x] Referenced all related issues in the PR body
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed (not applicable; neither changed)
- [x] Have tested the modifications by compiling and running the extension on an Android device (Gradle debug build and installed playback validation)
- [x] Have removed `web_hi_res_512.png` when adding a new extension (not applicable; this is an existing extension)
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [x] Have made sure all the icons are in png format

## Summary by Sourcery

Fix RouVideo video extraction so HLS playback and downloads work with the site's current video data and playlist endpoints.

Bug Fixes:
- Restore RouVideo HLS playback and downloads by decoding the current embedded video payload and resolving API and CDN playlist URLs correctly.

Enhancements:
- Preserve required playlist and video request headers and route extracted HLS videos through the local M3U8 integration.

Build:
- Update the RouVideo extension version and configure dependencies and source handling for unit tests.

Tests:
- Add regression coverage for video payload decoding, playlist URL normalization, and local HLS proxy routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved RouVideo playback with support for updated video data formats and HLS playlists.
  - Added handling for embedded and encoded video information.
  - Added compatibility with relative, HTTPS, and API-based playlist links.
  - Improved HLS playback through local playlist processing.

- **Bug Fixes**
  - Updated video request handling and URL normalization for more reliable playback.

- **Tests**
  - Added coverage for video decoding, playlist URL handling, and HLS playback routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->