### PR TITLE
Animeito [PT]: Fix 'No Available Videos'

### DIFF
--- a/src/pt/animeito/build.gradle
+++ b/src/pt/animeito/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.AnimeIto'
     themePkg = 'animestream'
     baseUrl = 'https://animesonline.io'
-    overrideVersionCode = 7
+    overrideVersionCode = 8
 }
 
 apply plugin: "kei.plugins.extension.legacy"

--- a/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/AnimeIto.kt
+++ b/src/pt/animeito/src/eu/kanade/tachiyomi/animeextension/pt/animeito/AnimeIto.kt
@@ -11,7 +11,6 @@ class AnimeIto :
         "Animeito",
         "https://animesonline.io",
     ) {
-    override fun headersBuilder() = super.headersBuilder().add("Referer", baseUrl)
 
     // ============================ Video Links =============================
     override val prefQualityValues = listOf("1080p", "720p", "480p", "360p", "240p")


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] This PR is AI-assisted, I have reviewed the changes manually and confirmed they are not slop
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/anime-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Fix Animeito video extraction so available videos can be loaded again.

Bug Fixes:
- Restore video availability for Animeito by updating its source request configuration.

Build:
- Bump the Animeito extension version code.