### PR TITLE
fix: Don't clearing all apks when manually skipping build

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -27,7 +27,6 @@ jobs:
       matrix: ${{ steps.generate-matrices.outputs.matrix }}
       delete: ${{ steps.generate-matrices.outputs.delete }}
       skipBump: ${{ steps.set-env.outputs.SKIP_BUMP }}
-      skipBuild: ${{ steps.set-env.outputs.SKIP_BUILD }}
     steps:
       - name: Checkout PR
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,7 +46,8 @@ jobs:
 
           # Commit message markers:
           #   [skip bumping version] -> skip the version bumping step only
-          #   [skip yuzono ci]       -> skip the version bumping step and the build job
+          #   [skip yuzono ci]       -> skip the version bumping step and emit empty
+          #                             build matrices, so the build job does not run
           skip_bump=false
           skip_build=false
           case "$LATEST_COMMIT_MESSAGE" in
@@ -86,15 +86,23 @@ jobs:
 
       - id: generate-matrices
         name: Generate build matrices
+        env:
+          SKIP_BUILD: ${{ steps.set-env.outputs.SKIP_BUILD }}
         run: |
-          python ./.github/scripts/generate-build-matrices.py origin/master ${{ secrets.SIGNING_KEY != '' && 'Release' || 'Debug' }}
+          if [ "$SKIP_BUILD" = "true" ]; then
+            echo "Skipping build: emitting empty matrices."
+            echo 'matrix={"chunk":[]}' >> $GITHUB_OUTPUT
+            echo 'delete=[]' >> $GITHUB_OUTPUT
+          else
+            python ./.github/scripts/generate-build-matrices.py origin/master ${{ secrets.SIGNING_KEY != '' && 'Release' || 'Debug' }}
+          fi
 
   build:
     name: Build extensions (${{ matrix.chunk.number }})
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ needs.prepare.outputs.skipBuild != 'true' && toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
+    if: ${{ toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -35,7 +35,6 @@ jobs:
       matrix: ${{ steps.generate-matrices.outputs.matrix }}
       delete: ${{ steps.generate-matrices.outputs.delete }}
       skipBump: ${{ steps.set-env.outputs.SKIP_BUMP }}
-      skipBuild: ${{ steps.set-env.outputs.SKIP_BUILD }}
     steps:
       - name: Checkout ${{ github.ref_name }} branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,7 +53,8 @@ jobs:
 
           # Commit message markers:
           #   [skip bumping version] -> skip the version bumping step only
-          #   [skip yuzono ci]       -> skip the version bumping step and the build job
+          #   [skip yuzono ci]       -> skip the version bumping step and emit empty
+          #                             build matrices, so the build job does not run
           skip_bump=false
           skip_build=false
           case "$LATEST_COMMIT_MESSAGE" in
@@ -102,15 +102,23 @@ jobs:
 
       - id: generate-matrices
         name: Create output matrices
+        env:
+          SKIP_BUILD: ${{ steps.set-env.outputs.SKIP_BUILD }}
         run: |
-          python ./.github/scripts/generate-build-matrices.py "$NX_BASE" Release
+          if [ "$SKIP_BUILD" = "true" ]; then
+            echo "Skipping build: emitting empty matrices."
+            echo 'matrix={"chunk":[]}' >> $GITHUB_OUTPUT
+            echo 'delete=[]' >> $GITHUB_OUTPUT
+          else
+            python ./.github/scripts/generate-build-matrices.py "$NX_BASE" Release
+          fi
 
   build:
     name: Build extensions (${{ matrix.chunk.number }})
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ needs.prepare.outputs.skipBuild != 'true' && toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
+    if: ${{ toJson(fromJson(needs.prepare.outputs.matrix).chunk) != '[]' }}
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:


### PR DESCRIPTION
## Summary by Sourcery

Prevent manually skipped builds from deleting existing APKs by generating empty build and deletion matrices.

Bug Fixes:
- Prevent manually skipped builds from clearing all APKs by emitting empty build and deletion matrices.

Enhancements:
- Align pull request and push workflows so build skipping is controlled through empty matrices rather than a separate build-job condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of commits marked to skip CI, preventing unnecessary build and cleanup jobs from running.
  * Ensured builds run only when there is work to process, making CI execution more efficient and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->