### PR TITLE
Anikage [EN]: Update API Domain

### DIFF
--- a/src/en/anikage/build.gradle
+++ b/src/en/anikage/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anikage'
     extClass = '.Anikage'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = true
 }
 

--- a/src/en/anikage/src/eu/kanade/tachiyomi/animeextension/en/anikage/Anikage.kt
+++ b/src/en/anikage/src/eu/kanade/tachiyomi/animeextension/en/anikage/Anikage.kt
@@ -324,7 +324,7 @@ class Anikage :
                 .parseAs<EpisodeSource>()
 
             val tracks = episodeData.subtitles.map {
-                Track("https://gg.akage.lol/m3u8/${it.file}", it.label)
+                Track("https://og.bakayaro.live/stream/${it.file}", it.label)
             }
 
             val videos = episodeData.sources.parallelCatchingFlatMap { source ->

--- a/src/en/anikage/src/eu/kanade/tachiyomi/animeextension/en/anikage/Dto.kt
+++ b/src/en/anikage/src/eu/kanade/tachiyomi/animeextension/en/anikage/Dto.kt
@@ -186,7 +186,7 @@ data class SourceData(
     val type: String?,
 ) {
     fun episodeSourceUrl(): String = listOfNotNull(
-        "https://gg.akage.lol",
+        "https://og.bakayaro.live",
         isM3U8?.let { "m3u8" } ?: "stream",
         url,
     ).joinToString("/")
@@ -197,7 +197,7 @@ data class SubtitleData(
     val file: String,
     val label: String,
     val kind: String,
-    val default: Boolean,
+    val default: Boolean? = null,
     val embedUrl: String? = null,
 )
 

--- a/src/en/anikage/src/eu/kanade/tachiyomi/animeextension/en/anikage/Dto.kt
+++ b/src/en/anikage/src/eu/kanade/tachiyomi/animeextension/en/anikage/Dto.kt
@@ -187,7 +187,7 @@ data class SourceData(
 ) {
     fun episodeSourceUrl(): String = listOfNotNull(
         "https://og.bakayaro.live",
-        isM3U8?.let { "m3u8" } ?: "stream",
+        if (isM3U8 == true) "m3u8" else "stream",
         url,
     ).joinToString("/")
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

closes : #860

## Summary by Sourcery

Restore Anikage media playback compatibility with the updated streaming service.

Bug Fixes:
- Update Anikage playback and subtitle handling to support the service’s new streaming endpoints and optional subtitle defaults.

Build:
- Increment the Anikage extension version code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Anikage video and subtitle links to use the current streaming host.
  * Improved compatibility with subtitle data when a default subtitle track is not specified.
* **Chores**
  * Incremented the Anikage extension version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->