### PR TITLE
feat(stremio): Support `Hoster` and various fixes

### DIFF
--- a/src/all/stremio/build.gradle
+++ b/src/all/stremio/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Stremio'
     extClass = '.Stremio'
-    extVersionCode = 9
+    extVersionCode = 10
     extNames = ["Stremio"]
 }
 

--- a/src/all/stremio/build.gradle
+++ b/src/all/stremio/build.gradle
@@ -1,6 +1,7 @@
 ext {
     extName = 'Stremio'
     extClass = '.Stremio'
+    libVersion = '16'
     extVersionCode = 10
     extNames = ["Stremio"]
 }

--- a/src/all/stremio/build.gradle
+++ b/src/all/stremio/build.gradle
@@ -1,7 +1,6 @@
 ext {
     extName = 'Stremio'
     extClass = '.Stremio'
-    libVersion = '16'
     extVersionCode = 10
     extNames = ["Stremio"]
 }

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
@@ -67,7 +67,7 @@ data class MetaDto(
     @Serializable(with = ObjectToListSerializer::class)
     val director: List<String>? = null,
     val cast: List<String>? = null,
-    val year: String? = null,
+    val releaseInfo: String? = null,
 
     // Episodes
     val videos: List<VideoDto>? = null,
@@ -87,12 +87,12 @@ data class MetaDto(
         description = buildString {
             append(this@MetaDto.description ?: "")
             append("\n\n")
-            year?.let {
+            releaseInfo?.let {
                 append("Release year: ")
                 append(it)
             }
         }.trim()
-        year?.let {
+        releaseInfo?.let {
             status = if (it.last().isDigit()) {
                 SAnime.COMPLETED
             } else {

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
@@ -2,10 +2,12 @@
 
 package eu.kanade.tachiyomi.animeextension.all.stremio
 
+import eu.kanade.tachiyomi.animesource.model.FetchType
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
-import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
+import keiyoushi.utils.Source
+import keiyoushi.utils.toJsonString
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -75,11 +77,11 @@ data class MetaDto(
     // Tv
     val streams: List<StreamDto>? = null,
 ) {
-    fun toSAnime(): SAnime = SAnime.create().apply {
+    fun toSAnime(splitSeasons: Boolean): SAnime = SAnime.create().apply {
         title = name
-        url = "$type-$id"
+        url = "#-$type-$id"
         thumbnail_url = poster
-        // background_url = background ?: poster
+        background_url = background ?: poster
 
         genre = genres?.joinToString()
         author = director?.take(5)?.joinToString()
@@ -98,6 +100,12 @@ data class MetaDto(
             } else {
                 SAnime.ONGOING
             }
+        }
+
+        fetch_type = if (type.equals("movie", true) || !splitSeasons) {
+            FetchType.Episodes
+        } else {
+            FetchType.Seasons
         }
     }
 }
@@ -158,8 +166,8 @@ data class VideoDto(
         url = "$type-$id"
         name = sub.replace(episodeTemplate).trim()
         scanlator = sub.replace(scanlatorTemplate).trim().takeNotBlank()
-        // summary = overview?.takeNotBlank() ?: description
-        // preview_url = thumbnail
+        summary = overview?.takeNotBlank() ?: description
+        preview_url = thumbnail
         episode_number = episode?.toFloat() ?: 1F
         date_upload = DATE_FORMAT.tryParse(released)
     }
@@ -200,7 +208,17 @@ data class StreamDto(
     val url: String? = null,
     val behaviorHints: BehaviorHintDto? = null,
 ) {
-    fun toVideo(serverUrl: String?, subtitleList: List<Track>): Video? {
+    context(source: Source)
+    fun toVideo(serverUrl: String?, hosterData: String): Video? {
+        val (type, id) = hosterData.split("-", limit = 2)
+        val videoData = VideoData(
+            type = type,
+            id = id,
+            videoHash = behaviorHints?.videoHash,
+            videoSize = behaviorHints?.videoSize,
+            filename = behaviorHints?.filename,
+        )
+
         val headers = behaviorHints?.proxyHeaders?.request?.toHeaders()
 
         val videoName = buildString {
@@ -212,11 +230,10 @@ data class StreamDto(
 
         if (url?.isNotEmpty() == true) {
             return Video(
-                url = url,
-                quality = videoName,
+                videoTitle = videoName,
                 videoUrl = url,
-                subtitleTracks = subtitleList,
                 headers = headers,
+                internalData = videoData.toJsonString(),
             )
         }
 
@@ -245,10 +262,9 @@ data class StreamDto(
             }
 
             return Video(
-                url = url,
-                quality = videoName,
+                videoTitle = videoName,
                 videoUrl = url,
-                subtitleTracks = subtitleList,
+                internalData = videoData.toJsonString(),
             )
         }
 
@@ -258,6 +274,9 @@ data class StreamDto(
     @Serializable
     data class BehaviorHintDto(
         val proxyHeaders: ProxyHeaderDto? = null,
+        val filename: String? = null,
+        val videoHash: String? = null,
+        val videoSize: Long? = null,
     ) {
         @Serializable
         data class ProxyHeaderDto(
@@ -265,3 +284,12 @@ data class StreamDto(
         )
     }
 }
+
+@Serializable
+data class VideoData(
+    val type: String,
+    val id: String,
+    val videoHash: String? = null,
+    val videoSize: Long? = null,
+    val filename: String? = null,
+)

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
@@ -7,8 +7,16 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import keiyoushi.utils.tryParse
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonTransformingSerializer
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.apache.commons.text.StringSubstitutor
@@ -36,6 +44,15 @@ data class MetaResultDto(
     val meta: MetaDto,
 )
 
+class ObjectToListSerializer<T : Any>(
+    tSerializer: KSerializer<T>,
+) : JsonTransformingSerializer<List<T>>(ListSerializer(tSerializer)) {
+    override fun transformDeserialize(element: JsonElement): JsonElement = when (element) {
+        JsonNull, is JsonArray -> element
+        is JsonPrimitive, is JsonObject -> JsonArray(listOf(element))
+    }
+}
+
 @Serializable
 data class MetaDto(
     val id: String,
@@ -47,6 +64,7 @@ data class MetaDto(
     // Details
     val description: String? = null,
     val genres: List<String>? = null,
+    @Serializable(with = ObjectToListSerializer::class)
     val director: List<String>? = null,
     val cast: List<String>? = null,
     val year: String? = null,

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
@@ -2,7 +2,6 @@
 
 package eu.kanade.tachiyomi.animeextension.all.stremio
 
-import eu.kanade.tachiyomi.animesource.model.FetchType
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
@@ -81,7 +80,8 @@ data class MetaDto(
         title = name
         url = "#-$type-$id"
         thumbnail_url = poster
-        background_url = background ?: poster
+        // TODO: enable after bumping to lib-16
+        // background_url = background ?: poster
 
         genre = genres?.joinToString()
         author = director?.take(5)?.joinToString()
@@ -102,11 +102,12 @@ data class MetaDto(
             }
         }
 
-        fetch_type = if (type.equals("movie", true) || !splitSeasons) {
-            FetchType.Episodes
-        } else {
-            FetchType.Seasons
-        }
+        // TODO: enable after bumping to lib-16
+        // fetch_type = if (type.equals("movie", true) || !splitSeasons) {
+        //    FetchType.Episodes
+        // } else {
+        //    FetchType.Seasons
+        // }
     }
 }
 
@@ -166,8 +167,9 @@ data class VideoDto(
         url = "$type-$id"
         name = sub.replace(episodeTemplate).trim()
         scanlator = sub.replace(scanlatorTemplate).trim().takeNotBlank()
-        summary = overview?.takeNotBlank() ?: description
-        preview_url = thumbnail
+        // TODO: enable after bumping to lib-16
+        // summary = overview?.takeNotBlank() ?: description
+        // preview_url = thumbnail
         episode_number = episode?.toFloat() ?: 1F
         date_upload = DATE_FORMAT.tryParse(released)
     }
@@ -229,7 +231,7 @@ data class StreamDto(
         }.trim().ifBlank { "Video" }
 
         if (url?.isNotEmpty() == true) {
-            return Video(
+            return source.legacyVideo(
                 videoTitle = videoName,
                 videoUrl = url,
                 headers = headers,
@@ -261,7 +263,7 @@ data class StreamDto(
                 }
             }
 
-            return Video(
+            return source.legacyVideo(
                 videoTitle = videoName,
                 videoUrl = url,
                 internalData = videoData.toJsonString(),

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Dto.kt
@@ -36,7 +36,7 @@ data class LoginDto(
 @Serializable
 data class CatalogListDto(
     val hasMore: Boolean? = null,
-    val metas: List<MetaDto>,
+    val metas: List<MetaDto>? = null,
 )
 
 @Serializable

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -63,7 +63,7 @@ class Stremio : Source() {
     private val addonManager by lazy {
         AddonManager(addonDelegate, authKeyDelegate)
     }
-    private suspend fun addons() = addonManager.getAddons(this)
+    private suspend fun addons() = addonManager.getAddons()
     // KMK <--
 
     // ============================== Popular ===============================

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.animeextension.all.stremio.addon.dto.ExtraType
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
+import eu.kanade.tachiyomi.animesource.model.FetchType
 import eu.kanade.tachiyomi.animesource.model.Hoster
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
@@ -60,24 +61,21 @@ class Stremio : Source() {
     private val addonDelegate = preferences.delegate(ADDONS_KEY, ADDONS_DEFAULT)
     private val authKeyDelegate = preferences.delegate(AUTHKEY_KEY, "")
 
-    // KMK -->
     private val addonManager by lazy {
         AddonManager(addonDelegate, authKeyDelegate)
     }
-    private suspend fun addons() = addonManager.getAddons()
-    // KMK <--
 
     // ============================== Popular ===============================
 
     override suspend fun getPopularAnime(page: Int): AnimesPage {
-        val popularCatalog = addons().firstNotNullOfOrNull { addon ->
+        val popularCatalog = addonManager.getAddons().firstNotNullOfOrNull { addon ->
             addon.manifest.catalogs.firstOrNull { catalog ->
                 catalog.extra.orEmpty().none { it.isRequired == true }
             }?.copy(transportUrl = addon.getTransportUrl().toString())
         } ?: throw Exception("No valid catalog addons found")
 
         try {
-            setCatalogList(addons())
+            setCatalogList(addonManager.getAddons())
         } catch (_: Exception) { }
 
         return getSearchAnime(
@@ -157,7 +155,7 @@ class Stremio : Source() {
         )
 
         val data = response.parseAs<CatalogListDto>()
-        val entries = data.metas.orEmpty().map { it.toSAnime() }
+        val entries = data.metas.orEmpty().map { it.toSAnime(preferences.splitSeasons) }
 
         if (page == 1) {
             nextSkip = entries.size
@@ -304,7 +302,7 @@ class Stremio : Source() {
     private suspend fun fetchLibrary() {
         if (filtersState == FilterState.Unfetched && filterAttempts < 3) {
             filtersState = FilterState.Fetching
-            filterAttempts
+            filterAttempts++
 
             try {
                 val body = buildJsonObject {
@@ -414,8 +412,6 @@ class Stremio : Source() {
                     add(LibrarySortFilter())
                 }
             }
-
-            add(AnimeFilter.Header(""))
         }
 
         return AnimeFilterList(filters)
@@ -424,7 +420,7 @@ class Stremio : Source() {
     // =========================== Anime Details ============================
 
     override fun getAnimeUrl(anime: SAnime): String {
-        val (type, id) = anime.url.split("-", limit = 2)
+        val (_, type, id) = anime.url.getUrlParts()
 
         return baseUrl.toHttpUrl().newBuilder()
             .fragment("/detail/$type/$id")
@@ -432,15 +428,15 @@ class Stremio : Source() {
     }
 
     override suspend fun getAnimeDetails(anime: SAnime): SAnime {
-        val (type, id) = anime.url.split("-", limit = 2)
+        val (_, type, id) = anime.url.getUrlParts()
 
-        val validAddons = addons().filter {
+        val validAddons = addonManager.getAddons().filter {
             it.manifest.isValidResource(AddonResource.META, type, id)
         }
 
         validAddons.forEach { addon ->
             getMeta(addon, type, id)?.let {
-                return it.toSAnime()
+                return it.toSAnime(preferences.splitSeasons)
             }
         }
 
@@ -464,7 +460,7 @@ class Stremio : Source() {
     // ============================== Episodes ==============================
 
     override fun getEpisodeUrl(episode: SEpisode): String {
-        val (type, id) = episode.url.split("-", limit = 2)
+        val (_, type, id) = episode.url.getUrlParts()
         val entryId = id.substringBefore(":")
 
         return baseUrl.toHttpUrl().newBuilder()
@@ -472,8 +468,47 @@ class Stremio : Source() {
             .build().toString()
     }
 
+    override suspend fun getSeasonList(anime: SAnime): List<SAnime> {
+        val (_, type, id) = anime.url.getUrlParts()
+
+        val validAddons = addonManager.getAddons().filter {
+            it.manifest.isValidResource(AddonResource.META, type, id)
+        }
+
+        validAddons.forEach { addon ->
+            getMeta(addon, type, id)?.let { meta ->
+                meta.videos?.takeIf { it.isNotEmpty() }?.let { videos ->
+                    return videos.distinctBy { it.season }.map {
+                        SAnime.create().apply {
+                            title = buildString {
+                                if (preferences.concatNames) {
+                                    append(anime.title)
+                                    append(" ")
+                                }
+                                append("Season ")
+                                append(it.season ?: 0)
+                            }
+                            url = "${it.season ?: 0}-$type-$id"
+                            season_number = it.season?.toDouble() ?: 0.0
+                            fetch_type = FetchType.Episodes
+
+                            thumbnail_url = anime.thumbnail_url
+                            genre = anime.genre
+                            author = anime.author
+                            artist = anime.artist
+                            description = anime.description
+                            status = anime.status
+                        }
+                    }
+                }
+            }
+        }
+
+        return emptyList()
+    }
+
     override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
-        val (type, id) = anime.url.split("-", limit = 2)
+        val (season, type, id) = anime.url.getUrlParts()
 
         if (type.equals("movie", true)) {
             return listOf(
@@ -485,11 +520,10 @@ class Stremio : Source() {
             )
         }
 
-        val validAddons = addons().filter {
+        val validAddons = addonManager.getAddons().filter {
             it.manifest.isValidResource(AddonResource.META, type, id)
         }
 
-        val skipSeason0 = preferences.skipSeason0
         val nameTemplate = preferences.nameTemplate
         val scanlatorTemplate = preferences.scanlatorTemplate
 
@@ -509,8 +543,13 @@ class Stremio : Source() {
 
                 // Other
                 meta.videos?.takeIf { it.isNotEmpty() }?.let { videos ->
-                    return videos
-                        .filterNot { skipSeason0 && it.season == 0 }
+                    val episodeData = if (season == "#") {
+                        videos
+                    } else {
+                        videos.filter { it.season == season.toInt() }
+                    }
+
+                    return episodeData
                         .sortedWith(
                             compareBy(
                                 { it.season ?: 1 },
@@ -529,9 +568,9 @@ class Stremio : Source() {
     // ============================ Video Links =============================
 
     override suspend fun getHosterList(episode: SEpisode): List<Hoster> {
-        val (type, id) = episode.url.split("-", limit = 2)
+        val (_, type, id) = episode.url.getUrlParts()
 
-        return addons()
+        return addonManager.getAddons()
             .filter { it.manifest.isValidResource(AddonResource.STREAM, type, id) }
             .map { addon ->
                 val url = addon.getTransportUrl().newBuilder().apply {
@@ -550,26 +589,48 @@ class Stremio : Source() {
     }
 
     override suspend fun getVideoList(hoster: Hoster): List<Video> {
-        val (type, id) = hoster.internalData.split("-", limit = 2)
-
-        val subtitles = getSubtitleList(type, id)
         val serverUrl = preferences.serverUrl.takeIf { it.isNotEmpty() }
 
-        val url = hoster.hosterUrl
-
-        return client.get(url, headers)
+        val videoList = client.get(hoster.hosterUrl, headers)
             .parseAs<StreamResultDto>()
-            .streams
-            .mapNotNull { v -> v.toVideo(serverUrl, subtitles) }
+            .streams.mapNotNull { v -> v.toVideo(serverUrl, hoster.internalData) }
+
+        val videoLimit = preferences.videoLimit.toInt()
+        return if (videoLimit == 0) videoList else videoList.take(videoLimit)
     }
 
-    private suspend fun getSubtitleList(type: String, id: String): List<Track> = addons()
-        .filter { it.manifest.isValidResource(AddonResource.SUBTITLES, type, id) }
+    override suspend fun resolveVideo(video: Video): Video {
+        val data = video.internalData.parseAs<VideoData>()
+        val subtitleList = getSubtitleList(data)
+
+        return video.copy(
+            subtitleTracks = subtitleList,
+        )
+    }
+
+    private suspend fun getSubtitleList(videoData: VideoData): List<Track> = addonManager.getAddons()
+        .filter { it.manifest.isValidResource(AddonResource.SUBTITLES, videoData.type, videoData.id) }
         .parallelCatchingFlatMap { addon ->
+            val hints = buildList(3) {
+                videoData.videoHash?.let {
+                    add("videoHash=${it.urlEncode()}")
+                }
+                videoData.videoSize?.let {
+                    add("videoSize=$it")
+                }
+                videoData.filename?.let {
+                    add("filename=${it.urlEncode()}")
+                }
+            }.joinToString("&")
+
             val url = addon.getTransportUrl().newBuilder().apply {
                 addPathSegment("subtitles")
-                addPathSegment(type)
-                addPathSegment(id)
+                addPathSegment(videoData.type)
+                addPathSegment(videoData.id)
+
+                if (hints.isNotEmpty()) {
+                    addPathSegment(hints)
+                }
             }.build().toString() +
                 ".json"
 
@@ -580,6 +641,16 @@ class Stremio : Source() {
         }
 
     // ============================= Utilities ==============================
+
+    private fun String.getUrlParts(): List<String> {
+        val url = if (this.first().let { it.isDigit() || it == '#' }) {
+            this
+        } else {
+            "#-$this"
+        }
+
+        return url.split("-", limit = 3)
+    }
 
     companion object {
         const val API_URL = "https://api.strem.io"
@@ -600,12 +671,19 @@ class Stremio : Source() {
         private const val PASSWORD_KEY = "password"
         private const val PASSWORD_DEFAULT = ""
 
-        private const val PREF_SKIP_SEASON_0_KEY = "pref_skip_season_0"
-        private const val PREF_SKIP_SEASON_0_DEFAULT = false
+        private const val PREF_SPLIT_SEASONS_KEY = "pref_split_seasons"
+        private const val PREF_SPLIT_SEASONS_DEFAULT = true
+
+        private const val PREF_CONCAT_NAMES_KEY = "pref_concatenate_names"
+        private const val PREF_CONCAT_NAMES_DEFAULT = true
+
+        private const val PREF_VIDEO_LIMIT_KEY = "pref_video_limit"
+        private const val PREF_VIDEO_LIMIT_DEFAULT = "0"
 
         private const val PREF_FETCH_LIBRARY_KEY = "pref_fetch_library"
         private const val PREF_FETCH_LIBRARY_DEFAULT = false
 
+        @Suppress("SpellCheckingInspection")
         const val AUTHKEY_KEY = ""
 
         private val SUBSTITUTE_VALUES = mapOf(
@@ -651,9 +729,17 @@ class Stremio : Source() {
         PREF_SCANLATOR_NAME_TEMPLATE_KEY,
         PREF_SCANLATOR_NAME_TEMPLATE_DEFAULT,
     )
-    private val SharedPreferences.skipSeason0 by preferences.delegate(
-        PREF_SKIP_SEASON_0_KEY,
-        PREF_SKIP_SEASON_0_DEFAULT,
+    private val SharedPreferences.splitSeasons by preferences.delegate(
+        PREF_SPLIT_SEASONS_KEY,
+        PREF_SPLIT_SEASONS_DEFAULT,
+    )
+    private val SharedPreferences.concatNames by preferences.delegate(
+        PREF_CONCAT_NAMES_KEY,
+        PREF_CONCAT_NAMES_DEFAULT,
+    )
+    private val SharedPreferences.videoLimit by preferences.delegate(
+        PREF_VIDEO_LIMIT_KEY,
+        PREF_VIDEO_LIMIT_DEFAULT,
     )
     private val SharedPreferences.fetchLibrary by preferences.delegate(
         PREF_FETCH_LIBRARY_KEY,
@@ -878,10 +964,37 @@ class Stremio : Source() {
         )
 
         screen.addSwitchPreference(
-            key = PREF_SKIP_SEASON_0_KEY,
-            default = PREF_SKIP_SEASON_0_DEFAULT,
-            title = "Skip season 0",
-            summary = "Filter out specials",
+            key = PREF_SPLIT_SEASONS_KEY,
+            default = PREF_SPLIT_SEASONS_DEFAULT,
+            title = "Split seasons",
+            summary = "Split seasons into its own entry",
+        )
+
+        screen.addSwitchPreference(
+            key = PREF_CONCAT_NAMES_KEY,
+            default = PREF_CONCAT_NAMES_DEFAULT,
+            title = "Concatenate series and season names",
+            summary = "",
+        )
+
+        val limitSummary: (String) -> String = { if (it == "0") "No limit" else "Limit: $it" }
+        screen.addEditTextPreference(
+            key = PREF_VIDEO_LIMIT_KEY,
+            default = PREF_VIDEO_LIMIT_DEFAULT,
+            title = "Limit number of videos from hosters",
+            summary = limitSummary(preferences.videoLimit),
+            getSummary = limitSummary,
+            dialogMessage = "0 means no limit",
+            inputType = InputType.TYPE_CLASS_NUMBER,
+            validate = {
+                if (it.toIntOrNull() == null) {
+                    false
+                } else {
+                    it.toInt() > -1
+                }
+            },
+            validationMessage = { "Limit must be a number equal or greater to 0" },
+            allowBlank = false,
         )
 
         screen.addPreference(logOutPref)

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.animeextension.all.stremio.addon.dto.ExtraType
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
+import eu.kanade.tachiyomi.animesource.model.Hoster
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Track
@@ -527,15 +528,12 @@ class Stremio : Source() {
 
     // ============================ Video Links =============================
 
-    override suspend fun getVideoList(episode: SEpisode): List<Video> {
+    override suspend fun getHosterList(episode: SEpisode): List<Hoster> {
         val (type, id) = episode.url.split("-", limit = 2)
-
-        val subtitles = getSubtitleList(type, id)
-        val serverUrl = preferences.serverUrl.takeIf { it.isNotEmpty() }
 
         return addons()
             .filter { it.manifest.isValidResource(AddonResource.STREAM, type, id) }
-            .parallelCatchingFlatMap { addon ->
+            .map { addon ->
                 val url = addon.getTransportUrl().newBuilder().apply {
                     addPathSegment("stream")
                     addPathSegment(type)
@@ -543,12 +541,26 @@ class Stremio : Source() {
                 }.build().toString() +
                     ".json"
 
-                client.get(url, headers)
-                    .parseAs<StreamResultDto>()
-                    .streams
-                    .map { v -> v.toVideo(serverUrl, subtitles) }
+                legacyHoster(
+                    hosterUrl = url,
+                    hosterName = addon.manifest.name,
+                    internalData = episode.url,
+                )
             }
-            .filterNotNull()
+    }
+
+    override suspend fun getVideoList(hoster: Hoster): List<Video> {
+        val (type, id) = hoster.internalData.split("-", limit = 2)
+
+        val subtitles = getSubtitleList(type, id)
+        val serverUrl = preferences.serverUrl.takeIf { it.isNotEmpty() }
+
+        val url = hoster.hosterUrl
+
+        return client.get(url, headers)
+            .parseAs<StreamResultDto>()
+            .streams
+            .mapNotNull { v -> v.toVideo(serverUrl, subtitles) }
     }
 
     private suspend fun getSubtitleList(type: String, id: String): List<Track> = addons()
@@ -605,14 +617,14 @@ class Stremio : Source() {
         private val STRING_SUBSTITUTOR = StringSubstitutor(SUBSTITUTE_VALUES, "{", "}").apply {
             isEnableUndefinedVariableException = true
         }
-        private val SUBSTITUTE_DIALOG_MESSAGE = """
+        private val SUBSTITUTE_DIALOG_MESSAGE = $$"""
         |Supported placeholders:
         |- {name}: Episode name
         |- {episodeNumber}: Episode number
         |- {seasonNumber}: Season number
         |- {description}: Episode description
         |If you wish to place some text between curly brackets, place the escape character "$"
-        |before the opening curly bracket, e.g. ${'$'}{name}.
+        |before the opening curly bracket, e.g. ${name}.
         """.trimMargin()
 
         private const val PREF_EPISODE_NAME_TEMPLATE_KEY = "pref_episode_name_template"

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -156,7 +156,7 @@ class Stremio : Source() {
         )
 
         val data = response.parseAs<CatalogListDto>()
-        val entries = data.metas.map { it.toSAnime() }
+        val entries = data.metas.orEmpty().map { it.toSAnime() }
 
         if (page == 1) {
             nextSkip = entries.size

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -21,7 +21,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import keiyoushi.utils.LazyMutable
 import keiyoushi.utils.Source
 import keiyoushi.utils.addEditTextPreference
-import keiyoushi.utils.addSwitchPreference
+import keiyoushi.utils.copyLegacy
 import keiyoushi.utils.delegate
 import keiyoushi.utils.firstInstance
 import keiyoushi.utils.get
@@ -603,7 +603,7 @@ class Stremio : Source() {
         val data = video.internalData.parseAs<VideoData>()
         val subtitleList = getSubtitleList(data)
 
-        return video.copy(
+        return video.copyLegacy(
             subtitleTracks = subtitleList,
         )
     }
@@ -963,19 +963,20 @@ class Stremio : Source() {
             validationMessage = { "Invalid scanlator format" },
         )
 
-        screen.addSwitchPreference(
-            key = PREF_SPLIT_SEASONS_KEY,
-            default = PREF_SPLIT_SEASONS_DEFAULT,
-            title = "Split seasons",
-            summary = "Split seasons into its own entry",
-        )
-
-        screen.addSwitchPreference(
-            key = PREF_CONCAT_NAMES_KEY,
-            default = PREF_CONCAT_NAMES_DEFAULT,
-            title = "Concatenate series and season names",
-            summary = "",
-        )
+        // TODO: enable after bumping to lib-16
+        // screen.addSwitchPreference(
+        //    key = PREF_SPLIT_SEASONS_KEY,
+        //    default = PREF_SPLIT_SEASONS_DEFAULT,
+        //    title = "Split seasons",
+        //    summary = "Split seasons into its own entry",
+        // )
+//
+        // screen.addSwitchPreference(
+        //    key = PREF_CONCAT_NAMES_KEY,
+        //    default = PREF_CONCAT_NAMES_DEFAULT,
+        //    title = "Concatenate series and season names",
+        //    summary = "",
+        // )
 
         val limitSummary: (String) -> String = { if (it == "0") "No limit" else "Limit: $it" }
         screen.addEditTextPreference(

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/addon/AddonManager.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/addon/AddonManager.kt
@@ -15,7 +15,6 @@ import keiyoushi.utils.toJsonRequestBody
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
-@Suppress("SpellCheckingInspection")
 class AddonManager(
     addonDelegate: PreferenceDelegate<String>,
     authKeyDelegate: PreferenceDelegate<String>,
@@ -27,7 +26,8 @@ class AddonManager(
     private var cachedAuthKey: String? = null
     private var addons: List<AddonDto>? = null
 
-    suspend fun getAddons(source: Source): List<AddonDto> {
+    context(source: Source)
+    suspend fun getAddons(): List<AddonDto> {
         val useAddons = addonValue.isNotBlank()
         val hasChanged = when {
             useAddons -> addonValue != cachedAddons
@@ -36,8 +36,8 @@ class AddonManager(
 
         if (hasChanged) {
             addons = when {
-                useAddons -> source.getFromPref(addonValue)
-                authKeyValue.isNotBlank() -> source.getFromUser(authKeyValue)
+                useAddons -> getFromPref(addonValue)
+                authKeyValue.isNotBlank() -> getFromUser(authKeyValue)
                 else -> throw Exception("Addons must be manually added if not logged in")
             }
 
@@ -53,13 +53,14 @@ class AddonManager(
         return addons ?: emptyList()
     }
 
-    private suspend fun Source.getFromPref(addons: String): List<AddonDto> {
+    context(source: Source)
+    private suspend fun getFromPref(addons: String): List<AddonDto> {
         val urls = addons.split("\n")
 
         return urls.parallelMapNotNull { url ->
             try {
                 val manifestUrl = url.replace("stremio://", "https://")
-                val manifest = client.get(manifestUrl).parseAs<ManifestDto>()
+                val manifest = source.client.get(manifestUrl).parseAs<ManifestDto>()
                 AddonDto(
                     transportUrl = manifestUrl,
                     manifest = manifest,
@@ -70,14 +71,15 @@ class AddonManager(
         }
     }
 
-    private suspend fun Source.getFromUser(authKey: String): List<AddonDto> {
+    context(source: Source)
+    private suspend fun getFromUser(authKey: String): List<AddonDto> = with(source) {
         val body = buildJsonObject {
             put("authKey", authKey)
             put("type", "AddonCollectionGet")
             put("update", true)
         }.toJsonRequestBody()
 
-        return client.post("${Stremio.API_URL}/api/addonCollectionGet", body = body)
+        client.post("${Stremio.API_URL}/api/addonCollectionGet", body = body)
             .parseAs<ResultDto<AddonResultDto>>().result.addons
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Support Stremio hosters and improve season, metadata, stream, subtitle, and preference handling.

New Features:
- Add hoster-based video playback with deferred subtitle resolution and configurable video result limits.
- Support splitting series into season entries and preserve season-specific episode navigation.

Bug Fixes:
- Handle missing catalog metadata, flexible director formats, updated release information, retry counting, and legacy URL formats more robustly.
- Include available stream metadata when resolving subtitles and avoid dropping valid hoster results.

Enhancements:
- Modernize addon access and video construction around the source context and legacy compatibility APIs.

Build:
- Increment the Stremio extension version code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Stremio extension to version 10.
  * Added season listings and improved support for season-specific and all-season episode URLs.
  * Added hoster selection, video resolution, subtitle handling, configurable video limits, and server settings.
  * Added support for catalogs and metadata returned in multiple formats.

* **Bug Fixes**
  * Improved library loading retries.
  * Improved handling of stream details, including torrent and HTTP video metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->