### PR TITLE
Oploverz [ID]: Migrate to oploverz.site & REST API

### DIFF
--- a/src/id/oploverz/build.gradle
+++ b/src/id/oploverz/build.gradle
@@ -1,7 +1,12 @@
 ext {
     extName = 'Oploverz'
     extClass = '.Oploverz'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply plugin: "kei.plugins.extension.legacy"
+
+dependencies {
+    implementation(project(':lib:dailymotionextractor'))
+    implementation(project(':lib:universalextractor'))
+}

--- a/src/id/oploverz/build.gradle
+++ b/src/id/oploverz/build.gradle
@@ -8,5 +8,7 @@ apply plugin: "kei.plugins.extension.legacy"
 
 dependencies {
     implementation(project(':lib:dailymotionextractor'))
+    implementation(project(':lib:playlistutils'))
+    implementation(project(':lib:unpacker'))
     implementation(project(':lib:universalextractor'))
 }

--- a/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Dto.kt
+++ b/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Dto.kt
@@ -1,0 +1,108 @@
+package eu.kanade.tachiyomi.animeextension.id.oploverz
+
+import eu.kanade.tachiyomi.animesource.model.SAnime
+import eu.kanade.tachiyomi.animesource.model.SEpisode
+import keiyoushi.utils.tryParse
+import kotlinx.serialization.Serializable
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+@Serializable
+class SeriesListResponseDto(
+    private val data: List<SeriesDto>,
+    private val meta: MetaDto,
+) {
+    fun toAnimesPage(): Pair<List<SAnime>, Boolean> = Pair(data.map { it.toSAnime() }, meta.hasNextPage)
+}
+
+@Serializable
+class MetaDto(
+    private val currentPage: Int,
+    private val lastPage: Int,
+) {
+    val hasNextPage get() = currentPage < lastPage
+}
+
+@Serializable
+class SeriesResponseDto(private val data: SeriesDto) {
+    fun toSAnime(): SAnime = data.toSAnime()
+}
+
+@Serializable
+class SeriesDto(
+    private val slug: String,
+    private val title: String,
+    private val poster: String? = null,
+    private val description: String? = null,
+    private val status: String? = null,
+    private val genres: List<GenreDto> = emptyList(),
+    private val studio: StudioDto? = null,
+) {
+    fun toSAnime(): SAnime {
+        val anime = SAnime.create()
+        anime.url = "/series/$slug"
+        anime.title = title
+        anime.thumbnail_url = poster
+        anime.description = description
+        anime.genre = genres.joinToString { it.name }
+        anime.author = studio?.name
+        anime.status = when (status?.lowercase()) {
+            "ongoing" -> SAnime.ONGOING
+            "completed" -> SAnime.COMPLETED
+            else -> SAnime.UNKNOWN
+        }
+        return anime
+    }
+}
+
+@Serializable
+class GenreDto(val name: String)
+
+@Serializable
+class StudioDto(val name: String)
+
+@Serializable
+class EpisodeListResponseDto(private val data: List<EpisodeDto>) {
+    fun toSEpisodeList(slug: String): List<SEpisode> = data.map { it.toSEpisode(slug) }
+}
+
+@Serializable
+class EpisodeDto(
+    private val episodeNumber: String,
+    private val releasedAt: String? = null,
+) {
+    fun toSEpisode(slug: String): SEpisode {
+        val episode = SEpisode.create()
+        episode.url = "/series/$slug/episode/$episodeNumber"
+        episode.name = "Episode $episodeNumber"
+        episode.episode_number = episodeNumber.toFloatOrNull() ?: 1F
+        episode.date_upload = DATE_FORMATTER.tryParse(releasedAt)
+        return episode
+    }
+
+    companion object {
+        private val DATE_FORMATTER = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+    }
+}
+
+@Serializable
+class EpisodeDetailResponseDto(private val data: EpisodeDetailDto) {
+    val streams get() = data.streamUrl
+}
+
+@Serializable
+class EpisodeDetailDto(val streamUrl: List<StreamDto> = emptyList())
+
+@Serializable
+class StreamDto(val source: String, val url: String)
+
+@Serializable
+class FiledonPageDto(private val props: FiledonPropsDto) {
+    val videoUrl get() = props.url
+}
+
+@Serializable
+class FiledonPropsDto(val url: String)

--- a/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Dto.kt
+++ b/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Dto.kt
@@ -36,7 +36,7 @@ class SeriesDto(
     private val poster: String? = null,
     private val description: String? = null,
     private val status: String? = null,
-    private val genres: List<GenreDto> = emptyList(),
+    private val genres: List<GenreDto>? = null,
     private val studio: StudioDto? = null,
 ) {
     fun toSAnime(): SAnime {
@@ -45,7 +45,7 @@ class SeriesDto(
         anime.title = title
         anime.thumbnail_url = poster
         anime.description = description
-        anime.genre = genres.joinToString { it.name }
+        anime.genre = genres?.joinToString { it.name }
         anime.author = studio?.name
         anime.status = when (status?.lowercase()) {
             "ongoing" -> SAnime.ONGOING
@@ -55,6 +55,20 @@ class SeriesDto(
         return anime
     }
 }
+
+@Serializable
+class LatestEpisodesResponseDto(
+    private val data: List<LatestEpisodeDto>,
+    private val meta: MetaDto,
+) {
+    fun toAnimesPage(): Pair<List<SAnime>, Boolean> = Pair(
+        data.map { it.series.toSAnime() }.distinctBy { it.url },
+        meta.hasNextPage,
+    )
+}
+
+@Serializable
+class LatestEpisodeDto(val series: SeriesDto)
 
 @Serializable
 class GenreDto(val name: String)
@@ -90,11 +104,11 @@ class EpisodeDto(
 
 @Serializable
 class EpisodeDetailResponseDto(private val data: EpisodeDetailDto) {
-    val streams get() = data.streamUrl
+    val streams get() = data.streamUrl ?: emptyList()
 }
 
 @Serializable
-class EpisodeDetailDto(val streamUrl: List<StreamDto> = emptyList())
+class EpisodeDetailDto(val streamUrl: List<StreamDto>? = null)
 
 @Serializable
 class StreamDto(val source: String, val url: String)

--- a/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Oploverz.kt
+++ b/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Oploverz.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.animeextension.id.oploverz
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import aniyomi.lib.dailymotionextractor.DailymotionExtractor
+import aniyomi.lib.playlistutils.PlaylistUtils
 import aniyomi.lib.universalextractor.UniversalExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -11,11 +12,14 @@ import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.lib.autoUnpacker
 import keiyoushi.utils.AnimeHttpLegacySource
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
 import keiyoushi.utils.parseAs
+import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -34,7 +38,7 @@ class Oploverz :
 
     // ============================== Popular ===============================
 
-    override fun popularAnimeRequest(page: Int): Request = GET("$apiUrl/api/series?hot=true&page=$page&pageSize=$ANIME_PAGE_SIZE", headers)
+    override fun popularAnimeRequest(page: Int): Request = GET("$apiUrl/api/series?page=$page&pageSize=$ANIME_PAGE_SIZE", headers)
 
     override fun popularAnimeParse(response: Response): AnimesPage {
         val (animes, hasNextPage) = response.parseAs<SeriesListResponseDto>().toAnimesPage()
@@ -43,9 +47,12 @@ class Oploverz :
 
     // =============================== Latest ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$apiUrl/api/series?page=$page&pageSize=$ANIME_PAGE_SIZE", headers)
+    override fun latestUpdatesRequest(page: Int): Request = GET("$apiUrl/api/episodes?page=$page&pageSize=$ANIME_PAGE_SIZE&sort=latest", headers)
 
-    override fun latestUpdatesParse(response: Response): AnimesPage = popularAnimeParse(response)
+    override fun latestUpdatesParse(response: Response): AnimesPage {
+        val (animes, hasNextPage) = response.parseAs<LatestEpisodesResponseDto>().toAnimesPage()
+        return AnimesPage(animes, hasNextPage)
+    }
 
     // =============================== Search ===============================
 
@@ -91,6 +98,7 @@ class Oploverz :
 
     private val dailymotionExtractor by lazy { DailymotionExtractor(client, headers) }
     private val universalExtractor by lazy { UniversalExtractor(client) }
+    private val playlistUtils by lazy { PlaylistUtils(client, headers) }
 
     private val videoHeaders by lazy { headersBuilder().set("Referer", "$baseUrl/").build() }
 
@@ -113,7 +121,9 @@ class Oploverz :
         return when {
             "dailymotion" in url -> dailymotionExtractor.videosFromUrl(url, "$prefix Dailymotion - ")
             "filedon.co" in url -> getFiledonVideo(url, prefix)
-            else -> universalExtractor.videosFromUrl(url, videoHeaders, prefix)
+            else -> getXFileSharingVideos(url, prefix).ifEmpty {
+                universalExtractor.videosFromUrl(url, videoHeaders, prefix)
+            }
         }
     }
 
@@ -123,6 +133,29 @@ class Oploverz :
         val videoUrl = dataPage.parseAs<FiledonPageDto>().videoUrl
         return listOf(Video(videoUrl, quality, videoUrl, videoHeaders))
     }
+
+    // Handles XFileSharing-style hosts (e.g. upbolt.to): the embed page auto-submits
+    // a form to /dl, whose response contains a (usually packed) player script with the source.
+    private fun getXFileSharingVideos(url: String, quality: String): List<Video> = runCatching {
+        val embedUrl = url.toHttpUrl()
+        val code = embedUrl.pathSegments.last()
+        val origin = "${embedUrl.scheme}://${embedUrl.host}"
+        val form = FormBody.Builder()
+            .add("op", "embed")
+            .add("file_code", code)
+            .add("auto", "1")
+            .add("referer", "")
+            .build()
+        val dlHeaders = videoHeaders.newBuilder().set("Referer", url).build()
+        val body = client.newCall(POST("$origin/dl", dlHeaders, form)).execute().body.string()
+        val unpacked = autoUnpacker(body) ?: body
+        val videoUrl = XFS_SOURCE_REGEX.find(unpacked)?.groupValues?.get(1) ?: return@runCatching emptyList()
+        if ("m3u8" in videoUrl) {
+            playlistUtils.extractFromHls(videoUrl, referer = url, videoNameGen = { "$quality - $it" })
+        } else {
+            listOf(Video(videoUrl, quality, videoUrl, dlHeaders))
+        }
+    }.getOrDefault(emptyList())
 
     // ============================= Utilities ==============================
 
@@ -156,6 +189,8 @@ class Oploverz :
     companion object {
         private const val ANIME_PAGE_SIZE = 20
         private const val EPISODE_PAGE_SIZE = 2000
+
+        private val XFS_SOURCE_REGEX = Regex("""file\s*:\s*["']([^"']+)["']""")
 
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_TITLE = "Preferred quality"

--- a/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Oploverz.kt
+++ b/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Oploverz.kt
@@ -122,7 +122,7 @@ class Oploverz :
             "dailymotion" in url -> dailymotionExtractor.videosFromUrl(url, "$prefix Dailymotion - ")
             "filedon.co" in url -> getFiledonVideo(url, prefix)
             else -> getXFileSharingVideos(url, prefix).ifEmpty {
-                universalExtractor.videosFromUrl(url, videoHeaders, prefix)
+                universalExtractor.videosFromUrl(url, videoHeaders, prefix = prefix)
             }
         }
     }
@@ -151,7 +151,13 @@ class Oploverz :
         val unpacked = autoUnpacker(body) ?: body
         val videoUrl = XFS_SOURCE_REGEX.find(unpacked)?.groupValues?.get(1) ?: return@runCatching emptyList()
         if ("m3u8" in videoUrl) {
-            playlistUtils.extractFromHls(videoUrl, referer = url, videoNameGen = { "$quality - $it" })
+            playlistUtils.extractFromHls(
+                playlistUrl = videoUrl,
+                referer = url,
+                masterHeaders = dlHeaders,
+                videoHeaders = dlHeaders,
+                videoNameGen = { "$quality - $it" },
+            )
         } else {
             listOf(Video(videoUrl, quality, videoUrl, dlHeaders))
         }

--- a/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Oploverz.kt
+++ b/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/Oploverz.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.animeextension.id.oploverz
 
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
+import aniyomi.lib.dailymotionextractor.DailymotionExtractor
+import aniyomi.lib.universalextractor.UniversalExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
 import eu.kanade.tachiyomi.animesource.model.AnimesPage
@@ -9,50 +11,58 @@ import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.AnimeHttpLegacySource
 import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMapBlocking
-import keiyoushi.utils.parallelMapNotNullBlocking
-import okhttp3.FormBody
+import keiyoushi.utils.parseAs
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
-import org.json.JSONObject
-import org.jsoup.nodes.Element
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 class Oploverz :
     AnimeHttpLegacySource(),
     ConfigurableAnimeSource {
     override val name: String = "Oploverz"
-    override val baseUrl: String = "https://oploverz.media"
+    override val baseUrl: String = "https://oploverz.site"
     override val lang: String = "id"
     override val supportsLatest: Boolean = true
+
+    private val apiUrl: String = "https://backapi.oploverz.ac"
 
     private val preferences by getPreferencesLazy()
 
     // ============================== Popular ===============================
 
-    override fun popularAnimeRequest(page: Int): Request = GET("$baseUrl/anime-list/page/$page/?order=popular")
+    override fun popularAnimeRequest(page: Int): Request = GET("$apiUrl/api/series?hot=true&page=$page&pageSize=$ANIME_PAGE_SIZE", headers)
 
-    override fun popularAnimeParse(response: Response): AnimesPage = getAnimeParse(response, "div.relat > article")
+    override fun popularAnimeParse(response: Response): AnimesPage {
+        val (animes, hasNextPage) = response.parseAs<SeriesListResponseDto>().toAnimesPage()
+        return AnimesPage(animes, hasNextPage)
+    }
 
     // =============================== Latest ===============================
 
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/anime-list/page/$page/?order=latest")
+    override fun latestUpdatesRequest(page: Int): Request = GET("$apiUrl/api/series?page=$page&pageSize=$ANIME_PAGE_SIZE", headers)
 
-    override fun latestUpdatesParse(response: Response): AnimesPage = getAnimeParse(response, "div.relat > article")
+    override fun latestUpdatesParse(response: Response): AnimesPage = popularAnimeParse(response)
 
     // =============================== Search ===============================
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
-        val params = OploverzFilters.getSearchParameters(filters)
-        return GET("$baseUrl/anime-list/page/$page/?title=$query${params.filter}", headers)
+        val url = "$apiUrl/api/series".toHttpUrl().newBuilder()
+            .addQueryParameter("page", page.toString())
+            .addQueryParameter("pageSize", ANIME_PAGE_SIZE.toString())
+            .apply {
+                if (query.isNotEmpty()) addQueryParameter("q", query)
+                OploverzFilters.getGenreParam(filters).takeIf { it.isNotEmpty() }
+                    ?.let { addQueryParameter("genres", it) }
+            }
+            .build()
+        return GET(url, headers)
     }
 
-    override fun searchAnimeParse(response: Response): AnimesPage = getAnimeParse(response, "div.relat > article")
+    override fun searchAnimeParse(response: Response): AnimesPage = popularAnimeParse(response)
 
     // ============================== Filters ===============================
 
@@ -60,129 +70,67 @@ class Oploverz :
 
     // =========================== Anime Details ============================
 
-    override fun animeDetailsParse(response: Response): SAnime {
-        val doc = response.asJsoup()
-        val detail = doc.selectFirst("div.infox > div.spe")!!
-        return SAnime.create().apply {
-            author = detail.getInfo("Studio")
-            status = parseStatus(doc.selectFirst("div.alternati > span:nth-child(2)")!!.text())
-            title = doc.selectFirst("div.title > h1.entry-title")!!.text()
-            thumbnail_url =
-                doc.selectFirst("div.infoanime.widget_senction > div.thumb > img")!!
-                    .attr("src")
-            description =
-                doc.select("div.entry-content.entry-content-single > p")
-                    .joinToString("\n\n") { it.text() }
-        }
-    }
+    override fun animeDetailsRequest(anime: SAnime): Request = GET("$apiUrl/api/series/${anime.slug()}", headers)
+
+    override fun animeDetailsParse(response: Response): SAnime = response.parseAs<SeriesResponseDto>().toSAnime()
+
+    override fun getAnimeUrl(anime: SAnime): String = baseUrl + anime.url
 
     // ============================== Episodes ==============================
 
+    override fun episodeListRequest(anime: SAnime): Request = GET("$apiUrl/api/series/${anime.slug()}/episodes?pageSize=$EPISODE_PAGE_SIZE", headers)
+
     override fun episodeListParse(response: Response): List<SEpisode> {
-        val doc = response.asJsoup()
-        return doc.select("div.lstepsiode.listeps > ul.scrolling > li").map {
-            val episode = it.selectFirst("span.eps > a")!!
-            SEpisode.create().apply {
-                setUrlWithoutDomain(episode.attr("href"))
-                episode_number = episode.text().trim().toFloatOrNull() ?: 1F
-                name = it.selectFirst("span.lchx > a")!!.text()
-                date_upload = it.selectFirst("span.date")!!.text().toDate()
-            }
-        }
+        val slug = response.request.url.pathSegments[2]
+        return response.parseAs<EpisodeListResponseDto>().toSEpisodeList(slug)
     }
+
+    override fun getEpisodeUrl(episode: SEpisode): String = baseUrl + episode.url
 
     // ============================ Video Links =============================
 
-    override fun videoListParse(response: Response): List<Video> {
-        val doc = response.asJsoup()
-        val parseUrl = response.request.url.toUrl()
-        val url = "${parseUrl.protocol}://${parseUrl.host}"
-        return doc.select("#server > ul > li > div.east_player_option")
-            .parallelMapNotNullBlocking {
-                runCatching { getEmbedLinks(url, it) }.getOrNull()
-            }
-            .parallelCatchingFlatMapBlocking {
-                getVideosFromEmbed(it.first)
-            }
+    private val dailymotionExtractor by lazy { DailymotionExtractor(client, headers) }
+    private val universalExtractor by lazy { UniversalExtractor(client) }
+
+    private val videoHeaders by lazy { headersBuilder().set("Referer", "$baseUrl/").build() }
+
+    override fun videoListRequest(episode: SEpisode): Request {
+        val (slug, number) = episode.slugAndNumber()
+        return GET("$apiUrl/api/series/$slug/episodes/$number", headers)
     }
 
-    // ============================= Utilities ==============================
+    override fun videoListParse(response: Response): List<Video> = response.parseAs<EpisodeDetailResponseDto>().streams
+        .parallelCatchingFlatMapBlocking { getVideosFromStream(it) }
 
     override fun List<Video>.sortVideos(): List<Video> {
         val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
         return sortedWith(compareByDescending { it.videoTitle.contains(quality) })
     }
 
-    private fun String?.toDate(): Long = runCatching { DATE_FORMATTER.parse(this?.trim() ?: "")?.time }
-        .getOrNull() ?: 0L
-
-    private fun Element.getInfo(info: String, cut: Boolean = true): String = selectFirst("span:has(b:contains($info))")!!.text()
-        .let {
-            when {
-                cut -> it.substringAfter(" ")
-                else -> it
-            }.trim()
+    private fun getVideosFromStream(stream: StreamDto): List<Video> {
+        val url = stream.url
+        val prefix = stream.source
+        return when {
+            "dailymotion" in url -> dailymotionExtractor.videosFromUrl(url, "$prefix Dailymotion - ")
+            "filedon.co" in url -> getFiledonVideo(url, prefix)
+            else -> universalExtractor.videosFromUrl(url, videoHeaders, prefix)
         }
-
-    private fun getAnimeParse(response: Response, query: String): AnimesPage {
-        val doc = response.asJsoup()
-        val animes = doc.select(query).map {
-            SAnime.create().apply {
-                setUrlWithoutDomain(it.selectFirst("div.animposx > a")!!.attr("href"))
-                title = it.selectFirst("div.title > h2")!!.text()
-                thumbnail_url = it.selectFirst("div.content-thumb > img")!!.attr("src")
-            }
-        }
-        val hasNextPage = try {
-            val pagination = doc.selectFirst("div.pagination")!!
-            val totalPage = pagination.selectFirst("span:nth-child(1)")!!.text().split(" ").last()
-            val currentPage = pagination.selectFirst("span.page-numbers.current")!!.text()
-            currentPage.toInt() < totalPage.toInt()
-        } catch (_: Exception) {
-            false
-        }
-        return AnimesPage(animes, hasNextPage)
     }
 
-    private fun parseStatus(status: String?): Int = when (status?.trim()?.lowercase()) {
-        "completed" -> SAnime.COMPLETED
-        "ongoing" -> SAnime.ONGOING
-        else -> SAnime.UNKNOWN
+    private fun getFiledonVideo(url: String, quality: String): List<Video> {
+        val doc = client.newCall(GET(url, videoHeaders)).execute().asJsoup()
+        val dataPage = doc.selectFirst("div#app")?.attr("data-page") ?: return emptyList()
+        val videoUrl = dataPage.parseAs<FiledonPageDto>().videoUrl
+        return listOf(Video(videoUrl, quality, videoUrl, videoHeaders))
     }
 
-    private fun getEmbedLinks(url: String, element: Element): Pair<String, String> {
-        val form = FormBody.Builder().apply {
-            add("action", "player_ajax")
-            add("post", element.attr("data-post"))
-            add("nume", element.attr("data-nume"))
-            add("type", element.attr("data-type"))
-        }.build()
-        return client.newCall(POST("$url/wp-admin/admin-ajax.php", body = form))
-            .execute()
-            .let { Pair(it.asJsoup().selectFirst(".playeriframe")!!.attr("src"), "") }
-    }
+    // ============================= Utilities ==============================
 
-    private fun getVideosFromEmbed(link: String): List<Video> = when {
-        "blogger" in link -> {
-            client.newCall(GET(link)).execute().body.string().let {
-                val json = JSONObject(it.substringAfter("= ").substringBefore("<"))
-                val streams = json.getJSONArray("streams")
-                val videoList = mutableListOf<Video>()
-                for (i in 0 until streams.length()) {
-                    val stream = streams.getJSONObject(i)
-                    val url = stream.getString("play_url")
-                    val quality = when (stream.getString("format_id")) {
-                        "18" -> "Google - 360p"
-                        "22" -> "Google - 720p"
-                        else -> "Unknown Resolution"
-                    }
-                    videoList.add(Video(url, quality, url))
-                }
-                videoList
-            }
-        }
+    private fun SAnime.slug(): String = url.substringAfter("/series/").substringBefore("/")
 
-        else -> emptyList()
+    private fun SEpisode.slugAndNumber(): Pair<String, String> {
+        val segments = url.trim('/').split("/")
+        return segments[1] to segments[3]
     }
 
     // ============================== Settings ==============================
@@ -206,13 +154,12 @@ class Oploverz :
     }
 
     companion object {
-        private val DATE_FORMATTER by lazy {
-            SimpleDateFormat("dd/MM/yyyy", Locale("id", "ID"))
-        }
+        private const val ANIME_PAGE_SIZE = 20
+        private const val EPISODE_PAGE_SIZE = 2000
 
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_TITLE = "Preferred quality"
         private const val PREF_QUALITY_DEFAULT = "720p"
-        private val PREF_QUALITY_ENTRIES = arrayOf("720p", "360p")
+        private val PREF_QUALITY_ENTRIES = arrayOf("1080p", "720p", "480p", "360p")
     }
 }

--- a/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/OploverzFilters.kt
+++ b/src/id/oploverz/src/eu/kanade/tachiyomi/animeextension/id/oploverz/OploverzFilters.kt
@@ -2,323 +2,75 @@ package eu.kanade.tachiyomi.animeextension.id.oploverz
 
 import eu.kanade.tachiyomi.animesource.model.AnimeFilter
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
+import keiyoushi.utils.firstInstanceOrNull
 
 object OploverzFilters {
-    open class QueryPartFilter(
-        displayName: String,
-        val vals: Array<Pair<String, String>>,
-    ) : AnimeFilter.Select<String>(
-        displayName,
-        vals.map { it.first }.toTypedArray(),
-    ) {
-        fun toQueryPart(name: String) = "&$name=${vals[state].second}"
-    }
+    class GenreCheckBox(name: String) : AnimeFilter.CheckBox(name, false)
 
-    open class CheckBoxFilterList(name: String, values: List<CheckBox>) : AnimeFilter.Group<AnimeFilter.CheckBox>(name, values)
+    class GenreFilter : AnimeFilter.Group<GenreCheckBox>("Genre", GENRE_LIST.map { GenreCheckBox(it.first) })
 
-    private class CheckBoxVal(name: String, state: Boolean = false) : AnimeFilter.CheckBox(name, state)
+    val FILTER_LIST get() = AnimeFilterList(GenreFilter())
 
-    private inline fun <reified R> AnimeFilterList.asQueryPart(name: String): String = (this.getFirst<R>() as QueryPartFilter).toQueryPart(name)
+    fun getGenreParam(filters: AnimeFilterList): String = filters.firstInstanceOrNull<GenreFilter>()
+        ?.state
+        ?.filter { it.state }
+        ?.mapNotNull { checkbox -> GENRE_LIST.find { it.first == checkbox.name }?.second }
+        ?.joinToString(",")
+        ?: ""
 
-    private inline fun <reified R> AnimeFilterList.getFirst(): R = this.filterIsInstance<R>().first()
-
-    private inline fun <reified R> AnimeFilterList.parseCheckbox(
-        options: Array<Pair<String, String>>,
-        name: String,
-    ): String = (this.getFirst<R>() as CheckBoxFilterList).state
-        .mapNotNull { checkbox ->
-            if (checkbox.state) {
-                options.find { it.first == checkbox.name }!!.second
-            } else {
-                null
-            }
-        }.joinToString("&$name[]=").let {
-            if (it.isBlank()) {
-                ""
-            } else {
-                "&$name[]=$it"
-            }
-        }
-
-    class GenreFilter :
-        CheckBoxFilterList(
-            "Genre",
-            FiltersData.GENRE.map { CheckBoxVal(it.first, false) },
-        )
-
-    class SeasonFilter :
-        CheckBoxFilterList(
-            "Season",
-            FiltersData.SEASON.map { CheckBoxVal(it.first, false) },
-        )
-
-    class StudioFilter :
-        CheckBoxFilterList(
-            "Studio",
-            FiltersData.STUDIO.map { CheckBoxVal(it.first, false) },
-        )
-
-    class TypeFilter : QueryPartFilter("Type", FiltersData.TYPE)
-
-    class StatusFilter : QueryPartFilter("Status", FiltersData.STATUS)
-
-    class OrderFilter : QueryPartFilter("Sort By", FiltersData.ORDER)
-
-    val FILTER_LIST
-        get() = AnimeFilterList(
-            GenreFilter(),
-            SeasonFilter(),
-            StudioFilter(),
-            TypeFilter(),
-            StatusFilter(),
-            OrderFilter(),
-        )
-
-    data class FilterSearchParams(
-        val filter: String = "",
+    private val GENRE_LIST = arrayOf(
+        Pair("+18", "18"),
+        Pair("Action", "action"),
+        Pair("Adventure", "adventure"),
+        Pair("Cars", "cars"),
+        Pair("Comedy", "comedy"),
+        Pair("Crime", "crime"),
+        Pair("Demons", "demons"),
+        Pair("Donghua", "donghua"),
+        Pair("Drama", "drama"),
+        Pair("Drive", "drive"),
+        Pair("Ecchi", "ecchi"),
+        Pair("Fantasy", "fantasy"),
+        Pair("Game", "game"),
+        Pair("Gore", "gore"),
+        Pair("Gourmet", "gourmet"),
+        Pair("Harem", "harem"),
+        Pair("Historical", "historical"),
+        Pair("Horror", "horror"),
+        Pair("Isekai", "isekai"),
+        Pair("Josei", "josei"),
+        Pair("Live Action", "live-action"),
+        Pair("Magic", "magic"),
+        Pair("Martial Arts", "martial-arts"),
+        Pair("Mecha", "mecha"),
+        Pair("Medical", "medical"),
+        Pair("Military", "military"),
+        Pair("Music", "music"),
+        Pair("Mystery", "mystery"),
+        Pair("Mythology", "mythology"),
+        Pair("OLM", "olm"),
+        Pair("Parody", "parody"),
+        Pair("Police", "police"),
+        Pair("Psychological", "psychological"),
+        Pair("Racing", "racing"),
+        Pair("Reincarnation", "reincarnation"),
+        Pair("Romance", "romance"),
+        Pair("Samurai", "samurai"),
+        Pair("School", "school"),
+        Pair("Sci-Fi", "sci-fi"),
+        Pair("Seinen", "seinen"),
+        Pair("Shoujo", "shoujo"),
+        Pair("Shounen", "shounen"),
+        Pair("Showbiz", "showbiz"),
+        Pair("Slice of Life", "slice-of-life"),
+        Pair("Space", "space"),
+        Pair("Sports", "sports"),
+        Pair("Supernatural", "supernatural"),
+        Pair("Super Power", "super-power"),
+        Pair("Survival", "survival"),
+        Pair("Suspense", "suspense"),
+        Pair("Thriller", "thriller"),
+        Pair("Vampire", "vampire"),
+        Pair("Zero-G", "zero-g"),
     )
-
-    internal fun getSearchParameters(filters: AnimeFilterList): FilterSearchParams {
-        if (filters.isEmpty()) return FilterSearchParams()
-        return FilterSearchParams(
-            filters.parseCheckbox<GenreFilter>(FiltersData.GENRE, "genre") +
-                filters.parseCheckbox<SeasonFilter>(FiltersData.SEASON, "season") +
-                filters.parseCheckbox<StudioFilter>(FiltersData.STUDIO, "studio") +
-                filters.asQueryPart<TypeFilter>("type") +
-                filters.asQueryPart<StatusFilter>("status") +
-                filters.asQueryPart<OrderFilter>("order"),
-        )
-    }
-
-    private object FiltersData {
-        val ORDER = arrayOf(
-            Pair("Latest Update", "update"),
-            Pair("Latest Added", "latest"),
-            Pair("Popular", "popular"),
-            Pair("Rating", "rating"),
-        )
-
-        val STATUS = arrayOf(
-            Pair("All", ""),
-            Pair("Currently Airing", "Currently Airing"),
-            Pair("Finished Airing", "Finished Airing"),
-        )
-
-        val TYPE = arrayOf(
-            Pair("All", ""),
-            Pair("TV", "TV"),
-            Pair("OVA", "OVA"),
-            Pair("ONA", "ONA"),
-            Pair("Special", "Special"),
-            Pair("Movie", "Movie"),
-        )
-
-        val GENRE = arrayOf(
-            Pair("Action", "action"),
-            Pair("Adventure", "adventure"),
-            Pair("Award Winning", "award-winning"),
-            Pair("Comedy", "comedy"),
-            Pair("Drama", "drama"),
-            Pair("Ecchi", "ecchi"),
-            Pair("Fantasy", "fantasy"),
-            Pair("Game", "game"),
-            Pair("Gore", "gore"),
-            Pair("Gourmet", "gourmet"),
-            Pair("Harem", "harem"),
-            Pair("Historical", "historical"),
-            Pair("Horror", "horror"),
-            Pair("Isekai", "isekai"),
-            Pair("Josei", "josei"),
-            Pair("Live Action", "live-action"),
-            Pair("Magic", "magic"),
-            Pair("Martial Arts", "martial-arts"),
-            Pair("Mecha", "mecha"),
-            Pair("Military", "military"),
-            Pair("Music", "music"),
-            Pair("Mystery", "mystery"),
-            Pair("Parody", "parody"),
-            Pair("Psychological", "psychological"),
-            Pair("Racing", "racing"),
-            Pair("Reverse Harem", "reverse-harem"),
-            Pair("Romance", "romance"),
-            Pair("Samurai", "samurai"),
-            Pair("School", "school"),
-            Pair("Sci-Fi", "sci-fi"),
-            Pair("Seinen", "seinen"),
-            Pair("Shoujo", "shoujo"),
-            Pair("Shounen", "shounen"),
-            Pair("Siekai", "siekai"),
-            Pair("Slice of Life", "slice-of-life"),
-            Pair("Sports", "sports"),
-            Pair("Super Power", "super-power"),
-            Pair("Supernatural", "supernatural"),
-            Pair("Survival", "survival"),
-            Pair("Suspense", "suspense"),
-            Pair("Time Travel", "time-travel"),
-            Pair("Vampire", "vampire"),
-        )
-
-        val SEASON = arrayOf(
-            Pair("Fall 1999", "fall-1999"),
-            Pair("Fall 2002", "fall-2002"),
-            Pair("Fall 2004", "fall-2004"),
-            Pair("Fall 2006", "fall-2006"),
-            Pair("Fall 2009", "fall-2009"),
-            Pair("Fall 2011", "fall-2011"),
-            Pair("Fall 2012", "fall-2012"),
-            Pair("Fall 2013", "fall-2013"),
-            Pair("Fall 2014", "fall-2014"),
-            Pair("Fall 2015", "fall-2015"),
-            Pair("Fall 2016", "fall-2016"),
-            Pair("Fall 2017", "fall-2017"),
-            Pair("Fall 2018", "fall-2018"),
-            Pair("Fall 2019", "fall-2019"),
-            Pair("Fall 2020", "fall-2020"),
-            Pair("Fall 2021", "fall-2021"),
-            Pair("Fall 2022", "fall-2022"),
-            Pair("Fall 2023", "fall-2023"),
-            Pair("Spring 1998", "spring-1998"),
-            Pair("Spring 2004", "spring-2004"),
-            Pair("Spring 2009", "spring-2009"),
-            Pair("Spring 2011", "spring-2011"),
-            Pair("Spring 2012", "spring-2012"),
-            Pair("Spring 2013", "spring-2013"),
-            Pair("Spring 2014", "spring-2014"),
-            Pair("Spring 2015", "spring-2015"),
-            Pair("Spring 2016", "spring-2016"),
-            Pair("Spring 2017", "spring-2017"),
-            Pair("Spring 2018", "spring-2018"),
-            Pair("Spring 2019", "spring-2019"),
-            Pair("Spring 2020", "spring-2020"),
-            Pair("Spring 2021", "spring-2021"),
-            Pair("Spring 2022", "spring-2022"),
-            Pair("Spring 2023", "spring-2023"),
-            Pair("Spring 2024", "spring-2024"),
-            Pair("Summer 1996", "summer-1996"),
-            Pair("Summer 2012", "summer-2012"),
-            Pair("Summer 2013", "summer-2013"),
-            Pair("Summer 2014", "summer-2014"),
-            Pair("Summer 2015", "summer-2015"),
-            Pair("Summer 2016", "summer-2016"),
-            Pair("Summer 2017", "summer-2017"),
-            Pair("Summer 2018", "summer-2018"),
-            Pair("Summer 2019", "summer-2019"),
-            Pair("Summer 2020", "summer-2020"),
-            Pair("Summer 2021", "summer-2021"),
-            Pair("Summer 2022", "summer-2022"),
-            Pair("Summer 2023", "summer-2023"),
-            Pair("Winter 2000", "winter-2000"),
-            Pair("Winter 2001", "winter-2001"),
-            Pair("Winter 2007", "winter-2007"),
-            Pair("Winter 2012", "winter-2012"),
-            Pair("Winter 2013", "winter-2013"),
-            Pair("Winter 2014", "winter-2014"),
-            Pair("Winter 2015", "winter-2015"),
-            Pair("Winter 2016", "winter-2016"),
-            Pair("Winter 2017", "winter-2017"),
-            Pair("Winter 2018", "winter-2018"),
-            Pair("Winter 2019", "winter-2019"),
-            Pair("Winter 2020", "winter-2020"),
-            Pair("Winter 2021", "winter-2021"),
-            Pair("Winter 2022", "winter-2022"),
-            Pair("Winter 2023", "winter-2023"),
-            Pair("Winter 2024", "winter-2024"),
-        )
-
-        val STUDIO = arrayOf(
-            Pair("8b", "8b"),
-            Pair("8bit", "8bit"),
-            Pair("A-1 Pictures", "a-1-pictures"),
-            Pair("A.C.G.T.", "a-c-g-t"),
-            Pair("AIC PLUS+", "aic-plus"),
-            Pair("Ajia-Do", "ajia-do"),
-            Pair("Animation Do", "animation-do"),
-            Pair("Aniplex", "aniplex"),
-            Pair("Aniplex of America", "aniplex-of-america"),
-            Pair("Arms", "arms"),
-            Pair("Asread", "asread"),
-            Pair("AtelierPontdarc", "atelierpontdarc"),
-            Pair("Bandai Namco Pictures", "bandai-namco-pictures"),
-            Pair("Bones", "bones"),
-            Pair("Brain's Base", "brains-base"),
-            Pair("Bridge", "bridge"),
-            Pair("BUG FILMS", "bug-films"),
-            Pair("C2C", "c2c"),
-            Pair("Children's Playground Entertainment", "childrens-playground-entertainment"),
-            Pair("CloverWorks", "cloverworks"),
-            Pair("Connect", "connect"),
-            Pair("David Production", "david-production"),
-            Pair("Diomedea", "diomedea"),
-            Pair("Doga Kobo", "doga-kobo"),
-            Pair("DR Movie", "dr-movie"),
-            Pair("Drive", "drive"),
-            Pair("E&H Production", "eh-production"),
-            Pair("Encourage Films", "encourage-films"),
-            Pair("Feel", "feel"),
-            Pair("Gallop", "gallop"),
-            Pair("GEEK TOYS", "geek-toys"),
-            Pair("Geno Studio", "geno-studio"),
-            Pair("GoHands", "gohands"),
-            Pair("Gonzo", "gonzo"),
-            Pair("Graphinica", "graphinica"),
-            Pair("Hoods Drifters Studio", "hoods-drifters-studio"),
-            Pair("Hoods Entertainment", "hoods-entertainment"),
-            Pair("HOTLINE", "hotline"),
-            Pair("J.C.Staff", "j-c-staff"),
-            Pair("Kinema Citrus", "kinema-citrus"),
-            Pair("Kyoto Animation", "kyoto-animation"),
-            Pair("Lerche", "lerche"),
-            Pair("LIDENFILMS", "lidenfilms"),
-            Pair("M.S.C", "m-s-c"),
-            Pair("Madhouse", "madhouse"),
-            Pair("Manglobe", "manglobe"),
-            Pair("MAPPA", "mappa"),
-            Pair("Media Factory", "media-factory"),
-            Pair("Millepensee", "millepensee"),
-            Pair("NAZ", "naz"),
-            Pair("Nexus", "nexus"),
-            Pair("Nitroplus", "nitroplus"),
-            Pair("Okuruto Noboru", "okuruto-noboru"),
-            Pair("Orange", "orange"),
-            Pair("P.A. Works", "p-a-works"),
-            Pair("Pastel", "pastel"),
-            Pair("Pierrot Plus", "pierrot-plus"),
-            Pair("Polygon Pictures", "polygon-pictures"),
-            Pair("Pony Canyon", "pony-canyon"),
-            Pair("Production I.G", "production-i-g"),
-            Pair("Production IMS", "production-ims"),
-            Pair("Production Reed", "production-reed"),
-            Pair("SANZIGEN", "sanzigen"),
-            Pair("Satelight", "satelight"),
-            Pair("Sentai Filmworks", "sentai-filmworks"),
-            Pair("Seven Arcs", "seven-arcs"),
-            Pair("Shaft", "shaft"),
-            Pair("Shin-Ei Animation", "shin-ei-animation"),
-            Pair("Shuka", "shuka"),
-            Pair("Signal.MD", "signal-md"),
-            Pair("SILVER LINK.", "silver-link"),
-            Pair("Studio 3Hz", "studio-3hz"),
-            Pair("Studio Bind", "studio-bind"),
-            Pair("Studio Comet", "studio-comet"),
-            Pair("Studio Deen", "studio-deen"),
-            Pair("Studio Kai", "studio-kai"),
-            Pair("studio MOTHER", "studio-mother"),
-            Pair("Studio Pierrot", "studio-pierrot"),
-            Pair("Studio VOLN", "studio-voln"),
-            Pair("Sunrise", "sunrise"),
-            Pair("SynergySP", "synergysp"),
-            Pair("Tatsunoko Production", "tatsunoko-production"),
-            Pair("Telecom Animation Film", "telecom-animation-film"),
-            Pair("Tezuka Productions", "tezuka-productions"),
-            Pair("TMS Entertainment", "tms-entertainment"),
-            Pair("Toei Animation", "toei-animation"),
-            Pair("Trigger", "trigger"),
-            Pair("TROYCA", "troyca"),
-            Pair("TYO Animations", "tyo-animations"),
-            Pair("ufotable", "ufotable"),
-            Pair("White Fox", "white-fox"),
-            Pair("Wit Studio", "wit-studio"),
-            Pair("Yumeta Company", "yumeta-company"),
-        )
-    }
 }


### PR DESCRIPTION
## Summary

Oploverz's old domain (`oploverz.media`) is dead. The site relaunched at `oploverz.site` as a completely different SvelteKit SPA backed by a REST API at `backapi.oploverz.ac`, so this is a full rewrite of the extension (not just a `baseUrl` change):

- Browse/Search/Popular/Latest now use `backapi.oploverz.ac/api/series` and `/api/episodes` (search via `q=`, genre filter via `genres=`, Popular = full series listing, Latest = episode-driven `sort=latest` feed deduped by anime — matching what the site itself actually offers, since it has no real "trending" browse page beyond a fixed 12-item homepage carousel).
- Details/Episodes come from `api/series/{slug}` and `api/series/{slug}/episodes`.
- Video extraction: added Dailymotion (existing lib) and Filedon (inline, same pattern as Samehadaku) extractors, plus a small XFileSharing-style extractor for `upbolt.to` (the dominant current streaming host, Cloudflare-protected) that replicates its embed page's auto-submitted `/dl` form POST and unpacks the returned script, falling back to `UniversalExtractor` for any other/unknown host.
- Simplified `OploverzFilters` to the one real server-side filter the new API supports (Genre).
- New `Dto.kt` for the JSON models; nullable fields where the API can return JSON `null` instead of omitting/empty-arraying a key.
- `extVersionCode` bumped to 27, added `dailymotionextractor`/`playlistutils`/`unpacker`/`universalextractor` lib deps.

Closes #887

## Test plan

- [x] `./gradlew :src:id:oploverz:assembleDebug` and `spotlessCheck` pass
- [x] Verified all API endpoints (browse, search, genre filter, movies vs series, episode data) against the live backend
- [x] Installed the built debug APK on a real device running Anikku and manually tested: Popular, Latest, Search + Genre filter, anime details, episode list, and playing videos across multiple different anime/episodes (including the Cloudflare-protected `upbolt.to` host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rewrite the Oploverz extension for the relaunched site and backend, including updated catalog access, metadata handling, filtering, and video extraction.

New Features:
- Migrate Oploverz browsing, search, filtering, anime details, episode listings, and playback to the new REST API and site backend.
- Support video playback through Dailymotion, Filedon, XFileSharing-style hosts, and universal fallback extraction.

Bug Fixes:
- Restore Oploverz functionality after the previous domain and backend became unavailable.

Enhancements:
- Simplify filtering to the genres supported by the new API and expand selectable video quality options.

Build:
- Add video extraction and playlist processing library dependencies and bump the extension version code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Oploverz extension to use the current website and API.
  * Improved browsing for popular and latest anime, search results, series details, episodes, and streaming links.
  * Added support for additional streaming sources and playlist-based playback.
  * Added genre-based filtering.

* **Improvements**
  * Updated anime metadata, episode dates, descriptions, genres, studios, and statuses.
  * Improved playback reliability for supported video hosts.
  * Increased the extension version to include these updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->