### PR TITLE
MKissa [EN]: Fix stream crypto after site rebuild

### DIFF
--- a/src/en/mkissa/build.gradle
+++ b/src/en/mkissa/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MKissa'
     extClass = '.MKissa'
-    extVersionCode = 65
+    extVersionCode = 66
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissa.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissa.kt
@@ -69,8 +69,6 @@ class MKissa :
     override fun headersBuilder() = super.headersBuilder()
         .set("Referer", "$baseUrl/")
 
-    // ============================== Popular ===============================
-
     override fun popularAnimeRequest(page: Int): Request {
         val variables = buildJsonObject {
             put("type", "anime")
@@ -100,8 +98,6 @@ class MKissa :
         return AnimesPage(animeList, animeList.size == PAGE_SIZE)
     }
 
-    // =============================== Latest ===============================
-
     override fun latestUpdatesRequest(page: Int): Request {
         val variables = buildJsonObject {
             putJsonObject("search") {
@@ -117,8 +113,6 @@ class MKissa :
     }
 
     override fun latestUpdatesParse(response: Response): AnimesPage = parseAnime(response)
-
-    // =============================== Search ===============================
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val filters = MKissaFilters.getSearchParameters(filters)
@@ -167,11 +161,7 @@ class MKissa :
 
     override fun relatedAnimeListParse(response: Response): List<SAnime> = parseAnime(response).animes
 
-    // ============================== Filters ===============================
-
     override fun getFilterList(): AnimeFilterList = MKissaFilters.FILTER_LIST
-
-    // =========================== Anime Details ============================
 
     override fun animeDetailsRequest(anime: SAnime): Request {
         val variables = buildJsonObject {
@@ -205,8 +195,6 @@ class MKissa :
             }
         }
     }
-
-    // ============================== Episodes ==============================
 
     override fun episodeListRequest(anime: SAnime): Request {
         val variables = buildJsonObject {
@@ -242,15 +230,12 @@ class MKissa :
         }
     }
 
-    // ============================ Video Links =============================
-
     private val keyManager by lazy {
         MKissaKeyManager(client, headers, preferences, preferences.siteUrl, apiUrl)
     }
 
     override fun videoListRequest(episode: SEpisode): Request = throw UnsupportedOperationException()
 
-    // videoListRequest no longer yields a usable URL, so point "Open in WebView" at the watch page.
     override fun getEpisodeUrl(episode: SEpisode): String {
         val vars = episode.url.parseAs<EpisodeVariables>().variables
         return "${preferences.siteUrl}/anime/${vars.showId}/p-${vars.episodeString}-${vars.translationType}"
@@ -268,8 +253,6 @@ class MKissa :
             put("aaReq", keyManager.aaReq(material))
         }
 
-        // The text goes out next to the hash so the server can register the query itself rather
-        // than having to already know it; see STREAM_QUERY.
         val url = apiUrl.toHttpUrl().newBuilder()
             .addPathSegment("api")
             .appendGraphQLParams(
@@ -279,7 +262,6 @@ class MKissa :
             )
             .build()
 
-        // The build the token was minted for; the server rejects a mismatch with AA_CRYPTO_BUILD_MISMATCH.
         val streamHeaders = headers.newBuilder().set("x-build-id", material.buildId).build()
 
         return GET(url, streamHeaders)
@@ -306,7 +288,6 @@ class MKissa :
             val sourceName = video.sourceName.lowercase()
 
             val matchingMapping = HOSTER_MAPPINGS.firstOrNull { (altHoster, urlMatches) ->
-                // Fm-Hls lives in the Hoster selection (lowercased); the rest are Alternative Hosts.
                 (hosterSelection.contains(altHoster.lowercase()) || altHosterSelection.contains(altHoster)) &&
                     videoUrl.containsAny(urlMatches)
             }
@@ -338,10 +319,6 @@ class MKissa :
                 }
 
                 sName.startsWith("player@") -> {
-                    // These Yt sources live on the site's CDN (tools.fast4speed.rsvp), which is
-                    // Cloudflare-gated: it streams with a legacy allanime.day Referer and 403s on
-                    // any mkissa one. `set` replaces the base mkissa Referer instead of appending,
-                    // while keeping the client's configured headers (user agent, etc.).
                     val videoHeaders = headers.newBuilder().apply {
                         add("Accept", "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5")
                         set("Referer", "$PLAYER_DOMAIN/")
@@ -389,8 +366,6 @@ class MKissa :
             .let(::prioritySort)
     }
 
-    // ============================= Utilities ==============================
-
     private fun String.decryptSource(): String {
         val (hexPayload, keyType) = when {
             startsWith("--") -> substring(2) to 3
@@ -401,22 +376,27 @@ class MKissa :
             else -> this to null
         }
 
-        val parsedChunks = try {
-            hexPayload.chunked(2).map { it.toInt(16) }
-        } catch (_: NumberFormatException) {
-            return this // Fail fast and return the original string instead of a corrupted decryption
+        if (hexPayload.length % 2 != 0) return this
+        val size = hexPayload.length / 2
+        val bytes = ByteArray(size)
+        for (i in 0 until size) {
+            val hi = hexPayload[i * 2].digitToIntOrNull(16) ?: return this
+            val lo = hexPayload[i * 2 + 1].digitToIntOrNull(16) ?: return this
+            bytes[i] = ((hi shl 4) or lo).toByte()
         }
 
         if (keyType == null) {
-            XOR_MASKS.forEach { mask ->
-                val decrypted = String(CharArray(parsedChunks.size) { i -> ((parsedChunks[i] xor mask) and 0xFF).toChar() })
-                if (decrypted.contains("/clock") || decrypted.contains("http")) return decrypted
+            for (mask in XOR_MASKS) {
+                val chars = CharArray(size) { idx -> ((bytes[idx].toInt() and 0xFF) xor mask).toChar() }
+                val decoded = String(chars)
+                if (decoded.contains("/clock") || decoded.contains("http")) return decoded
             }
             return this
         }
 
         val mask = XOR_MASKS[keyType]
-        return String(CharArray(parsedChunks.size) { i -> ((parsedChunks[i] xor mask) and 0xFF).toChar() })
+        val chars = CharArray(size) { idx -> ((bytes[idx].toInt() and 0xFF) xor mask).toChar() }
+        return String(chars)
     }
 
     private fun prioritySort(pList: List<Pair<Video, Float>>): List<Video> {
@@ -424,8 +404,6 @@ class MKissa :
         val quality = preferences.quality
         val subPref = preferences.subPref
 
-        // Reversed comparator, not reversed list: keeps the sort stable, so equal-key entries stay
-        // in extractor order (highest bitrate first).
         return pList.sortedWith(
             compareBy<Pair<Video, Float>>(
                 { if (prefServer == "site_default") it.second else it.first.quality.contains(prefServer, true) },
@@ -436,7 +414,6 @@ class MKissa :
         ).map { t -> t.first }
     }
 
-    // First match, not the largest: names can end in a bitrate ("Ak - 1080 5 mb/s").
     private fun String.resolution(): Int = RESOLUTION_REGEX.find(this)?.value?.toIntOrNull() ?: 0
 
     private val postHeaders by lazy {
@@ -503,15 +480,12 @@ class MKissa :
         var buildHealed = false
 
         repeat(MAX_KEY_ATTEMPTS) { attempt ->
-            // Obtaining material can itself fail transiently; letting that escape would spend the
-            // whole retry budget on the first attempt.
             val material = runCatching { keyManager.material(forceRefresh = attempt > 0) }
                 .getOrElse {
                     lastError = it
                     return@repeat
                 }
 
-            // Keep the real request error so it's surfaced instead of the generic crypto message.
             val responseBody = runCatching {
                 client.newCall(videoListRequest(episode, material)).awaitSuccess().bodyString()
             }.getOrElse {
@@ -524,10 +498,6 @@ class MKissa :
                     responseBody.parseAs<EncryptedEpisodeResult>().data.tobeparsed
                 }.getOrNull()
 
-                // NEED_CAPTCHA and the rate limiter answer 200 with a null episode and no payload,
-                // which the branches below read as an empty episode or a changed format. Retrying
-                // only deepens the block, and the generic message sends people chasing an extension
-                // update that does not exist.
                 if (tobeparsed.isNullOrBlank()) {
                     keyManager.apiErrorMessage(responseBody)?.let { throw Exception(it) }
                 }
@@ -538,7 +508,6 @@ class MKissa :
                             .getOrNull()
                             ?.let { return it.episode?.sourceUrls.orEmpty() }
                     }
-                    // No payload and no crypto error: an older, unencrypted show.
                     !keyManager.isCryptoError(responseBody) -> {
                         runCatching { responseBody.parseAs<EpisodeResult>().data.episode?.sourceUrls.orEmpty() }
                             .getOrNull()
@@ -546,12 +515,8 @@ class MKissa :
                     }
                 }
 
-                // A response that yields no usable sources means the stream format changed,
-                // not a network fault; record it so the surfaced error reflects this attempt.
                 lastError = encryptionChangedError
 
-                // The bootstrap accepted this build but the streams API did not, so only a rescrape
-                // can help; force one on the next attempt.
                 if (attempt >= 1 && !buildHealed && keyManager.isCryptoError(responseBody)) {
                     keyManager.invalidateBuild()
                     buildHealed = true
@@ -571,8 +536,6 @@ class MKissa :
             "Si-Hls", "S-mp4", "Ac-Hls", "Uv-mp4", "Pn-Hls",
         )
 
-        // Compiled once: the source-name match used to run through a freshly built Regex for every
-        // internal hoster, for every source, on every episode.
         private val INTERNAL_HOSTER_MATCHERS = INTERAL_HOSTER_NAMES.map {
             it.lowercase() to Regex("""\b${Regex.escape(it.lowercase())}\b""")
         }
@@ -583,8 +546,6 @@ class MKissa :
             "okru" to listOf("ok.ru", "okru"),
             "mp4upload" to listOf("mp4upload.com"),
             "streamlare" to listOf("streamlare.com"),
-            // Fm-Hls is Filemoon; the embed domain rotates (bysekoze.com is current), so match the
-            // legacy filemoon domains too.
             "Fm-Hls" to listOf("bysekoze.com", "fastmoon", "filemoon", "moonplayer"),
             "streamwish" to listOf("wish"),
         )
@@ -611,7 +572,6 @@ class MKissa :
         private const val PREF_DOMAIN_DEFAULT = "https://api.mkissa.net"
         private const val LEGACY_API_DOMAIN = "https://api.allanime.day"
 
-        // The site's default iframe host, for the legacy internal/player servers.
         private const val PLAYER_DOMAIN = "https://allanime.day"
 
         private const val PREF_SERVER_KEY = "preferred_server"
@@ -627,7 +587,6 @@ class MKissa :
 
         private const val PREF_HOSTER_KEY = "hoster_selection"
 
-        // Fm-Hls (Filemoon) is a Hoster here, not an Alternative Host, matching the site's layout.
         private val HOSTER_NAMES = INTERAL_HOSTER_NAMES + "Fm-Hls"
         private val PREF_HOSTER_ENTRY_VALUES = HOSTER_NAMES.map {
             it.lowercase()
@@ -662,7 +621,6 @@ class MKissa :
 
         private val RESOLUTION_REGEX = Regex("""\d{3,4}""")
 
-        // XOR keys indexed by source-URL prefix type: '--'=3  '#-'=2  '##'=1  '-#'=4  '#'=0
         private val XOR_KEYS = arrayOf(
             "allanimenews",
             "1234567890123456789",
@@ -675,8 +633,6 @@ class MKissa :
             key.fold(0) { mask, ch -> mask xor ch.code }
         }.toIntArray()
     }
-
-    // ============================== Settings ==============================
 
     @Suppress("UNCHECKED_CAST")
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
@@ -1,25 +1,11 @@
 package eu.kanade.tachiyomi.animeextension.en.mkissa
 
-/**
- * Recovers `buildId` and the four mask seeds from the obfuscated JS chunk. The seeds are lookups
- * into a string table rotated at load time by an amount only the bundle's checksum loop knows, so
- * [parse] tries every rotation and keeps the one whose results all have the seed shape.
- */
 object MKissaBundle {
 
     class BuildInfo(val buildId: String, val seeds: List<String>)
 
     fun parse(js: String): BuildInfo? {
-        // Legacy path: literal buildId like `!== "string" ? "12345" : ""`
-        BUILD_ID_REGEX.find(js)?.groupValues?.get(1)?.let { legacyId ->
-            extractSeeds(js)?.let { seeds -> return BuildInfo(legacyId, seeds) }
-        }
-
-        // New obfuscation: buildId is a decoded string via the same table rotation as seeds,
-        // e.g. `const Mm=zt(520,520)` where the call resolves to "132" after rotation.
-        // We reuse the same table/bases/aliases machinery and brute-force the rotation.
         val (tables, bases, aliases) = decodersFrom(js)
-
         val buildId = extractBuildIdNew(js, tables, bases, aliases) ?: return null
         val seeds = extractSeedsWithTables(js, tables, bases, aliases) ?: return null
         return BuildInfo(buildId, seeds)
@@ -31,13 +17,9 @@ object MKissaBundle {
         bases: Map<String, Base>,
         aliases: Map<String, Alias>,
     ): String? {
-        // Strategy 1: look for the variable used as default param for the mask function F_(e=Mm).
-        // The mask function is the one that takes buildId as default and is later called as F_(_r).
-        // Its name is minified (F_, U_, etc.) but we can find `function F_(e=Mm)` pattern.
         val maskDefaultVar = Regex("""function\s+($IDENT)\s*\(\s*\w+\s*=\s*(\w+)\s*[,)]""").findAll(js)
             .mapNotNull { it.groupValues[2].takeIf(String::isNotEmpty) }
             .firstOrNull { varName ->
-                // The variable should be assigned via a single decoder call near the seed array
                 Regex("""\b${Regex.escape(varName)}\s*=\s*$CALL_PATTERN""").containsMatchIn(js)
             }
 
@@ -45,12 +27,9 @@ object MKissaBundle {
 
         if (maskDefaultVar != null) {
             val assignRegex = Regex("""\b${Regex.escape(maskDefaultVar)}\s*=\s*($CALL_PATTERN)""")
-            assignRegex.findAll(js).forEach { m ->
-                candidates.add(m.groupValues[1])
-            }
+            assignRegex.findAll(js).forEach { m -> candidates.add(m.groupValues[1]) }
         }
 
-        // Fallback: look near `sf=` (seed array) for a preceding single-call assignment
         val sfIndex = js.indexOf("sf=")
         if (sfIndex != -1) {
             val windowStart = (sfIndex - 2000).coerceAtLeast(0)
@@ -58,14 +37,10 @@ object MKissaBundle {
             val assignRegex = Regex("""\b\w+\s*=\s*($CALL_PATTERN)\s*(?:,|;|\n)""")
             assignRegex.findAll(window).forEach { m ->
                 val call = m.groupValues[1]
-                // Exclude the seed array itself which is `=[call+call, ...]`
-                if (!call.contains("+")) {
-                    candidates.add(call)
-                }
+                if (!call.contains("+")) candidates.add(call)
             }
         }
 
-        // Last resort: any single CALL assignment that resolves to digits
         if (candidates.isEmpty()) {
             val assignRegex = Regex("""\b\w+\s*=\s*($CALL_PATTERN)\b""")
             assignRegex.findAll(js).forEach { m ->
@@ -74,26 +49,19 @@ object MKissaBundle {
             }
         }
 
-        // Try each candidate call with every rotation, looking for a numeric buildId
         for (call in candidates) {
-            // Find which table this call belongs to
             val aliasName = CALL_REGEX.find(call)?.groupValues?.get(1) ?: continue
             val alias = aliases[aliasName] ?: continue
             val base = bases[alias.base] ?: continue
             val table = tables[base.table] ?: continue
-
             for (rotation in table.indices) {
                 val decoded = resolve(call, rotation, tables, bases, aliases) ?: continue
-                if (decoded.matches(BUILD_ID_DIGITS_REGEX)) {
-                    // Require that the same rotation also yields valid seeds, to avoid false positives
-                    // (e.g. "211" salt value). Check that seeds resolve under this rotation.
-                    val seedsOk = extractSeedsWithTables(js, tables, bases, aliases, forcedRotation = rotation) != null
-                    if (seedsOk) return decoded
-                }
+                if (!decoded.matches(BUILD_ID_DIGITS_REGEX)) continue
+                val seedsOk = extractSeedsWithTables(js, tables, bases, aliases, forcedRotation = rotation) != null
+                if (seedsOk) return decoded
             }
         }
 
-        // Final fallback: brute-force any CALL that decodes to digits, even if not an assignment
         for (match in CALL_REGEX.findAll(js)) {
             val call = match.value
             if (call.contains("+")) continue
@@ -103,14 +71,11 @@ object MKissaBundle {
             val table = tables[base.table] ?: continue
             for (rotation in table.indices) {
                 val decoded = resolve(call, rotation, tables, bases, aliases) ?: continue
-                if (decoded.matches(BUILD_ID_DIGITS_REGEX) && decoded.length in 2..8) {
-                    // Heuristic: buildId is 2-8 digits, seeds are base64 12 chars with =
-                    // Ensure this call is not part of the seed array (seed array calls are in a `=[...]` context)
-                    val before = js.substring((match.range.first - 20).coerceAtLeast(0), match.range.first)
-                    if (before.contains("sf=") || before.contains("kd=")) continue
-                    if (extractSeedsWithTables(js, tables, bases, aliases, forcedRotation = rotation) == null) continue
-                    return decoded
-                }
+                if (!decoded.matches(BUILD_ID_DIGITS_REGEX) || decoded.length !in 2..8) continue
+                val before = js.substring((match.range.first - 20).coerceAtLeast(0), match.range.first)
+                if (before.contains("sf=") || before.contains("kd=")) continue
+                if (extractSeedsWithTables(js, tables, bases, aliases, forcedRotation = rotation) == null) continue
+                return decoded
             }
         }
         return null
@@ -125,21 +90,14 @@ object MKissaBundle {
             m.groupValues[1] to Base(m.groupValues[4], fold(m.groupValues[3]))
         }
         val aliases = buildMap {
-            // A seed may call a base decoder directly, so each base is its own identity alias.
             bases.keys.forEach { put(it, Alias(it, 0, 0)) }
             ALIAS_DECODER_REGEX.findAll(js).forEach { m ->
                 val (name, firstParam, _, callee, arg, delta) = m.destructured
                 if (callee !in bases) return@forEach
-                // Which parameter the alias forwards tells us where the table index sits.
                 put(name, Alias(callee, if (arg == firstParam) 0 else 1, if (delta.isEmpty()) 0 else fold(delta)))
             }
         }
         return Triple(tables, bases, aliases)
-    }
-
-    private fun extractSeeds(js: String): List<String>? {
-        val (tables, bases, aliases) = decodersFrom(js)
-        return extractSeedsWithTables(js, tables, bases, aliases)
     }
 
     private fun extractSeedsWithTables(
@@ -166,7 +124,6 @@ object MKissaBundle {
             val matches = table.indices.mapNotNull { rotation ->
                 seedsAt(calls, rotation, tables, bases, aliases)
             }
-            // A chance match would silently yield a bad mask, so require an unambiguous answer.
             matches.singleOrNull()?.let { return it }
         }
         return null
@@ -198,13 +155,11 @@ object MKissaBundle {
         val alias = aliases[match.groupValues[1]] ?: return null
         val base = bases[alias.base] ?: return null
         val table = tables[base.table]?.takeIf { it.isNotEmpty() } ?: return null
-
         val args = listOfNotNull(
             match.groupValues[2].toIntOrNull(),
             match.groupValues[3].toIntOrNull(),
         )
         val arg = args.getOrNull(alias.argIndex) ?: return null
-
         val index = arg + alias.delta - base.offset + rotation
         return table[((index % table.size) + table.size) % table.size]
     }
@@ -215,7 +170,6 @@ object MKissaBundle {
         }
     }
 
-    /** Whitelist parser: returns null rather than a partial array if anything unexpected appears. */
     private fun readStringArray(js: String, open: Int): List<String>? {
         val items = mutableListOf<String>()
         var i = open + 1
@@ -245,10 +199,6 @@ object MKissaBundle {
         return null
     }
 
-    /** Folds the `2935+-1459*2` arithmetic every integer is hidden behind; signs stack.
-     *  2025-09: the obfuscator started emitting negative factors (`2461*-4`), which the old
-     *  term scan split mid-product and misread as additions, zeroing every decoder offset.
-     */
     private fun fold(expression: String): Int {
         var total = 0
         for (term in TERM_REGEX.findAll(expression.replace(" ", "")).map(MatchResult::value)) {
@@ -258,8 +208,6 @@ object MKissaBundle {
                 if (body.startsWith('-')) sign = -sign
                 body = body.substring(1)
             }
-
-            // The term sign folds into the first factor, so Int.MIN_VALUE survives parsing.
             var value = parseFactor(sign, body.substringBefore('*')) ?: return 0
             val rest = body.substringAfter('*', "")
             if (rest.isNotEmpty()) {
@@ -270,7 +218,6 @@ object MKissaBundle {
         return total
     }
 
-    /** Signs stack before the digits; parity decides the sign ("2*--4"). */
     private fun parseFactor(sign: Int, factor: String): Int? {
         var negative = sign < 0
         var digits = factor
@@ -283,18 +230,14 @@ object MKissaBundle {
         return if (signed in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) signed.toInt() else null
     }
 
-    private val BUILD_ID_REGEX = Regex("""!==\s*["']string["']\s*\?\s*["'](\d+)["']\s*:\s*["']["']""")
     private val BUILD_ID_DIGITS_REGEX = Regex("""\d{2,10}""")
 
-    // The obfuscator names functions with `$` too (`$l`, `Cr`), which `\w` excludes. The `${'$'}`
-    // interpolation yields the literal dollar sign without starting a template.
     private val IDENT = """[${'$'}A-Za-z0-9_]+"""
 
     private val TABLE_HEAD_REGEX = Regex("""function ($IDENT)\(\)\s*\{\s*(?:const|let|var)\s+$IDENT\s*=\s*\[""")
 
     private val BASE_DECODER_REGEX = Regex("""function ($IDENT)\(($IDENT)(?:,$IDENT)*\)\{return \2=\2-\(?([-\d+*\s]+?)\)?,($IDENT)\(\)\[\2\]\}""")
 
-    // Two parameters exactly: the argIndex logic only distinguishes first from second.
     private val ALIAS_DECODER_REGEX = Regex("""function ($IDENT)\(($IDENT),($IDENT)\)\{return ($IDENT)\(($IDENT)((?:[-+][\d+*\s-]+)?)\)\}""")
 
     private val CALL_PATTERN = """($IDENT)\(\s*(-?\d+)\s*(?:,\s*(-?\d+)\s*)?\)"""
@@ -304,7 +247,5 @@ object MKissaBundle {
 
     private val SEED_REGEX = Regex("""[A-Za-z0-9+/]{11}=""")
 
-    // Leading signs matched greedily; `fold` counts them. Factors may be negative, so the
-    // product is kept inside one term (`2461*-4`) instead of splitting at every sign.
     private val TERM_REGEX = Regex("""[-+]*\d+(?:\*[-+]*\d+)*""")
 }

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaBundle.kt
@@ -26,7 +26,7 @@ object MKissaBundle {
         val candidates = mutableListOf<String>()
 
         if (maskDefaultVar != null) {
-            val assignRegex = Regex("""\b${Regex.escape(maskDefaultVar)}\s*=\s*($CALL_PATTERN)""")
+            val assignRegex = Regex("""\b${Regex.escape(maskDefaultVar)}\s*=\s*($CALL_PATTERN)\s*(?:,|;|\n)""")
             assignRegex.findAll(js).forEach { m -> candidates.add(m.groupValues[1]) }
         }
 
@@ -42,7 +42,7 @@ object MKissaBundle {
         }
 
         if (candidates.isEmpty()) {
-            val assignRegex = Regex("""\b\w+\s*=\s*($CALL_PATTERN)\b""")
+            val assignRegex = Regex("""\b\w+\s*=\s*($CALL_PATTERN)\s*(?:,|;|\n)""")
             assignRegex.findAll(js).forEach { m ->
                 val call = m.groupValues[1]
                 if (!call.contains("+")) candidates.add(call)

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -144,6 +144,7 @@ object MKissaCrypto {
         return hmac(inner, message).toHex()
     }
 
+    /** Legacy `aa-boot` scheme, retained for grace window after a site rebuild. */
     fun bootTokenLegacy(
         mask: ByteArray,
         buildId: String,
@@ -161,6 +162,7 @@ object MKissaCrypto {
         return hmac(inner, message).toHex()
     }
 
+    /** Returns all boot-token candidates in priority order, newest first, for grace-window compatibility. */
     fun bootTokenCandidates(
         mask: ByteArray,
         buildId: String,

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -9,10 +9,6 @@ import javax.crypto.Mac
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-/**
- * Stateless primitives for the "aaReq" scheme, wire layout `[0x01] + iv(12) + AES-GCM(ct‖tag)`.
- * Request token and response payload are both keyed with `clientMask XOR partB`.
- */
 object MKissaCrypto {
 
     private const val TAG_LENGTH = 128
@@ -20,8 +16,6 @@ object MKissaCrypto {
     private const val HMAC_ALGO = "HmacSHA256"
     private const val KEY_TYPE = "AES"
     private const val CIPHER_ALGO = "AES/GCM/NoPadding"
-
-    private const val LEGACY_SECRET = "Xot36i3lK3"
 
     private const val KEY_SIZE = 32
     const val SEED_COUNT = 4
@@ -32,59 +26,48 @@ object MKissaCrypto {
 
     private const val WINDOW_MS = 5 * 60 * 1000L
 
-    // The server derives partB from a 7-day epoch and keeps the previous alive for a day.
     private const val EPOCH_WINDOW_MS = 7 * 24 * 60 * 60 * 1000L
     private const val EPOCH_GRACE_MS = 24 * 60 * 60 * 1000L
 
-    /** Identifies a persisted query: the server hashes the query text the same way. */
+    private const val SALT_MUL = 105
+    private const val SALT_ADD = 199
+    private const val FRAG_MUL = 68
+    private const val FRAG_ADD = 109
+    private const val BOOT_PREFIX = "3CPUb1AFbS:"
+
     fun sha256Hex(value: String): String = MessageDigest.getInstance(HASH_ALGO)
         .digest(value.toByteArray(Charsets.UTF_8))
         .toHex()
 
-    private data class MaskParams(val saltMul: Int, val saltAdd: Int, val fragMul: Int, val fragAdd: Int)
-
-    private val MASK_PARAMS = listOf(
-        MaskParams(105, 199, 68, 109),
-        MaskParams(250, 54, 16, 217),
-        MaskParams(211, 222, 200, 176),
-        MaskParams(17, 31, 41, 7),
-    )
-
-    /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild.
-     *  2025-09: site rotated salts from 250/54/16/217 to 105/199/68/109 (see Gd={saltMul:105,...} in chunk).
-     *  Keep older constants as fallback for a brief grace window.
-     */
     fun maskCandidates(buildId: String, seeds: List<String>): List<ByteArray> {
-        if (buildId.isEmpty() || seeds.size != SEED_COUNT) return emptyList()
-        val candidates = mutableListOf<ByteArray>()
-        for (params in MASK_PARAMS) {
-            val stream = ByteArray(KEY_SIZE) { i ->
-                (buildId[i % buildId.length].code xor ((i * params.saltMul + params.saltAdd) and 0xFF)).toByte()
-            }
-
-            val mask = ByteArray(KEY_SIZE)
-            var ok = true
-            seeds.forEachIndexed { index, seed ->
-                val bytes = runCatching { Base64.decode(seed, Base64.DEFAULT) }.getOrNull()
-                if (bytes == null || bytes.size < SEED_SIZE) {
-                    ok = false
-                    return@forEachIndexed
-                }
-                val base = index * SEED_SIZE
-                for (offset in 0 until SEED_SIZE) {
-                    mask[base + offset] = (
-                        (bytes[offset].toInt() and 0xFF) xor
-                            (stream[base + offset].toInt() and 0xFF) xor
-                            ((index * params.fragMul + offset * params.fragAdd) and 0xFF)
-                        ).toByte()
-                }
-            }
-            if (ok && mask.any { it != 0.toByte() }) candidates.add(mask)
-        }
-        return candidates
+        deriveMask(buildId, seeds)?.let { return listOf(it) }
+        return emptyList()
     }
 
-    fun deriveMask(buildId: String, seeds: List<String>): ByteArray? = maskCandidates(buildId, seeds).firstOrNull()
+    fun deriveMask(buildId: String, seeds: List<String>): ByteArray? {
+        if (buildId.isEmpty() || seeds.size != SEED_COUNT) return null
+
+        val stream = ByteArray(KEY_SIZE) { i ->
+            (buildId[i % buildId.length].code xor ((i * SALT_MUL + SALT_ADD) and 0xFF)).toByte()
+        }
+
+        val mask = ByteArray(KEY_SIZE)
+        for (index in seeds.indices) {
+            val bytes = runCatching { Base64.decode(seeds[index], Base64.DEFAULT) }.getOrNull()
+                ?: return null
+            if (bytes.size < SEED_SIZE) return null
+            val base = index * SEED_SIZE
+            for (offset in 0 until SEED_SIZE) {
+                mask[base + offset] = (
+                    (bytes[offset].toInt() and 0xFF) xor
+                        (stream[base + offset].toInt() and 0xFF) xor
+                        ((index * FRAG_MUL + offset * FRAG_ADD) and 0xFF)
+                    ).toByte()
+            }
+        }
+        if (mask.all { it == 0.toByte() }) return null
+        return mask
+    }
 
     fun deriveKey(mask: ByteArray, partB: ByteArray): SecretKeySpec {
         val keyBytes = ByteArray(KEY_SIZE) { i ->
@@ -93,13 +76,7 @@ object MKissaCrypto {
         return SecretKeySpec(keyBytes, KEY_TYPE)
     }
 
-    /** `x-aa-boot`, checked by the bootstrap endpoint before it hands out `partB`.
-     *  2025-09-30: site changed bootPrefix from "4X2PsZc2r:" to "3CPUb1AFbS:" and message
-     *  from "group.host.lane.buildId.epoch" to "host|epoch|group|lane|buildId"
-     *  (see Gd={bootPrefix:zt(-17,38)+zt(58,3),join:"|",parts:[host,epoch,group,lane,buildId]}).
-     *  We keep the previous formats as fallback for the brief window after a site rebuild.
-     */
-    fun bootTokenCurrent(
+    fun bootToken(
         mask: ByteArray,
         buildId: String,
         epoch: Long,
@@ -107,62 +84,11 @@ object MKissaCrypto {
         refererHost: String,
         lane: String,
     ): String {
-        val inner = hmac(mask, "3CPUb1AFbS:$buildId")
-        // Gd.parts = ["host","epoch","group","lane","buildId"], Gd.join = "|"
-        // omitEmptyLane = false, so always include lane even if empty
+        val inner = hmac(mask, "$BOOT_PREFIX$buildId")
         val message = listOf(refererHost, epoch.toString(), keyGroup, lane, buildId).joinToString("|")
         return hmac(inner, message).toHex()
     }
 
-    /** 2025-09 scheme, kept for the grace window after a rebuild. */
-    fun bootTokenNew(
-        mask: ByteArray,
-        buildId: String,
-        epoch: Long,
-        keyGroup: String,
-        refererHost: String,
-        lane: String,
-    ): String {
-        val inner = hmac(mask, "4X2PsZc2r:$buildId")
-        // Fd.parts = ["group","host","lane","buildId","epoch"], Fd.join = "."
-        // omitEmptyLane = false, so always include lane even if empty
-        val message = listOf(keyGroup, refererHost, lane, buildId, epoch.toString()).joinToString(".")
-        return hmac(inner, message).toHex()
-    }
-
-    /** 2025-08 scheme, kept for the grace window after a rebuild. */
-    fun bootTokenPrevious(
-        mask: ByteArray,
-        buildId: String,
-        epoch: Long,
-        keyGroup: String,
-        refererHost: String,
-        lane: String,
-    ): String {
-        val inner = hmac(mask, "kNk1YgwkSI:$buildId")
-        val message = listOf(epoch.toString(), keyGroup, refererHost, buildId, lane).joinToString(".")
-        return hmac(inner, message).toHex()
-    }
-
-    /** Legacy `aa-boot` scheme, retained for grace window after a site rebuild. */
-    fun bootTokenLegacy(
-        mask: ByteArray,
-        buildId: String,
-        epoch: Long,
-        keyGroup: String,
-        refererHost: String,
-        lane: String,
-    ): String {
-        val inner = hmac(mask, "aa-boot:$buildId")
-        val message = buildString {
-            append(buildId).append(':').append(keyGroup).append(':')
-            append(refererHost).append(':').append(epoch)
-            if (lane.isNotEmpty()) append(':').append(lane)
-        }
-        return hmac(inner, message).toHex()
-    }
-
-    /** Returns all boot-token candidates in priority order, newest first, for grace-window compatibility. */
     fun bootTokenCandidates(
         mask: ByteArray,
         buildId: String,
@@ -170,21 +96,14 @@ object MKissaCrypto {
         keyGroup: String,
         refererHost: String,
         lane: String,
-    ): List<String> = listOf(
-        bootTokenCurrent(mask, buildId, epoch, keyGroup, refererHost, lane),
-        bootTokenNew(mask, buildId, epoch, keyGroup, refererHost, lane),
-        bootTokenPrevious(mask, buildId, epoch, keyGroup, refererHost, lane),
-        bootTokenLegacy(mask, buildId, epoch, keyGroup, refererHost, lane),
-    )
+    ): List<String> = listOf(bootToken(mask, buildId, epoch, keyGroup, refererHost, lane))
 
-    /** Oldest first: during the grace window the server still mints `partB` for the previous. */
     fun epochCandidates(now: Long = System.currentTimeMillis()): List<Long> {
         val current = now / EPOCH_WINDOW_MS
         val inGrace = now - current * EPOCH_WINDOW_MS < EPOCH_GRACE_MS && current > 0
         return if (inGrace) listOf(current - 1, current) else listOf(current)
     }
 
-    /** Fallback for a device clock off by more than the grace window. */
     fun skewedEpochCandidates(now: Long = System.currentTimeMillis()): List<Long> {
         val current = now / EPOCH_WINDOW_MS
         return listOf(current + 1, current - 1).filter { it > 0 } - epochCandidates(now).toSet()
@@ -192,52 +111,34 @@ object MKissaCrypto {
 
     fun buildAaReq(key: SecretKeySpec, epoch: Long, buildId: String, queryHash: String, lane: String): String {
         val ts = System.currentTimeMillis() / WINDOW_MS * WINDOW_MS
-
-        // Derived, not random: the server recomputes the same one to decrypt.
         val iv = MessageDigest.getInstance(HASH_ALGO)
             .digest("$epoch:$buildId:$queryHash:$ts:$lane".toByteArray(Charsets.UTF_8))
             .copyOfRange(0, IV_SIZE)
-
         val payload = AaReqPayload(v = 1, ts = ts, epoch = epoch, buildId = buildId, qh = queryHash, k = lane).toJsonString()
-
         val cipher = Cipher.getInstance(CIPHER_ALGO)
         cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH, iv))
         val ciphertext = cipher.doFinal(payload.toByteArray(Charsets.UTF_8))
-
         val blob = ByteArray(HEADER_SIZE + ciphertext.size)
         blob[0] = 1
         System.arraycopy(iv, 0, blob, 1, IV_SIZE)
         System.arraycopy(ciphertext, 0, blob, HEADER_SIZE, ciphertext.size)
-
         return Base64.encodeToString(blob, Base64.NO_WRAP)
     }
 
     fun decrypt(base64Payload: String, materialKey: SecretKeySpec): String? {
         val blob = runCatching { Base64.decode(base64Payload, Base64.DEFAULT) }.getOrNull() ?: return null
         if (blob.size < HEADER_SIZE) return null
-
-        val version = blob[0].toInt() and 0xFF
         val iv = blob.sliceArray(1 until HEADER_SIZE)
         val encryptedData = blob.sliceArray(HEADER_SIZE until blob.size)
-
-        for (key in listOf(materialKey, legacyKey(version))) {
-            runCatching {
-                val cipher = Cipher.getInstance(CIPHER_ALGO)
-                cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH, iv))
-                String(cipher.doFinal(encryptedData), Charsets.UTF_8)
-            }.getOrNull()?.let { return it }
-        }
-        return null
+        return runCatching {
+            val cipher = Cipher.getInstance(CIPHER_ALGO)
+            cipher.init(Cipher.DECRYPT_MODE, materialKey, GCMParameterSpec(TAG_LENGTH, iv))
+            String(cipher.doFinal(encryptedData), Charsets.UTF_8)
+        }.getOrNull()
     }
 
     private fun hmac(key: ByteArray, message: String): ByteArray = Mac.getInstance(HMAC_ALGO).run {
         init(SecretKeySpec(key, HMAC_ALGO))
         doFinal(message.toByteArray(Charsets.UTF_8))
-    }
-
-    private fun legacyKey(version: Int): SecretKeySpec {
-        val bytes = MessageDigest.getInstance(HASH_ALGO)
-            .digest("$LEGACY_SECRET:v$version".toByteArray(Charsets.UTF_8))
-        return SecretKeySpec(bytes, KEY_TYPE)
     }
 }

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaCrypto.kt
@@ -44,13 +44,14 @@ object MKissaCrypto {
     private data class MaskParams(val saltMul: Int, val saltAdd: Int, val fragMul: Int, val fragAdd: Int)
 
     private val MASK_PARAMS = listOf(
+        MaskParams(105, 199, 68, 109),
         MaskParams(250, 54, 16, 217),
         MaskParams(211, 222, 200, 176),
         MaskParams(17, 31, 41, 7),
     )
 
     /** `seeds XOR f(buildId) XOR f(position)`; both inputs change on every site rebuild.
-     *  2025-09: site rotated salts from 211/222/200/176 to 250/54/16/217 (see Fd={saltMul:250,...} in chunk).
+     *  2025-09: site rotated salts from 250/54/16/217 to 105/199/68/109 (see Gd={saltMul:105,...} in chunk).
      *  Keep older constants as fallback for a brief grace window.
      */
     fun maskCandidates(buildId: String, seeds: List<String>): List<ByteArray> {
@@ -93,11 +94,27 @@ object MKissaCrypto {
     }
 
     /** `x-aa-boot`, checked by the bootstrap endpoint before it hands out `partB`.
-     *  2025-09: site changed bootPrefix from "kNk1YgwkSI:" to "4X2PsZc2r:" and message
-     *  from "epoch.group.host.buildId.lane" to "group.host.lane.buildId.epoch"
-     *  (see Fd={bootPrefix:"4X2PsZc2r:",join:".",parts:[group,host,lane,buildId,epoch]}).
+     *  2025-09-30: site changed bootPrefix from "4X2PsZc2r:" to "3CPUb1AFbS:" and message
+     *  from "group.host.lane.buildId.epoch" to "host|epoch|group|lane|buildId"
+     *  (see Gd={bootPrefix:zt(-17,38)+zt(58,3),join:"|",parts:[host,epoch,group,lane,buildId]}).
      *  We keep the previous formats as fallback for the brief window after a site rebuild.
      */
+    fun bootTokenCurrent(
+        mask: ByteArray,
+        buildId: String,
+        epoch: Long,
+        keyGroup: String,
+        refererHost: String,
+        lane: String,
+    ): String {
+        val inner = hmac(mask, "3CPUb1AFbS:$buildId")
+        // Gd.parts = ["host","epoch","group","lane","buildId"], Gd.join = "|"
+        // omitEmptyLane = false, so always include lane even if empty
+        val message = listOf(refererHost, epoch.toString(), keyGroup, lane, buildId).joinToString("|")
+        return hmac(inner, message).toHex()
+    }
+
+    /** 2025-09 scheme, kept for the grace window after a rebuild. */
     fun bootTokenNew(
         mask: ByteArray,
         buildId: String,
@@ -107,7 +124,7 @@ object MKissaCrypto {
         lane: String,
     ): String {
         val inner = hmac(mask, "4X2PsZc2r:$buildId")
-        // kd.parts = ["group","host","lane","buildId","epoch"], kd.join = "."
+        // Fd.parts = ["group","host","lane","buildId","epoch"], Fd.join = "."
         // omitEmptyLane = false, so always include lane even if empty
         val message = listOf(keyGroup, refererHost, lane, buildId, epoch.toString()).joinToString(".")
         return hmac(inner, message).toHex()
@@ -152,6 +169,7 @@ object MKissaCrypto {
         refererHost: String,
         lane: String,
     ): List<String> = listOf(
+        bootTokenCurrent(mask, buildId, epoch, keyGroup, refererHost, lane),
         bootTokenNew(mask, buildId, epoch, keyGroup, refererHost, lane),
         bootTokenPrevious(mask, buildId, epoch, keyGroup, refererHost, lane),
         bootTokenLegacy(mask, buildId, epoch, keyGroup, refererHost, lane),

--- a/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
+++ b/src/en/mkissa/src/eu/kanade/tachiyomi/animeextension/en/mkissa/MKissaKeyManager.kt
@@ -16,11 +16,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import javax.crypto.spec.SecretKeySpec
 
-/**
- * Owns the "aaReq" key material: `buildId` + mask seeds are scraped from the live JS bundle and
- * fold into the client mask, which signs the bootstrap request for `partB`; the key is
- * `mask XOR partB`.
- */
 class MKissaKeyManager(
     private val client: OkHttpClient,
     private val headers: Headers,
@@ -41,7 +36,6 @@ class MKissaKeyManager(
     private var cachedMaterial: Material? = null
     private val materialMutex = Mutex()
 
-    // One preference, so a concurrent write cannot pair one build's id with another's seeds.
     private var storedBuild by preferences.delegate(PREF_BUILD_KEY, "")
 
     suspend fun material(forceRefresh: Boolean = false): Material {
@@ -61,10 +55,8 @@ class MKissaKeyManager(
                 .getOrElse { throw Exception(MATERIAL_ERROR) }
             require(partB.size >= 32) { MATERIAL_ERROR }
 
-            // Only after the server accepted it, so a bad parse cannot wedge every later launch.
             storedBuild = handshake.build.serialize()
 
-            // Not the bootstrap's switchAt: it can already be past while the epoch is live.
             val now = System.currentTimeMillis()
             Material(
                 key = MKissaCrypto.deriveKey(handshake.mask, partB),
@@ -84,7 +76,6 @@ class MKissaKeyManager(
         cachedMaterial = null
     }
 
-    /** Used when the streams API rejects a token the bootstrap minted, which it cannot detect. */
     fun invalidateBuild() {
         storedBuild = ""
         cachedMaterial = null
@@ -93,17 +84,11 @@ class MKissaKeyManager(
     fun isCryptoError(body: String): Boolean = runCatching { body.parseAs<AaApiError>().errors }.getOrNull()
         ?.any { it.extensions?.code?.startsWith("AA_CRYPTO") == true } == true
 
-    /**
-     * The server's own complaint — a captcha gate, a rate limit — for responses it refuses outright.
-     * Null while a crypto error is present, since fresh material can still rescue those.
-     */
     fun apiErrorMessage(body: String): String? {
         if (isCryptoError(body)) return null
         val message = runCatching { body.parseAs<AaApiError>().errors }.getOrNull()
             ?.firstNotNullOfOrNull { it.message }
             ?: return null
-        // The bare code says nothing to someone whose episode just refused to load, and the gate is
-        // on the network rather than the account, so there is nothing to sign in to or re-install.
         return if (message == CAPTCHA_ERROR) {
             "MKissa is rate limiting this network ($CAPTCHA_ERROR). Browsing still works; " +
                 "streams should return on their own after a while."
@@ -118,37 +103,32 @@ class MKissaKeyManager(
         val bootstrap: AaCryptoBootstrap,
     )
 
-    /** [stale] distinguishes "server refused this build" from a network fault. */
     private class BootstrapResult(
         val bootstrap: AaCryptoBootstrap?,
         val stale: Boolean,
         val mask: ByteArray? = null,
     )
 
-    /** Re-scraping starts at the Cloudflare-gated HTML, so cheaper causes are ruled out first. */
     private suspend fun handshake(): Handshake? {
         val cached = cachedBuild()
-        val cachedMasks = cached?.let { MKissaCrypto.maskCandidates(it.buildId, it.seeds) }
+        val cachedMask = cached?.let { MKissaCrypto.deriveMask(it.buildId, it.seeds) }
 
-        if (cached != null && cachedMasks != null && cachedMasks.isNotEmpty()) {
-            val first = bootstrap(cached.buildId, cachedMasks, MKissaCrypto.epochCandidates())
-            first.bootstrap?.let { return Handshake(cached, first.mask!!, it) }
+        if (cached != null && cachedMask != null) {
+            val first = bootstrap(cached.buildId, cachedMask, MKissaCrypto.epochCandidates())
+            first.bootstrap?.let { return Handshake(cached, cachedMask, it) }
             if (!first.stale) return null
 
-            // A clock off by more than the grace window looks exactly like a stale build.
-            val second = bootstrap(cached.buildId, cachedMasks, MKissaCrypto.skewedEpochCandidates())
-            second.bootstrap?.let { return Handshake(cached, second.mask!!, it) }
+            val second = bootstrap(cached.buildId, cachedMask, MKissaCrypto.skewedEpochCandidates())
+            second.bootstrap?.let { return Handshake(cached, cachedMask, it) }
         }
 
         val fresh = resolveBuild() ?: return null
-        val freshMasks = MKissaCrypto.maskCandidates(fresh.buildId, fresh.seeds)
-        if (freshMasks.isEmpty()) return null
-        val freshResult = bootstrap(fresh.buildId, freshMasks, MKissaCrypto.epochCandidates())
-        return freshResult.bootstrap?.let { Handshake(fresh, freshResult.mask!!, it) }
+        val freshMask = MKissaCrypto.deriveMask(fresh.buildId, fresh.seeds) ?: return null
+        val freshResult = bootstrap(fresh.buildId, freshMask, MKissaCrypto.epochCandidates())
+        return freshResult.bootstrap?.let { Handshake(fresh, freshMask, it) }
     }
 
-    /** `GET /client-crypto/v1/bootstrap?buildId=&k=`, gated by an HMAC of the client mask. */
-    private suspend fun bootstrap(buildId: String, masks: List<ByteArray>, epochs: List<Long>): BootstrapResult {
+    private suspend fun bootstrap(buildId: String, mask: ByteArray, epochs: List<Long>): BootstrapResult {
         val host = siteUrl.toHttpUrl().host
         val url = "${apiUrl.trimEnd('/')}$BOOTSTRAP_PATH".toHttpUrl().newBuilder()
             .addQueryParameter("buildId", buildId)
@@ -156,36 +136,30 @@ class MKissaKeyManager(
             .build()
 
         var sawStale = false
-        for (mask in masks) {
-            for (epoch in epochs) {
-                var epochStale = false
-                for (bootToken in MKissaCrypto.bootTokenCandidates(mask, buildId, epoch, KEY_GROUP, host, ANIME_LANE)) {
-                    val requestHeaders = headers.newBuilder()
-                        .set("x-build-id", buildId)
-                        .set("x-aa-boot", bootToken)
-                        .set("Origin", siteUrl)
-                        .set("Referer", "$siteUrl/")
-                        .build()
+        for (epoch in epochs) {
+            val bootToken = MKissaCrypto.bootToken(mask, buildId, epoch, KEY_GROUP, host, ANIME_LANE)
+            val requestHeaders = headers.newBuilder()
+                .set("x-build-id", buildId)
+                .set("x-aa-boot", bootToken)
+                .set("Origin", siteUrl)
+                .set("Referer", "$siteUrl/")
+                .build()
 
-                    val response = runCatching { client.newCall(GET(url, requestHeaders)).await() }.getOrNull()
-                        ?: return BootstrapResult(null, stale = false)
+            val response = runCatching { client.newCall(GET(url, requestHeaders)).await() }.getOrNull()
+                ?: return BootstrapResult(null, stale = false)
 
-                    if (!response.isSuccessful) {
-                        response.close()
-                        if (response.code in STALE_CODES) epochStale = true
-                        continue
-                    }
-
-                    val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
-                        ?: continue
-
-                    // A partB from another lane would silently derive the wrong key.
-                    if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
-
-                    return BootstrapResult(bootstrap, stale = false, mask = mask)
-                }
-                if (epochStale) sawStale = true
+            if (!response.isSuccessful) {
+                response.close()
+                if (response.code in STALE_CODES) sawStale = true
+                continue
             }
+
+            val bootstrap = runCatching { response.parseAs<AaCryptoBootstrap>() }.getOrNull()
+                ?: continue
+
+            if (bootstrap.k != null && bootstrap.k != ANIME_LANE) continue
+
+            return BootstrapResult(bootstrap, stale = false, mask = mask)
         }
         return BootstrapResult(null, stale = sawStale)
     }
@@ -197,7 +171,6 @@ class MKissaKeyManager(
         return MKissaBundle.BuildInfo(buildId, seeds)
     }
 
-    /** The entry is re-read every time: chunk URLs are immutable, so a rebuild only shows in HTML. */
     private suspend fun resolveBuild(): MKissaBundle.BuildInfo? {
         val appUrl = entryUrlFromSite()?.toHttpUrl() ?: return null
 
@@ -205,7 +178,6 @@ class MKissaKeyManager(
             client.newCall(GET(appUrl, headers)).awaitSuccess().bodyString()
         }.getOrNull() ?: return null
 
-        // Shared chunks first: that is where it has always lived.
         val chunkRefs = CHUNK_REF_REGEX.findAll(appJs)
             .map { it.groupValues[1] }
             .distinct()
@@ -213,9 +185,6 @@ class MKissaKeyManager(
             .take(MAX_BUILD_CHUNKS)
             .toList()
 
-        // In batches rather than all at once: the chunks run to about a megabyte each, so fetching
-        // the whole list in parallel would pull tens of megabytes to use one of them, while walking
-        // them one at a time pays a full round trip per miss.
         for (batch in chunkRefs.chunked(BUILD_CHUNK_BATCH)) {
             val found = batch.parallelCatchingMapNotNull { ref ->
                 val chunkUrl = appUrl.resolve(ref) ?: return@parallelCatchingMapNotNull null
@@ -223,13 +192,11 @@ class MKissaKeyManager(
                 if (!body.contains(CRYPTO_CHUNK_MARKER)) return@parallelCatchingMapNotNull null
                 MKissaBundle.parse(body)
             }
-            // Order is preserved, so this stays the first hit in the site's own chunk order.
             found.firstOrNull()?.let { return it }
         }
         return null
     }
 
-    /** Cloudflare-gated; only needed to locate the CDN app entry. */
     private suspend fun entryUrlFromSite(): String? {
         val html = runCatching {
             client.newCall(GET("$siteUrl/", headers)).awaitSuccess().bodyString()
@@ -249,10 +216,8 @@ class MKissaKeyManager(
 
         private const val BOOTSTRAP_PATH = "/client-crypto/v1/bootstrap"
 
-        // 403 invalid_boot_token, 404 unknown_build_id.
         private val STALE_CODES = setOf(403, 404)
 
-        // The site buckets its hosts; adding a mirror to the domain pref means revisiting this.
         private const val KEY_GROUP = "mkissa"
 
         private const val PREF_BUILD_KEY = "client_build_cache"


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Closes #815

**Changes**

- Keep single current crypto params (`saltMul 105/199/68/109`, `bootPrefix 3CPUb1AFbS:` with `host|epoch|group|lane|buildId` join `|`) and remove legacy salts/tokens (`250/54`, `211/222`, `17/31`, `4X2PsZc2r:`, `kNk1...`, `aa-boot`) and `LEGACY_SECRET` fallback
- Remove date references and verbose logic comments that duplicate code; clean `MKissaBundle`/`MKissaKeyManager`/`MKissa` comments
- Simplify `maskCandidates`/`deriveMask` to single candidate (was 4) and `bootstrap` to single mask/token per epoch (was up to 32 requests)
- Remove decrypt legacy-key path, optimize AES-GCM and `decryptSource` hex parsing (direct byte array, no intermediate strings)

**Verification**

- `MKissaBundle.parse` extracts `buildId=150` and seeds at rotation 37
- `maskDerived` matches browser `importKey` for current build
- `bootToken` for `epoch` matches live bootstrap request and `GET /client-crypto/v1/bootstrap?buildId=150&k=k7` returns `partB`
- `./gradlew :src:en:mkissa:spotlessCheck` and `:src:en:mkissa:assembleDebug` BUILD SUCCESSFUL

Tracker: https://yuzono-tracker.7he.dev/report/485

## Summary by Sourcery

Restore MKissa stream decryption after the site rebuild by aligning the extension with the current crypto protocol and simplifying key negotiation.

Bug Fixes:
- Update MKissa stream cryptography to match the site's current post-rebuild crypto parameters and bootstrap token format.
- Remove obsolete crypto fallbacks so stream key negotiation uses the current protocol reliably.

Enhancements:
- Reduce crypto negotiation to a single derived mask and bootstrap request per epoch, improving stream loading efficiency.
- Simplify source decryption and bundle parsing while retaining support for the current build metadata format.
- Remove outdated implementation comments and legacy parsing, token, salt, and decryption paths.

Build:
- Increment the MKissa extension version code to 66.

Tests:
- Verify current build and crypto material against the live MKissa service and confirm formatting and debug assembly succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated MKissa authentication to support the latest security parameters and token formats.
  * Improved compatibility with current site protection mechanisms.

* **Bug Fixes**
  * Refined encrypted content handling and build identification for more reliable loading.
  * Improved authentication reliability across session timing and security-setting changes.
  * Enhanced handling of invalid or malformed encrypted responses.

* **Chores**
  * Increased the MKissa extension version to deliver these updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->